### PR TITLE
fix: install protoc and fix build steps in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev protobuf-compiler
 
       - name: Build
         run: cargo build --package pentest-desktop --release
@@ -51,6 +51,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+
+      - name: Install protoc
+        run: choco install protoc -y
 
       - name: Build
         run: cargo build --package pentest-desktop --release
@@ -80,6 +83,9 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
 
+      - name: Install protobuf
+        run: brew install protobuf
+
       - name: Build
         run: cargo build --package pentest-desktop --release --target ${{ matrix.target }}
 
@@ -98,26 +104,26 @@ jobs:
   # Web Build
   # ===========================================
   build-web:
-    name: Web (WASM)
+    name: Web (Liveview)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2
 
-      - name: Install trunk
-        run: cargo install trunk
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev protobuf-compiler
 
       - name: Build
-        working-directory: apps/web
-        run: trunk build --release
+        run: cargo build --package pentest-web --release
 
       - name: Package
         run: |
-          cd apps/web/dist
-          tar -czvf ../../../pentest-connector-web.tar.gz .
+          mkdir -p dist
+          cp target/release/pentest-web dist/
+          cd dist && tar -czvf ../pentest-connector-web.tar.gz pentest-web
 
       - uses: actions/upload-artifact@v4
         with:
@@ -149,8 +155,13 @@ jobs:
       - name: Install Android NDK
         run: sdkmanager "ndk;26.1.10909125"
 
+      - name: Install protoc
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
       - name: Install Dioxus CLI
-        run: curl -sSLf https://dioxus.dev/install.sh | sh
+        run: curl -sSLf https://dioxus.dev/install.sh | bash
 
       - name: Build APK
         env:
@@ -222,6 +233,11 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
 
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
       - name: Build
         run: cargo build --package pentest-headless --release
 
@@ -248,6 +264,9 @@ jobs:
         with:
           targets: ${{ matrix.target }}
       - uses: Swatinem/rust-cache@v2
+
+      - name: Install protobuf
+        run: brew install protobuf
 
       - name: Build
         run: cargo build --package pentest-headless --release --target ${{ matrix.target }}


### PR DESCRIPTION
## Summary

- **Install `protoc` on every platform** in the release workflow — the CI workflow had it (`protobuf-compiler`) but release.yml was missing it entirely, causing `strike48-proto` build failures on all 7 cargo-based jobs (Linux, Windows, macOS x2, headless Linux, headless macOS x2)
- **Fix Web build** — the web app is a Dioxus Liveview server (axum binary), not a Trunk/WASM app. Replaced `trunk build --release` (which required a nonexistent `index.html`) with `cargo build --package pentest-web --release`
- **Fix Android Dioxus CLI install** — the install script uses `set -o pipefail` which is a bash feature unsupported by Ubuntu's default `/bin/sh` (dash). Changed `| sh` to `| bash`
- **Headless macOS aarch64 "operation was canceled"** was a cascading failure from the x86_64 matrix sibling failing (no protoc) — fixed by the protoc install

## Per-job fix mapping

| Job | Root cause | Fix |
|-----|-----------|-----|
| Desktop Linux | missing protoc | `apt-get install protobuf-compiler` |
| Desktop Windows | missing protoc | `choco install protoc` |
| Desktop macOS (x2) | missing protoc | `brew install protobuf` |
| Web (WASM) | wrong build tool (trunk vs cargo) | `cargo build --package pentest-web` |
| Android | `set -o pipefail` in dash | pipe install.sh through `bash` + install protoc |
| Headless Linux | missing protoc | `apt-get install protobuf-compiler` |
| Headless macOS (x2) | missing protoc | `brew install protobuf` |

## Test plan

- [ ] Trigger a workflow_dispatch run of the Release workflow on this branch to verify all jobs pass
- [ ] Verify the web build produces the `pentest-web` binary artifact
- [ ] Verify Android build gets past the Dioxus CLI install step