### PR TITLE
fix(config): preserve URL scheme in normalize_host so desktop auto-detects WebSocket transport

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -143,26 +143,48 @@ impl ConnectorConfig {
         !self.auth_token.is_empty()
     }
 
-    /// Strip any URL scheme prefix from the host and return the bare `host:port`.
+    /// Validate `host` and return it with its scheme preserved so that transport
+    /// auto-detection in [`Self::to_sdk_config`] can distinguish WebSocket
+    /// (`wss://`) from gRPC (`grpc://`, `grpcs://`, or no scheme).
     ///
-    /// Handles `grpc://`, `grpcs://`, `http://`, `https://`, `ws://`, `wss://`.
-    /// Returns `Err` if the result is empty or missing a port (no `:`).
+    /// If no scheme is present and the host ends with `:443`, `wss://` is
+    /// prepended — Cloudflare-fronted Strike48 deployments (the common case
+    /// for port 443) do not proxy arbitrary gRPC over HTTP/2 and require
+    /// WebSocket. This mirrors what a user would type into a browser and
+    /// keeps saved settings from previous versions working.
+    ///
+    /// Returns `Err` if the bare `host:port` is missing or malformed.
     pub fn normalize_host(host: &str) -> Result<String, String> {
         let schemes = [
             "grpc://", "grpcs://", "http://", "https://", "ws://", "wss://",
         ];
-        let mut h = host.trim();
-        for scheme in &schemes {
-            if let Some(stripped) = h.strip_prefix(scheme) {
-                h = stripped;
-                break;
-            }
+        let trimmed = host.trim();
+        let lower = trimmed.to_lowercase();
+
+        let (scheme, bare) = schemes
+            .iter()
+            .find_map(|s| {
+                lower
+                    .strip_prefix(s)
+                    .map(|_| (&trimmed[..s.len()], &trimmed[s.len()..]))
+            })
+            .unwrap_or(("", trimmed));
+
+        if bare.is_empty() || !bare.contains(':') {
+            return Err(
+                "Invalid host format. Use scheme://host:port (e.g., wss://strike48.example.com:443)"
+                    .to_string(),
+            );
         }
 
-        if h.is_empty() || !h.contains(':') {
-            return Err("Invalid host format. Use host:port (e.g., localhost:50061)".to_string());
+        if !scheme.is_empty() {
+            return Ok(format!("{}{}", scheme, bare));
         }
-        Ok(h.to_string())
+
+        // No scheme: Strike48 behind Cloudflare on :443 must use WebSocket;
+        // other ports default to gRPC (SDK's default transport).
+        let inferred = if bare.ends_with(":443") { "wss://" } else { "" };
+        Ok(format!("{}{}", inferred, bare))
     }
 
     /// Convert to the SDK's ConnectorConfig
@@ -378,7 +400,6 @@ pub fn load_connector_config(args: &[String]) -> ConfigLoadResult {
 
     // Preserve the original URL (including scheme) so that to_sdk_config()
     // can auto-detect transport type (WebSocket vs gRPC) and TLS from the scheme.
-    // normalize_host used to strip the scheme here, which broke WSS detection.
 
     ConfigLoadResult::Ok(config)
 }
@@ -407,5 +428,58 @@ impl AppSettings {
             instance_id: self.device_id.clone(),
             ..base_config
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_host_preserves_wss_scheme() {
+        let out = ConnectorConfig::normalize_host("wss://studio.example.com:443").unwrap();
+        assert_eq!(out, "wss://studio.example.com:443");
+    }
+
+    #[test]
+    fn normalize_host_preserves_grpc_scheme() {
+        let out = ConnectorConfig::normalize_host("grpc://localhost:50061").unwrap();
+        assert_eq!(out, "grpc://localhost:50061");
+    }
+
+    #[test]
+    fn normalize_host_infers_wss_for_port_443() {
+        let out = ConnectorConfig::normalize_host("studio.example.com:443").unwrap();
+        assert_eq!(out, "wss://studio.example.com:443");
+    }
+
+    #[test]
+    fn normalize_host_leaves_non_443_bare() {
+        let out = ConnectorConfig::normalize_host("localhost:50061").unwrap();
+        assert_eq!(out, "localhost:50061");
+    }
+
+    #[test]
+    fn normalize_host_trims_whitespace() {
+        let out = ConnectorConfig::normalize_host("  wss://x.example.com:443  ").unwrap();
+        assert_eq!(out, "wss://x.example.com:443");
+    }
+
+    #[test]
+    fn normalize_host_rejects_missing_port() {
+        assert!(ConnectorConfig::normalize_host("studio.example.com").is_err());
+        assert!(ConnectorConfig::normalize_host("wss://studio.example.com").is_err());
+    }
+
+    #[test]
+    fn normalize_host_rejects_empty() {
+        assert!(ConnectorConfig::normalize_host("").is_err());
+        assert!(ConnectorConfig::normalize_host("   ").is_err());
+    }
+
+    #[test]
+    fn normalize_host_scheme_matching_is_case_insensitive() {
+        let out = ConnectorConfig::normalize_host("WSS://Studio.Example.com:443").unwrap();
+        assert_eq!(out, "WSS://Studio.Example.com:443");
     }
 }

--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -34,6 +34,8 @@ pub fn load_settings() -> AppSettings {
         Ok(contents) => {
             let mut settings: AppSettings = serde_json::from_str(&contents).unwrap_or_default();
 
+            let mut dirty = false;
+
             // Validate and clear expired auth token
             if let Some(last_config) = &mut settings.last_config {
                 if let Some(validated) =
@@ -41,17 +43,37 @@ pub fn load_settings() -> AppSettings {
                 {
                     last_config.auth_token = validated;
                 } else {
-                    // Token is expired or invalid, clear it
                     tracing::info!("Cleared expired/invalid auth token from settings");
                     last_config.auth_token.clear();
+                    dirty = true;
+                }
+            }
 
-                    // Save the updated settings to persist the change
-                    if let Err(e) = save_settings(&settings) {
-                        tracing::warn!(
-                            "Failed to save settings after clearing expired token: {}",
-                            e
-                        );
+            // Migrate saved hosts written by older versions that stripped the
+            // URL scheme. Without a scheme the SDK defaults to gRPC, which
+            // fails on Cloudflare-fronted Strike48 deployments. Re-running
+            // normalize_host now re-introduces wss:// for :443 hosts.
+            if let Some(last_config) = &mut settings.last_config {
+                if !last_config.host.is_empty() {
+                    if let Ok(normalized) =
+                        crate::config::ConnectorConfig::normalize_host(&last_config.host)
+                    {
+                        if normalized != last_config.host {
+                            tracing::info!(
+                                "Migrated saved host {} -> {}",
+                                last_config.host,
+                                normalized
+                            );
+                            last_config.host = normalized;
+                            dirty = true;
+                        }
                     }
+                }
+            }
+
+            if dirty {
+                if let Err(e) = save_settings(&settings) {
+                    tracing::warn!("Failed to save settings after migration: {}", e);
                 }
             }
 

--- a/crates/ui/src/components/config_form.rs
+++ b/crates/ui/src/components/config_form.rs
@@ -54,7 +54,7 @@ pub fn ConfigForm(
                     label { "Strike48 Host" }
                     input {
                         r#type: "text",
-                        placeholder: "grpc://localhost:50061",
+                        placeholder: "wss://strike48.example.com:443",
                         value: "{host}",
                         disabled: is_connecting,
                         oninput: move |e| host.set(e.value()),


### PR DESCRIPTION
> [!NOTE]
> **The failing `Docker Build` check is NOT caused by this PR.** It's a pre-existing CI infrastructure issue where `Dockerfile:3` runs `cargo install cargo-chef` unlocked, so Cargo resolves the newly-published `cargo-platform@0.3.3` which requires rustc 1.91 — but the base image pins `FROM rust:1.88-bookworm`. Cargo itself prints the recommended fix: *"Try re-running `cargo install` with `--locked`"*. That one-line fix is in #79. Once #79 merges, re-running Docker Build on this PR will go green. All 17 other checks pass.

## Summary

- `normalize_host` previously stripped the URL scheme. Headless apps read `STRIKE48_HOST` directly and the scheme survived, but the desktop UI routed user input through `normalize_host` and lost it. Without a scheme, the SDK's `parse_url` fell back to **gRPC**.
- Strike48 production is Cloudflare-fronted on `:443`. Cloudflare terminates TLS cleanly but does not proxy arbitrary gRPC/HTTP2, so tonic surfaces the closed stream as `TLS connection failed: transport error` — after a successful TLS 1.3 handshake. That is why the symptom looked like a TLS bug but headless worked with identical credentials.
- `normalize_host` now preserves any provided scheme and, when no scheme is given and the host ends with `:443`, infers `wss://` (the Cloudflare convention).
- `load_settings` re-runs `normalize_host` on persisted `last_config.host` so existing users with a bare hostname saved by older versions get migrated transparently on first launch.
- The `ConfigForm` placeholder is updated from `grpc://localhost:50061` to `wss://strike48.example.com:443` so the correct scheme is discoverable.

## Files changed

- `crates/core/src/config.rs` — preserve scheme; infer `wss://` for bare `:443` hosts; 8 new unit tests (preservation, inference, case-insensitivity, trimming, error cases).
- `crates/core/src/settings.rs` — re-run `normalize_host` on persisted host and atomically save when the value changes.
- `crates/ui/src/components/config_form.rs` — updated placeholder.

## Test plan

- [x] `cargo test -p pentest-core --lib config::` → 8/8 pass.
- [x] `cargo clippy -p pentest-core --all-targets --tests -- -D warnings` → clean.
- [x] `cargo check -p pentest-desktop` → clean.
- [x] `cargo check -p pentest-headless` → clean.
- [x] `cargo fmt --all -- --check` → clean.
- [x] End-to-end desktop: connect over `wss://`, accept OTT approval in Prospector Studio, OTT exchange returns 200, Keycloak issues JWT, reconnect with JWT succeeds, final registration confirmed.
- [ ] (reviewer) Verify headless still connects with existing `.env` configuration.

## Follow-ups (not in this PR)

- Browser OAuth callback server falls back to a random port when 4000/5173 are busy, which breaks CORS. Not a blocker for deployments that have a registration token, but worth tracking.
- Startup can stall up to ~90s on stale credentials files pointing at a now-unreachable auth URL. Stale-file cleanup should also run on pre-registration token refresh connect failures, not only on auth-error responses during registration.
