### PR TITLE
fix: add rustls-tls-native-roots for OTT registration with local CAs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 
 # Networking
-reqwest = { version = "0.12", features = ["json", "cookies", "stream"] }
+reqwest = { version = "0.12", features = ["json", "cookies", "stream", "rustls-tls-native-roots"] }
 
 # Time
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -52,7 +52,7 @@ wifi_scan = { version = "0.7", optional = true }
 ssdp-client = { version = "2.1", optional = true }
 
 # Sandbox dependencies (desktop)
-reqwest = { version = "0.12", features = ["rustls-tls", "stream"], default-features = false, optional = true }
+reqwest = { version = "0.12", features = ["rustls-tls", "rustls-tls-native-roots", "stream"], default-features = false, optional = true }
 
 # PTY support (desktop + android)
 portable-pty = { version = "0.9", optional = true }


### PR DESCRIPTION
## Summary

- Add `rustls-tls-native-roots` feature to reqwest in workspace root and `crates/platform` so rustls trusts system CA certificates (macOS keychain, etc.)

## Problem

The SDK v0.3.4 `OttProvider` activates reqwest's `rustls-tls` feature, which only trusts Mozilla's CA bundle. When the Studio server (`studio.strike48.test`) uses a cert signed by a local/internal CA trusted in the macOS keychain but not in webpki-roots, the OTT HTTP POST fails:

```
error sending request for url (https://studio.strike48.test/api/connectors/register-with-ott):
  error trying to connect: invalid peer certificate: UnknownIssuer
```

The WebSocket transport was unaffected because it uses `native-tls` (via tokio-tungstenite), which trusts the OS cert store. The connector appeared Online but could not persist durable credentials via OTT exchange.

## Fix

`rustls-tls-native-roots` enables `rustls-native-certs`, which loads certificates from the OS trust store into rustls. This aligns the HTTP transport's CA trust with the WebSocket transport. No cert verification is disabled; the trust store is extended from Mozilla-only to Mozilla + OS (same as browsers).

Applied to both:
- **Workspace root `Cargo.toml`** — default features ON, adds native-roots alongside existing features
- **`crates/platform/Cargo.toml`** — `default-features = false` with explicit `rustls-tls`, adds native-roots

## Test plan

- [x] `cargo build --bin pentest-agent` compiles
- [x] `just run` from strikehub: OTT pre-approval registration succeeds, connector reaches Online, JWT refresh works
- [x] No regression on kubestudio (both connectors Online simultaneously)
