### PR TITLE
fix: add missing linker dependencies for release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev protobuf-compiler
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev protobuf-compiler libpcap-dev libxdo-dev
 
       - name: Build
         run: cargo build --package pentest-desktop --release
@@ -54,6 +54,13 @@ jobs:
 
       - name: Install protoc
         run: choco install protoc -y
+
+      - name: Install Npcap SDK
+        shell: pwsh
+        run: |
+          Invoke-WebRequest -Uri "https://npcap.com/dist/npcap-sdk-1.13.zip" -OutFile npcap-sdk.zip
+          Expand-Archive -Path npcap-sdk.zip -DestinationPath "${{ github.workspace }}\npcap-sdk"
+          echo "LIB=${{ github.workspace }}\npcap-sdk\Lib\x64;$env:LIB" >> $env:GITHUB_ENV
 
       - name: Build
         run: cargo build --package pentest-desktop --release
@@ -114,7 +121,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev protobuf-compiler
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libayatana-appindicator3-dev protobuf-compiler libpcap-dev
 
       - name: Build
         run: cargo build --package pentest-web --release
@@ -236,7 +243,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y protobuf-compiler
+          sudo apt-get install -y protobuf-compiler libpcap-dev
 
       - name: Build
         run: cargo build --package pentest-headless --release

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -37,6 +37,12 @@ pub use desktop::{
     stop_current_capture,
 };
 
+/// Pcap is never available on non-desktop platforms
+#[cfg(not(feature = "desktop"))]
+pub fn is_pcap_available() -> bool {
+    false
+}
+
 /// Get the platform implementation for the current target
 #[cfg(feature = "desktop")]
 pub fn get_platform() -> impl PlatformProvider {


### PR DESCRIPTION
## Summary

Fixes all 5 failing release builds caused by missing linker dependencies and a compile-time feature gate issue.

- **Desktop Linux**: Add `libpcap-dev` and `libxdo-dev` to CI dependencies
- **Desktop Windows**: Install Npcap SDK and set `LIB` so the linker can find `wpcap.lib`
- **Web (Liveview)**: Add `libpcap-dev` to CI dependencies
- **Headless Linux**: Add `libpcap-dev` to CI dependencies
- **Android**: Add `is_pcap_available()` fallback in `pentest-platform` for non-desktop feature builds (function was gated behind `#[cfg(feature = "desktop")]` with no alternative, causing `E0425`)

The `ci.yml` workflow already had these system packages; `release.yml` was missing them.

## Test plan

- [ ] Desktop Linux release build passes (no `-lpcap` / `-lxdo` linker errors)
- [ ] Desktop Windows release build passes (no `LNK1181: wpcap.lib` error)
- [ ] Web (Liveview) release build passes (no `-lpcap` linker error)
- [ ] Headless Linux release build passes (no `-lpcap` linker error)
- [ ] Android build passes (no `E0425: cannot find function is_pcap_available`)
- [ ] macOS and iOS builds unaffected