### PR TITLE
fix: skip docker push on fork PRs to resolve GHCR permission denied

### DIFF
--- a/.github/workflows/docker-multiarch.yml
+++ b/.github/workflows/docker-multiarch.yml
@@ -72,21 +72,23 @@ jobs:
           context: .
           file: Dockerfile.scratch
           platforms: ${{ matrix.platform }}
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           provenance: false
           sbom: false
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          outputs: ${{ github.event_name != 'pull_request' && format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.REGISTRY_IMAGE) || '' }}
           cache-from: |
             type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache-${{ matrix.arch }}
-          cache-to: type=registry,ref=${{ env.REGISTRY_IMAGE }}:buildcache-${{ matrix.arch }},mode=max,image-manifest=true,oci-mediatypes=true
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}:buildcache-{1},mode=max,image-manifest=true,oci-mediatypes=true', env.REGISTRY_IMAGE, matrix.arch) || '' }}
 
       - name: Export digest
+        if: github.event_name != 'pull_request'
         run: |
           mkdir -p /tmp/digests
           digest="${{ steps.build.outputs.digest }}"
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           name: digests-${{ matrix.arch }}
@@ -99,6 +101,7 @@ jobs:
   # ---------------------------------------------------------------------------
   merge-manifests:
     name: Merge Multi-Arch Manifest
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     needs: [build-image]
     steps:


### PR DESCRIPTION
## Summary                                                                                                                                 
                                                                                                                                             
  - Fork PRs (e.g., from `jtomek-strike48/pick`) fail the multi-arch Docker workflow because the `GITHUB_TOKEN` is scoped to the fork and cannot push to `ghcr.io/strike48-public/pick`                                                                                              
  - Gates all push, cache-to, digest export, and manifest merge steps behind `github.event_name != 'pull_request'` so PRs validate the build without attempting registry writes                                                                                                         
  - Pushes to `main` and tag-based releases continue to build, push, and merge manifests as before                                           
                                                                                                                                             
  ## What changed                                                                                                                            
                                                                                                                                             
  | Step | Before | After |                                                                                                                  
  |------|--------|-------|                                                                                                                  
  | `push` | Always `true` | `false` on PRs |                                                                                                
  | `outputs` (push-by-digest) | Always set | Empty on PRs |                                                                                 
  | `cache-to` | Always writes to registry | Skipped on PRs |                                                                                
  | Export/upload digest | Always runs | Skipped on PRs |                                                                                    
  | `merge-manifests` job | Always runs | Skipped on PRs |                                                                                   
                                                                                                                                             
  `cache-from` is unchanged — PR builds still read from the upstream cache for faster builds.                                                
                                                                                                                                             
  ## Test plan                                                                                                                               
                                                                                                                                             
  - [ ] Open a PR from a fork and verify the Docker build step succeeds (build-only, no push)                                                
  - [ ] Verify digest export/upload and merge-manifests steps are skipped on the fork PR                                                     
  - [ ] Push to `main` and verify the full build+push+manifest-merge flow still works