### PR TITLE
ci: publish releases instead of creating drafts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -332,7 +332,6 @@ jobs:
         with:
           tag_name: v${{ steps.version.outputs.version }}
           name: Pentest Connector v${{ steps.version.outputs.version }}
-          draft: true
           files: |
             release/*
           body: |


### PR DESCRIPTION
Remove draft: true so releases are immediately available for downstream repos (e.g. strikehub) to download connector binaries.