### PR TITLE
docs: add installation guides, runtime troubleshooting, feature overview, and dep-check script

### DIFF
--- a/check-deps.sh
+++ b/check-deps.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# Pick Dependency Checker - Validates prerequisites before building
+# Run this before building if you didn't use install.sh
+
+set -euo pipefail
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Detect OS
+OS="unknown"
+DISTRO="unknown"
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+    OS="linux"
+    if [[ -f /etc/os-release ]]; then
+        # shellcheck source=/dev/null
+        source /etc/os-release
+        DISTRO="$ID"
+    fi
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+    OS="macos"
+elif [[ "$OSTYPE" == "msys" ]] || [[ "$OSTYPE" == "cygwin" ]]; then
+    OS="windows"
+fi
+
+# Print functions
+print_header() {
+    echo ""
+    echo -e "${BLUE}========================================${NC}"
+    echo -e "${BLUE}  Pick Dependency Checker${NC}"
+    echo -e "${BLUE}========================================${NC}"
+    echo ""
+}
+
+print_check() {
+    echo -ne "${BLUE}[CHECK]${NC} $1... "
+}
+
+print_ok() {
+    echo -e "${GREEN}OK${NC}"
+}
+
+print_missing() {
+    echo -e "${RED}MISSING${NC}"
+}
+
+print_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $*"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $*"
+}
+
+print_fix() {
+    echo -e "${BLUE}[FIX]${NC} $*"
+}
+
+# Check if command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Check if library exists (Linux)
+library_exists() {
+    if [[ "$OS" == "linux" ]]; then
+        pkg-config --exists "$1" 2>/dev/null
+    else
+        return 0  # Skip on non-Linux
+    fi
+}
+
+# Track missing dependencies
+MISSING_COUNT=0
+MISSING_DEPS=()
+
+# Check Rust and Cargo
+check_rust() {
+    print_check "Rust (rustc)"
+    if command_exists rustc; then
+        RUST_VERSION=$(rustc --version | cut -d' ' -f2)
+        RUST_MAJOR=$(echo "$RUST_VERSION" | cut -d'.' -f1)
+        RUST_MINOR=$(echo "$RUST_VERSION" | cut -d'.' -f2)
+
+        if [[ $RUST_MAJOR -gt 1 ]] || [[ $RUST_MAJOR -eq 1 && $RUST_MINOR -ge 70 ]]; then
+            print_ok
+            echo "    Version: $RUST_VERSION"
+        else
+            print_missing
+            echo "    Found: $RUST_VERSION (need 1.70+)"
+            MISSING_COUNT=$((MISSING_COUNT + 1))
+            MISSING_DEPS+=("rust")
+        fi
+    else
+        print_missing
+        MISSING_COUNT=$((MISSING_COUNT + 1))
+        MISSING_DEPS+=("rust")
+    fi
+
+    print_check "Cargo"
+    if command_exists cargo; then
+        print_ok
+        echo "    Version: $(cargo --version | cut -d' ' -f2)"
+    else
+        print_missing
+        MISSING_COUNT=$((MISSING_COUNT + 1))
+        MISSING_DEPS+=("cargo")
+    fi
+}
+
+# Check build tools
+check_build_tools() {
+    case "$OS" in
+        linux)
+            print_check "C compiler (gcc/clang)"
+            if command_exists gcc || command_exists clang; then
+                print_ok
+            else
+                print_missing
+                MISSING_COUNT=$((MISSING_COUNT + 1))
+                MISSING_DEPS+=("gcc")
+            fi
+
+            print_check "pkg-config"
+            if command_exists pkg-config; then
+                print_ok
+            else
+                print_missing
+                MISSING_COUNT=$((MISSING_COUNT + 1))
+                MISSING_DEPS+=("pkg-config")
+            fi
+
+            print_check "OpenSSL development headers"
+            if library_exists openssl; then
+                print_ok
+            else
+                print_missing
+                MISSING_COUNT=$((MISSING_COUNT + 1))
+                MISSING_DEPS+=("libssl-dev")
+            fi
+
+            print_check "Protocol Buffers compiler (protoc)"
+            if command_exists protoc; then
+                print_ok
+            else
+                print_missing
+                MISSING_COUNT=$((MISSING_COUNT + 1))
+                MISSING_DEPS+=("protobuf-compiler")
+            fi
+            ;;
+
+        macos)
+            print_check "Xcode Command Line Tools"
+            if command_exists xcode-select && xcode-select -p >/dev/null 2>&1; then
+                print_ok
+            else
+                print_missing
+                MISSING_COUNT=$((MISSING_COUNT + 1))
+                MISSING_DEPS+=("xcode-cli")
+            fi
+            ;;
+    esac
+}
+
+# Check optional desktop dependencies
+check_desktop_deps() {
+    if [[ "$OS" == "linux" ]]; then
+        echo ""
+        echo -e "${BLUE}Optional Desktop Dependencies:${NC}"
+
+        print_check "WebKit2GTK"
+        if library_exists webkit2gtk-4.0; then
+            print_ok
+        else
+            print_warn "Not installed (needed for desktop app)"
+        fi
+
+        print_check "GTK3"
+        if library_exists gtk+-3.0; then
+            print_ok
+        else
+            print_warn "Not installed (needed for desktop app)"
+        fi
+    fi
+}
+
+# Check WiFi tools
+check_wifi_tools() {
+    echo ""
+    echo -e "${BLUE}Optional WiFi Tools:${NC}"
+
+    print_check "wireless-tools"
+    if command_exists iwconfig; then
+        print_ok
+    else
+        print_warn "Not installed (needed for WiFi scanning)"
+    fi
+
+    print_check "aircrack-ng"
+    if command_exists aircrack-ng; then
+        print_ok
+    else
+        print_warn "Not installed (needed for advanced WiFi features)"
+    fi
+}
+
+# Generate fix commands
+generate_fix_commands() {
+    if [[ $MISSING_COUNT -eq 0 ]]; then
+        echo ""
+        echo -e "${GREEN}All required dependencies are installed!${NC}"
+        echo ""
+        echo "You can now build Pick:"
+        echo "  cargo build --package pentest-headless"
+        return 0
+    fi
+
+    echo ""
+    echo -e "${RED}Missing $MISSING_COUNT required dependencies${NC}"
+    echo ""
+    echo "To fix this, run the following commands:"
+    echo ""
+
+    case "$OS" in
+        linux)
+            case "$DISTRO" in
+                ubuntu|debian)
+                    print_fix "Debian/Ubuntu:"
+                    echo "    sudo apt update"
+                    if [[ " ${MISSING_DEPS[*]} " =~ " gcc " ]] || [[ " ${MISSING_DEPS[*]} " =~ " pkg-config " ]] || [[ " ${MISSING_DEPS[*]} " =~ " libssl-dev " ]] || [[ " ${MISSING_DEPS[*]} " =~ " protobuf-compiler " ]]; then
+                        echo "    sudo apt install -y build-essential pkg-config libssl-dev protobuf-compiler"
+                    fi
+                    ;;
+                fedora|rhel|centos)
+                    print_fix "Fedora/RHEL:"
+                    if [[ " ${MISSING_DEPS[*]} " =~ " gcc " ]] || [[ " ${MISSING_DEPS[*]} " =~ " pkg-config " ]] || [[ " ${MISSING_DEPS[*]} " =~ " libssl-dev " ]] || [[ " ${MISSING_DEPS[*]} " =~ " protobuf-compiler " ]]; then
+                        echo "    sudo dnf install -y gcc gcc-c++ make openssl-devel protobuf-compiler"
+                    fi
+                    ;;
+                *)
+                    print_fix "Linux:"
+                    echo "    Install: build-essential, pkg-config, libssl-dev (or equivalents)"
+                    ;;
+            esac
+            ;;
+
+        macos)
+            print_fix "macOS:"
+            if [[ " ${MISSING_DEPS[*]} " =~ " xcode-cli " ]]; then
+                echo "    xcode-select --install"
+            fi
+            ;;
+
+        windows)
+            print_fix "Windows:"
+            echo "    Install Visual Studio Build Tools with C++ workload"
+            echo "    Or: winget install Microsoft.VisualStudio.2022.BuildTools"
+            ;;
+    esac
+
+    if [[ " ${MISSING_DEPS[*]} " =~ " rust " ]] || [[ " ${MISSING_DEPS[*]} " =~ " cargo " ]]; then
+        echo ""
+        print_fix "Install Rust:"
+        echo "    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"
+        echo "    source \$HOME/.cargo/env"
+    fi
+
+    echo ""
+    echo "Or run the automated installer:"
+    echo "    ./install.sh"
+    echo ""
+
+    return 1
+}
+
+# Main
+main() {
+    print_header
+    echo "Detected OS: $OS ($DISTRO)"
+    echo ""
+    echo -e "${BLUE}Required Dependencies:${NC}"
+
+    check_rust
+    check_build_tools
+    check_desktop_deps
+    check_wifi_tools
+
+    generate_fix_commands
+}
+
+main "$@"

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,410 @@
+# Pick Installation Guide
+
+Complete installation guide for the Pick penetration testing connector.
+
+## Table of Contents
+
+- [Quick Install](#quick-install)
+- [Manual Installation](#manual-installation)
+- [Platform-Specific Guides](#platform-specific-guides)
+- [Environment Configuration](#environment-configuration)
+- [Troubleshooting](#troubleshooting)
+
+## Quick Install
+
+The automated installation script handles prerequisites, dependencies, and configuration:
+
+```bash
+git clone https://github.com/Strike48-public/pick.git
+cd pick
+./install.sh
+```
+
+### What the Script Does
+
+1. Detects your operating system and distribution
+2. Installs Rust and Cargo (if not present)
+3. Installs platform-specific build dependencies
+4. Optionally installs desktop app dependencies
+5. Optionally installs WiFi scanning tools
+6. Creates `.env` configuration file from template
+7. Optionally builds and tests the project
+
+### Interactive Prompts
+
+The script will ask:
+- Install desktop app dependencies? (WebKit, GTK)
+- Install WiFi scanning tools? (wireless-tools, aircrack-ng)
+- Overwrite existing .env file?
+- Open .env in editor?
+- Build Pick now?
+- Run tests?
+
+All prompts default to "No" if you press Enter.
+
+## Manual Installation
+
+### Step 0: Check Dependencies (Optional)
+
+Before installing, you can check if you have all required dependencies:
+
+```bash
+./check-deps.sh
+```
+
+This script will:
+- Check for Rust and Cargo (version 1.70+)
+- Verify build tools (gcc/clang, pkg-config)
+- Check for OpenSSL development headers
+- Report optional dependencies (desktop, WiFi tools)
+- Provide specific fix commands for missing dependencies
+
+### Step 1: Install Rust
+
+**Linux / macOS / WSL:**
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source $HOME/.cargo/env
+```
+
+**Windows:**
+- Download and run [rustup-init.exe](https://rustup.rs/)
+- Or use winget:
+  ```powershell
+  winget install Rustlang.Rustup
+  ```
+
+**Verify:**
+```bash
+rustc --version  # Should show 1.70 or higher
+cargo --version
+```
+
+### Step 2: Install Dependencies
+
+See [Platform-Specific Guides](#platform-specific-guides) below.
+
+### Step 3: Clone Repository
+
+```bash
+git clone https://github.com/Strike48-public/pick.git
+cd pick
+```
+
+### Step 4: Configure Environment
+
+```bash
+cp .env.example .env
+nano .env  # Edit with your Strike48 backend details
+```
+
+Required configuration:
+- `STRIKE48_HOST` - Strike48 server endpoint
+- `STRIKE48_TENANT` - Tenant identifier
+- `MATRIX_API_URL` - Matrix API endpoint
+- `MATRIX_TENANT_ID` - Matrix tenant identifier
+
+See [Environment Configuration](#environment-configuration) for details.
+
+### Step 5: Build
+
+```bash
+# Build headless agent (recommended for first time)
+cargo build --package pentest-headless
+
+# Or build all packages
+cargo build --all
+```
+
+### Step 6: Run
+
+```bash
+# Headless agent (no GUI)
+./run-pentest.sh headless dev
+
+# Desktop app (requires sudo for WiFi)
+sudo cargo run --package pentest-desktop
+```
+
+## Platform-Specific Guides
+
+### Linux (Debian/Ubuntu)
+
+```bash
+# Update package list
+sudo apt update
+
+# Core build tools (required)
+sudo apt install -y build-essential pkg-config libssl-dev protobuf-compiler
+
+# Desktop app dependencies (optional)
+sudo apt install -y libwebkit2gtk-4.0-dev libgtk-3-dev libayatana-appindicator3-dev
+
+# WiFi scanning tools (optional)
+sudo apt install -y wireless-tools aircrack-ng
+```
+
+### Linux (Fedora/RHEL/CentOS)
+
+```bash
+# Core build tools (required)
+sudo dnf install -y gcc gcc-c++ make openssl-devel protobuf-compiler
+
+# Desktop app dependencies (optional)
+sudo dnf install -y webkit2gtk3-devel gtk3-devel libappindicator-gtk3-devel
+
+# WiFi scanning tools (optional)
+sudo dnf install -y wireless-tools aircrack-ng
+```
+
+### macOS
+
+```bash
+# Install Xcode Command Line Tools
+xcode-select --install
+
+# No additional dependencies needed for basic building
+# Desktop app will work out of the box
+```
+
+### Windows
+
+**Visual Studio Build Tools:**
+1. Download [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2022)
+2. Select "Desktop development with C++" workload
+3. Install
+
+**Or use winget:**
+```powershell
+winget install Microsoft.VisualStudio.2022.BuildTools
+```
+
+## Environment Configuration
+
+### Required Variables
+
+Edit `.env` and set these values:
+
+```bash
+# Strike48 Backend
+STRIKE48_HOST=wss://your-server.example.com
+STRIKE48_TENANT=your-tenant-id
+
+# Matrix API
+MATRIX_API_URL=https://your-server.example.com
+MATRIX_TENANT_ID=your-tenant-id
+```
+
+### Optional Variables
+
+```bash
+# Authentication (if not using OTT)
+STRIKE48_TOKEN=your_jwt_token_here
+
+# Custom instance ID
+STRIKE48_INSTANCE_ID=pick-machine-01
+
+# TLS Configuration
+STRIKE48_TLS=true
+MATRIX_TLS_INSECURE=false  # Set true for self-signed certs (dev only)
+
+# Logging
+RUST_LOG=debug  # trace, debug, info, warn, error
+
+# Gateway Identity
+CONNECTOR_NAME=pentest-connector  # Set unique name per host
+
+# Workspace
+WORKSPACE_PATH=/custom/workspace/path
+```
+
+### Connection Formats
+
+**WebSocket:**
+```bash
+STRIKE48_HOST=ws://localhost:3030   # HTTP
+STRIKE48_HOST=wss://example.com     # HTTPS
+```
+
+**gRPC:**
+```bash
+STRIKE48_HOST=grpc://localhost:50061   # Without TLS
+STRIKE48_HOST=grpc://example.com:443   # With TLS (set STRIKE48_TLS=true)
+```
+
+### Development vs Production
+
+**Development:**
+```bash
+STRIKE48_HOST=ws://localhost:3030
+STRIKE48_TLS=false
+MATRIX_TLS_INSECURE=true
+RUST_LOG=debug
+```
+
+**Production:**
+```bash
+STRIKE48_HOST=wss://connectors.example.com
+STRIKE48_TLS=true
+MATRIX_TLS_INSECURE=false
+RUST_LOG=info
+```
+
+## Troubleshooting
+
+### Using the Dependency Checker
+
+If you encounter build errors, run the dependency checker first:
+
+```bash
+./check-deps.sh
+```
+
+It will identify exactly what's missing and provide the fix commands for your OS.
+
+### Rust Installation Issues
+
+**Permission denied during install:**
+```bash
+# Ensure you can write to ~/.cargo
+ls -la ~/.cargo || mkdir -p ~/.cargo
+```
+
+**Rust not in PATH after install:**
+```bash
+source $HOME/.cargo/env
+# Or add to ~/.bashrc or ~/.zshrc
+echo 'source $HOME/.cargo/env' >> ~/.bashrc
+```
+
+### Build Errors
+
+**OpenSSL not found (Linux):**
+
+This is the most common build error. You need both OpenSSL headers AND pkg-config:
+
+```bash
+# Debian/Ubuntu
+sudo apt update
+sudo apt install -y build-essential pkg-config libssl-dev
+
+# Fedora/RHEL
+sudo dnf install -y gcc gcc-c++ make openssl-devel
+
+# Arch Linux
+sudo pacman -S base-devel openssl pkg-config
+```
+
+**pkg-config not found:**
+
+pkg-config is required for the build system to find OpenSSL and other libraries:
+
+```bash
+# Debian/Ubuntu
+sudo apt install -y pkg-config
+
+# Fedora/RHEL  
+sudo dnf install -y pkgconfig
+
+# macOS (via Homebrew)
+brew install pkg-config
+```
+
+**protoc (Protocol Buffers compiler) not found:**
+
+protoc is required to compile gRPC/protobuf definitions:
+
+```bash
+# Debian/Ubuntu
+sudo apt install -y protobuf-compiler
+
+# Fedora/RHEL
+sudo dnf install -y protobuf-compiler
+
+# Arch Linux
+sudo pacman -S protobuf
+
+# macOS (via Homebrew)
+brew install protobuf
+
+# Verify installation
+protoc --version
+```
+
+**WebKit not found (Linux desktop):**
+```bash
+sudo apt install -y libwebkit2gtk-4.0-dev  # Debian/Ubuntu
+sudo dnf install -y webkit2gtk3-devel      # Fedora/RHEL
+```
+
+**Linker errors on Windows:**
+- Ensure Visual Studio Build Tools with C++ workload is installed
+- Restart terminal after installation
+
+### Runtime Issues
+
+**Connection refused:**
+- Verify `STRIKE48_HOST` is correct
+- Check if Strike48 backend is running
+- Verify firewall/network connectivity
+
+**TLS certificate errors:**
+- For development: Set `MATRIX_TLS_INSECURE=true`
+- For production: Ensure valid certificates or provide CA cert
+
+**WiFi scanning doesn't work:**
+- WiFi tools require root privileges
+- Run with: `sudo cargo run --package pentest-desktop`
+- Or use: `sudo ./run-pentest.sh desktop dev`
+
+**Permission denied on tools:**
+- Some penetration testing tools require elevated privileges
+- Run Pick with `sudo` when using these features
+
+### First Build is Slow
+
+The first build downloads and compiles all dependencies, which can take 5-10 minutes:
+
+```bash
+# Monitor progress with verbose output
+cargo build --package pentest-headless --verbose
+
+# Or build in release mode (slower but optimized)
+cargo build --package pentest-headless --release
+```
+
+### Recommended WiFi Adapter Lost Connection
+
+If you're scanning with your primary WiFi adapter:
+- Your adapter enters monitor mode
+- You lose internet connection
+- Pick disconnects from Strike48
+
+**Solution:** Use an external WiFi adapter for scanning while keeping your primary connection active.
+
+See [Recommended WiFi Adapters](../README.md#recommended-wifi-adapters) in README.
+
+## Next Steps
+
+After successful installation:
+
+1. **Configure environment:** Edit `.env` with your backend details
+2. **Build the project:** `cargo build --package pentest-headless`
+3. **Run Pick:** `./run-pentest.sh headless dev`
+4. **Read the docs:**
+   - [README.md](../README.md) - Full documentation
+   - [UI_FEATURES.md](UI_FEATURES.md) - UI customization guide
+   - [RUNNING.md](RUNNING.md) - Deployment guide (if available)
+
+## Getting Help
+
+- GitHub Issues: [https://github.com/Strike48-public/pick/issues](https://github.com/Strike48-public/pick/issues)
+- Documentation: [docs/](.)
+- Strike48 Support: Contact your administrator
+
+## Security Notes
+
+- Never commit your `.env` file with real credentials
+- Use TLS (`STRIKE48_TLS=true`) in production
+- Only use `MATRIX_TLS_INSECURE=true` in development
+- WiFi tools require authorization before use on any network

--- a/docs/PICK_CUSTOMER_FEATURES.md
+++ b/docs/PICK_CUSTOMER_FEATURES.md
@@ -1,0 +1,462 @@
+# Pick: Adaptive Penetration Testing Platform
+
+## Overview
+
+Pick is an open-source penetration testing platform that combines 90+ integrated security tools with adaptive multi-agent reasoning. When automated attacks encounter obstacles, Pick figures out alternative approaches, validates findings through independent verification, and adjusts its strategy based on what it discovers.
+
+Built for red teamers, penetration testers, and security learners, Pick handles the technical orchestration of complex attack chains while you focus on strategic decisions. Use Pick standalone for solo assessments, or integrate with StrikeKit for enterprise red team operations with team collaboration and engagement management.
+
+**Key Capabilities:**
+- Adaptive execution that adjusts strategy when obstacles are encountered
+- Multi-agent validation architecture to verify findings before reporting
+- 90+ integrated tools with access to 3,000+ BlackArch tools for learning
+- Multi-platform deployment (desktop, headless, web, mobile, Kubernetes)
+- Standalone operation or enterprise integration via StrikeKit
+
+---
+
+## How Pick Works
+
+### Multi-Agent Validation Architecture
+
+Pick uses independent agents working together to ensure reliable results:
+
+**Red Team Agent** → Executes penetration testing tactics and techniques  
+**Validator Agent** → Independently verifies findings and prevents false positives  
+**Report Generator** → Documents only validated findings with confidence levels
+
+This separation of execution and verification reduces wasted time chasing false positives and provides clear audit trails showing how each vulnerability was discovered and validated.
+
+### Adaptive Execution
+
+Unlike traditional pentesting tools that fail when they encounter unexpected responses, Pick treats obstacles as new information and adapts its approach:
+
+**Scenario Examples:**
+- Web application returns unexpected error → Pick tries different encoding techniques and payload variations
+- Port scan blocked by firewall → Pick adjusts timing, fragmentation, and scan techniques
+- Initial exploit fails → Pick analyzes the failure and pivots to alternative attack vectors
+- Authentication bypass needed → Pick orchestrates credential harvesting and brute force strategies
+
+Pick doesn't blindly follow scripts—it figures out what the target actually needs and adjusts its strategy accordingly.
+
+### Unified Tool Orchestration
+
+Pick integrates 90+ security tools and has access to learn from 3,000+ BlackArch tools. Rather than requiring manual tool chaining and output parsing, Pick understands tool capabilities, knows which tools work well together, and orchestrates complex multi-tool attack chains automatically.
+
+**From reconnaissance to exploitation to post-exploitation**, Pick handles the technical execution while you provide strategic guidance and oversight.
+
+---
+
+## Use Cases
+
+### External Network Penetration Testing
+
+**Scenario:** Security assessment of external network infrastructure
+
+Pick orchestrates the complete external penetration testing workflow:
+1. **Reconnaissance** - Host discovery, port scanning, service enumeration
+2. **Vulnerability Assessment** - Service banner analysis, CVE lookup, default credential checking
+3. **Exploitation** - Automated exploitation attempts with validated results
+4. **Post-Exploitation** - Credential harvesting, lateral movement planning
+5. **Reporting** - Validated findings with attack chain documentation
+
+**Value:** Complete external network assessments without manual tool chaining or output correlation.
+
+---
+
+### WiFi Security Assessment
+
+**Scenario:** Wireless network security testing and WPA/WPA2 password auditing
+
+Pick's AutoPWN feature provides fully orchestrated WiFi penetration testing:
+1. **Network Discovery** - Scan for WiFi networks with signal strength filtering
+2. **Target Selection** - Intelligent filtering by security type and signal quality
+3. **Monitor Mode Management** - Automated wireless interface configuration
+4. **Handshake Capture** - Deauthentication attacks and packet capture orchestration
+5. **Password Cracking** - Dictionary attacks with wordlist management
+6. **Cleanup** - Automatic restoration of network interfaces
+
+**Value:** Professional-grade WiFi security assessments with hardware-level access in a multi-platform deployment model.
+
+**Technical Note:** Configurable sandbox profiles allow WiFi hardware passthrough while maintaining isolation for other operations—enabling WiFi pentesting even in containerized deployments.
+
+---
+
+### Web Application Security Testing
+
+**Scenario:** Comprehensive web application vulnerability assessment
+
+Pick orchestrates web application testing across the OWASP Top 10 and beyond:
+- **Content Discovery** - Directory/file enumeration, endpoint discovery, parameter detection
+- **Vulnerability Scanning** - SQL injection, XSS, command injection, authentication bypass
+- **Web Fuzzing** - Parameter fuzzing, subdomain enumeration, DNS discovery
+- **CMS/Framework Detection** - Automated identification and targeted scanning
+- **API Security** - REST/GraphQL endpoint testing and authentication analysis
+
+**Integrated Tools:** ffuf, gobuster, sqlmap, nuclei, nikto, wpscan, arjun, and 30+ web security tools
+
+**Value:** Comprehensive web application security testing with tool selection based on discovered technologies.
+
+---
+
+### Learning & Skill Development
+
+**Scenario:** Security professionals and students learning penetration testing methodology
+
+Pick serves as an interactive learning platform:
+- **Watch agents demonstrate real-world pentesting** - Observe tool selection, decision-making, and attack chains
+- **Understand methodology** - See how reconnaissance informs exploitation, and how tools chain together
+- **Practice safely** - Use against authorized targets in controlled environments
+- **Build skills progressively** - Start with guided attacks, transition to strategic oversight
+
+**Value:** Learn by observing adaptive agent behavior, then take increasing control as skills develop.
+
+---
+
+### Red Team Operations (with StrikeKit)
+
+**Scenario:** Multi-week red team engagements with team collaboration
+
+When integrated with StrikeKit, Pick enables enterprise red team operations:
+- **Engagement Management** - Track targets, credentials, findings, and attack paths
+- **Team Collaboration** - Matrix integration for real-time collaboration
+- **C2 Infrastructure** - Built-in command and control with cross-platform agents
+- **Pivot Tracking** - Document lateral movement and attack chain progression
+- **Client Deliverables** - PDF reports with findings and remediation guidance
+
+**Value:** Solo pentester capabilities scale to full red team operations with engagement tracking and team coordination.
+
+---
+
+### Beyond These Use Cases
+
+With access to 90+ integrated tools and the ability to learn from 3,000+ BlackArch tools, Pick supports extensive security testing scenarios:
+
+**Network Security:**
+- Internal network penetration testing
+- Cloud infrastructure assessment
+- Network device security auditing
+- SNMP enumeration and exploitation
+
+**Credential Attacks:**
+- Password cracking (50+ protocols via Hydra)
+- Hash cracking with GPU acceleration (Hashcat)
+- Kerberoasting and Windows authentication attacks
+- Default credential auditing
+
+**Post-Exploitation:**
+- Windows credential extraction (Impacket suite)
+- Linux privilege escalation enumeration
+- Lateral movement orchestration
+- Active Directory exploitation
+
+**OSINT & Reconnaissance:**
+- Subdomain enumeration and discovery
+- DNS analysis and zone transfers
+- Social media and data breach correlation
+- Asset discovery and mapping
+
+**Specialized Testing:**
+- SMB/Windows share enumeration
+- Database security assessment
+- IoT device security testing
+- Network service exploitation
+
+**The key difference:** Pick doesn't just provide access to these tools—it understands when to use them, how to chain them together, and how to validate their results.
+
+---
+
+## Platform Capabilities
+
+### Integrated Security Tools (90+)
+
+Pick provides unified orchestration across industry-standard penetration testing tools:
+
+**Network Scanning & Discovery:**
+nmap, rustscan, masscan, arp-scan, netdiscover, nbtscan, unicornscan, hping3
+
+**Web Application Testing:**
+ffuf, gobuster, nikto, dirb, sqlmap, nuclei, wpscan, wfuzz, feroxbuster, arjun, commix, dirsearch, xsstrike, hakrawler, httprobe, wafw00f, whatweb, skipfish, dalfox, joomscan, droopescan
+
+**DNS & Subdomain Enumeration:**
+sublist3r, amass, subfinder, assetfinder, dnsenum, dnsrecon, fierce
+
+**Credential Attacks:**
+hydra (50+ protocols), john (password cracking), hashcat (GPU acceleration), aircrack-ng (WiFi)
+
+**Post-Exploitation:**
+impacket suite (secretsdump, psexec, wmiexec, getuserspns), crackmapexec, evil-winrm, linpeas
+
+**Network Exploitation:**
+bettercap, responder, socat, ncat, tshark
+
+**OSINT & Reconnaissance:**
+theHarvester, spiderfoot, recon-ng, whois, gau, waybackurls, gospider, katana, paramspider, eyewitness, cewl
+
+**SMB & Windows:**
+enum4linux, enum4linux-ng, smbmap, ldapsearch, onesixtyone
+
+**Additional Capabilities:**
+exiftool (forensics), changeme (default credentials), crunch (wordlist generation), searchsploit, testssl, sslscan
+
+**Learning from 3,000+ BlackArch Tools:**
+Pick has access to the full BlackArch repository for learning tool capabilities, output patterns, and orchestration strategies.
+
+---
+
+### Multi-Platform Deployment
+
+Deploy Pick wherever your security testing needs to happen:
+
+**Desktop Application**
+- Native Linux/macOS/Windows GUI with full tool access
+- WiFi hardware passthrough for wireless security testing
+- Configurable sandbox profiles (restrictive, WiFi-enabled, permissive)
+
+**Headless Agent**
+- Server/container deployment with web-based UI
+- Kubernetes-native with Helm charts
+- StrikeHub integration for automated lifecycle management
+- Minimal scratch-based container images
+
+**Web Application**
+- Browser-based interface with server-side tool execution
+- No client-side installation required
+- Multi-user support via LiveView architecture
+
+**Mobile Applications**
+- Native Android and iOS apps
+- On-device tool execution for physical security assessments
+- Perfect for WiFi surveys and network reconnaissance in the field
+
+**Terminal UI (TUI)**
+- Terminal-based interface for SSH/remote environments
+- Full functionality in console-only environments
+
+---
+
+### Adaptive Reasoning
+
+Pick's multi-agent architecture enables adaptive decision-making:
+
+**Tool Selection:**
+- Analyzes target characteristics to choose appropriate tools
+- Understands which tools provide overlapping vs. complementary data
+- Prioritizes faster tools for initial reconnaissance, comprehensive tools for validation
+
+**Attack Chain Orchestration:**
+- Reconnaissance findings inform exploitation strategy
+- Successful exploits trigger post-exploitation workflows
+- Blocked techniques trigger alternative approaches
+
+**Real-Time Adjustment:**
+- Target rate limiting detected → adjust timing and concurrency
+- Service behaving unexpectedly → try alternative interrogation techniques
+- Initial exploit failed → analyze error output and pivot strategy
+
+**Validation Logic:**
+- Independent Validator agent confirms findings before reporting
+- Cross-references results from multiple tools for confidence scoring
+- Identifies false positives through behavioral analysis
+
+---
+
+### Open Source & Auditable
+
+Pick is fully open source and auditable:
+- Complete source code available on GitHub
+- Review agent decision-making logic and tool orchestration
+- Contribute integrations, improvements, and bug fixes
+- No proprietary "black box" decision-making
+
+**Security & Privacy:**
+- All tool execution happens locally (your infrastructure)
+- No telemetry or data collection
+- Full control over results and findings
+- Auditable logs showing every decision and action
+
+---
+
+## Enterprise Integration: StrikeKit
+
+### When You Need Team Collaboration
+
+Pick operates standalone for solo penetration testers and learners. When you need team coordination, engagement tracking, and client deliverables, integrate with StrikeKit.
+
+**StrikeKit Adds:**
+
+**Engagement Management**
+- Track red team engagements with workflow states (Planning → Active → Paused → Complete)
+- Target tracking (hosts, services, network topology)
+- Credential storage and organization (passwords, hashes, tokens, API keys)
+- Findings documentation with severity ratings and remediation guidance
+
+**C2 Infrastructure**
+- Built-in HTTPS listener with lightweight cross-platform agents
+- Automatic extraction of targets, credentials, and findings from command output
+- Pivot tracking and lateral movement documentation
+- Attack chain visualization
+
+**Team Collaboration**
+- Matrix integration for real-time team communication
+- Shared engagement context across team members
+- Real-time oversight and aggression controls for autonomous agents
+- Activity logging and audit trails
+
+**Client Deliverables**
+- PDF report generation with findings and recommendations
+- MITRE ATT&CK technique mapping and tagging
+- Methodology checklists (external, internal, web app, Active Directory)
+- Objective tracking and scope drift detection
+
+**Workflow Orchestration**
+- Multi-phase engagement planning
+- Blocker tracking and resolution workflows
+- Automated task assignment and execution
+- Progress monitoring and status reporting
+
+### Architecture: Pick + StrikeKit
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                     StrikeKit                           │
+│         (Engagement Management & Collaboration)         │
+│                                                          │
+│  • Target Tracking        • Team Collaboration          │
+│  • Findings Management    • C2 Infrastructure           │
+│  • PDF Reports            • Matrix Integration          │
+└────────────────────┬────────────────────────────────────┘
+                     │
+                     │ Orchestrates
+                     ▼
+┌─────────────────────────────────────────────────────────┐
+│                        Pick                             │
+│         (Adaptive Pentesting Execution)                 │
+│                                                          │
+│  • Multi-Agent Validation  • 90+ Integrated Tools       │
+│  • Adaptive Reasoning      • 3,000+ BlackArch Learning  │
+│  • Tool Orchestration      • Multi-Platform Deployment  │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Use Pick Standalone When:**
+- Solo penetration testing or bug bounty hunting
+- Learning and skill development
+- Quick assessments and vulnerability validation
+- Personal security research projects
+
+**Use Pick + StrikeKit When:**
+- Multi-week red team engagements
+- Team-based penetration testing operations
+- Client-facing assessments requiring deliverables
+- Enterprise security programs with compliance requirements
+- Operations requiring C2 infrastructure and pivot tracking
+
+---
+
+## Getting Started
+
+### Installation
+
+**Desktop (Linux/macOS/Windows):**
+```bash
+# Clone repository
+git clone https://github.com/Strike48-public/pick.git
+cd pick
+
+# Run desktop application
+cargo run --package pentest-desktop
+```
+
+**Headless Agent (Server/Container):**
+```bash
+# Using convenience script
+./run-pentest.sh headless
+
+# Or with Docker
+docker pull strike48/pick-connector:latest
+docker run -p 3030:3030 strike48/pick-connector
+```
+
+**Kubernetes:**
+```bash
+# Using Helm
+helm repo add pick https://strike48-public.github.io/pick
+helm install pick pick/pick-connector
+```
+
+### Quick Start
+
+1. **First Run** - Pick automatically detects your platform and available tools
+2. **Dashboard** - Access the Quick Actions dashboard for common workflows
+3. **Tool Execution** - Select tools manually or let agents orchestrate automatically
+4. **Results** - View validated findings with confidence levels and evidence
+
+### Configuration
+
+**Environment Variables:**
+- `STRIKE48_HOST` - Backend integration endpoint (optional for standalone)
+- `RUST_LOG` - Logging level (debug, info, warn, error)
+- `CONNECTOR_NAME` - Unique identifier for this Pick instance
+
+**Optional Integrations:**
+- **StrikeKit** - Enterprise engagement management and team collaboration
+- **Matrix** - Real-time agent communication and oversight
+- **Custom Wordlists** - Provide domain-specific dictionaries for password attacks
+
+### System Requirements
+
+**Minimum:**
+- Linux, macOS, or Windows
+- 4GB RAM
+- 2GB disk space
+
+**Recommended:**
+- 8GB+ RAM for complex assessments
+- SSD for faster tool execution
+- WiFi adapter with monitor mode support (for wireless testing)
+
+**For WiFi Testing:**
+- Requires root/administrator privileges for hardware access
+- External WiFi adapter recommended to avoid connection loss
+- See docs/AUTOPWN.md for recommended hardware
+
+---
+
+## Community & Support
+
+**Documentation:**
+- Full documentation at https://github.com/Strike48-public/pick/docs
+- Tool-specific guides and examples
+- Architecture and development documentation
+
+**Community:**
+- GitHub Issues for bug reports and feature requests
+- Discussions for questions and community support
+- Contributing guidelines for code contributions
+
+**Enterprise Support:**
+- StrikeKit integration documentation
+- Enterprise deployment guides
+- Professional services available
+
+---
+
+## Open Source
+
+Pick is MIT licensed and fully open source:
+- **Repository:** https://github.com/Strike48-public/pick
+- **License:** MIT
+- **Contributing:** Pull requests welcome
+
+**Why Open Source?**
+- Build trust through code transparency
+- Enable community contributions and improvements
+- Allow security audits and verification
+- Provide learning opportunities for security professionals
+
+---
+
+*Pick: Adaptive penetration testing with multi-agent validation*
+
+*For enterprise red team operations, see StrikeKit integration documentation.*

--- a/docs/QUICK_INSTALL.md
+++ b/docs/QUICK_INSTALL.md
@@ -1,0 +1,88 @@
+# Quick Install Guide
+
+Get Pick running in under 5 minutes.
+
+## One-Line Install
+
+```bash
+curl -sSL https://raw.githubusercontent.com/Strike48-public/pick/main/install.sh | bash
+```
+
+Or clone first:
+
+```bash
+git clone https://github.com/Strike48-public/pick.git
+cd pick
+./install.sh
+```
+
+## What Gets Installed
+
+- Rust and Cargo (if needed)
+- Build dependencies for your OS
+- (Optional) Desktop app dependencies
+- (Optional) WiFi scanning tools
+
+## Interactive Prompts
+
+The script will ask:
+
+| Prompt | Recommendation |
+|--------|----------------|
+| Install desktop dependencies? | Yes if you want the GUI app |
+| Install WiFi tools? | Yes if you need penetration testing features |
+| Overwrite .env? | No if you already configured it |
+| Open .env editor? | Yes for first-time setup |
+| Build now? | Yes (takes 5-10 minutes) |
+| Run tests? | Yes to verify installation |
+
+## Quick Configuration
+
+Edit `.env` with your Strike48 backend:
+
+```bash
+STRIKE48_HOST=wss://your-server.example.com
+STRIKE48_TENANT=your-tenant-id
+MATRIX_API_URL=https://your-server.example.com
+MATRIX_TENANT_ID=your-tenant-id
+```
+
+## Run Pick
+
+```bash
+# Headless agent (no GUI)
+./run-pentest.sh headless dev
+
+# Desktop app (requires sudo for WiFi)
+sudo cargo run --package pentest-desktop
+```
+
+## Troubleshooting
+
+**Script fails on dependency installation:**
+- Check you have sudo/admin privileges
+- Verify network connectivity
+
+**Rust not found after install:**
+```bash
+source $HOME/.cargo/env
+```
+
+**Build takes forever:**
+- First build compiles all dependencies (5-10 minutes)
+- Subsequent builds are much faster
+
+**Connection refused when running:**
+- Verify STRIKE48_HOST in .env
+- Check if backend is running
+
+## Full Documentation
+
+- [INSTALLATION.md](INSTALLATION.md) - Complete installation guide
+- [README.md](../README.md) - Full project documentation
+- [UI_FEATURES.md](UI_FEATURES.md) - Customization guide
+
+## Getting Help
+
+- GitHub Issues: [Strike48-public/pick/issues](https://github.com/Strike48-public/pick/issues)
+- Full troubleshooting guide: [INSTALLATION.md#troubleshooting](INSTALLATION.md#troubleshooting)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,121 @@
+# Pick Documentation
+
+Complete documentation for the Pick penetration testing connector.
+
+## Getting Started
+
+- **[Quick Install Guide](QUICK_INSTALL.md)** - Get running in 5 minutes
+- **[Installation Guide](INSTALLATION.md)** - Complete installation instructions, troubleshooting, and platform guides
+- **[Build Troubleshooting](BUILD_TROUBLESHOOTING.md)** - Fix common build errors (OpenSSL, pkg-config, protoc, linker issues)
+- **[Runtime Troubleshooting](RUNTIME_TROUBLESHOOTING.md)** - Fix runtime errors (workspace, resources, connections, permissions)
+- **[Main README](../README.md)** - Project overview, features, and architecture
+
+## User Guides
+
+- **[UI Features](UI_FEATURES.md)** - Theme customization, keyboard shortcuts, and visual features
+- **[Autopwn Guide](AUTOPWN.md)** - Automated penetration testing workflows
+- **[Autopwn Testing](autopwn-testing-guide.md)** - Testing autopwn scenarios
+
+## Technical Documentation
+
+- **[Network Restoration](network-restoration.md)** - WiFi recovery procedures
+- **[Token Expiration Fix](token-expiration-fix.md)** - Authentication troubleshooting
+- **[CyberChef Drag & Drop](cyberchef-drag-drop-testing.md)** - File analysis testing
+- **[E2E Testing Setup](e2e-testing-setup.md)** - End-to-end test configuration
+
+## Product & Planning
+
+- **[Customer Features](PICK_CUSTOMER_FEATURES.md)** - Feature roadmap and customer requests
+- **[Competitive Analysis](COMPETITIVE_ANALYSIS_TRIAGE.md)** - Market analysis and positioning
+
+## Quick Reference
+
+### Installation
+
+```bash
+# Automated install
+./install.sh
+
+# Manual build
+cargo build --package pentest-headless
+
+# Run
+./run-pentest.sh headless dev
+```
+
+### Configuration
+
+Edit `.env`:
+```bash
+STRIKE48_HOST=wss://your-server.example.com
+STRIKE48_TENANT=your-tenant-id
+MATRIX_API_URL=https://your-server.example.com
+MATRIX_TENANT_ID=your-tenant-id
+```
+
+### Common Commands
+
+```bash
+# Headless agent
+./run-pentest.sh headless dev
+
+# Desktop app (requires sudo)
+sudo cargo run --package pentest-desktop
+
+# Web app
+cargo run --package pentest-web
+
+# Run tests
+cargo test
+
+# Format code
+cargo fmt --all
+
+# Lint
+cargo clippy -- -D warnings
+```
+
+## Platform Support
+
+| Platform | Status | Notes |
+|----------|--------|-------|
+| Linux | ✓ Full Support | Debian/Ubuntu, Fedora/RHEL |
+| macOS | ✓ Full Support | Intel and Apple Silicon |
+| Windows | ✓ Via WSL | Native support in progress |
+| Android | ⚠ Experimental | Requires cargo-mobile2 |
+| iOS | ⚠ Experimental | Requires Xcode |
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     Strike48 Backend                             │
+│                   (Routes tool requests)                        │
+└───────┬─────────────────┬─────────────────┬─────────────────┬───┘
+        │                 │                 │                 │
+        ▼                 ▼                 ▼                 ▼
+┌───────────────┐ ┌───────────────┐ ┌───────────────┐ ┌───────────────┐
+│   Desktop     │ │     Web       │ │    Mobile     │ │     TUI       │
+│  (dioxus-     │ │  (dioxus-     │ │  (dioxus-     │ │  (dioxus-     │
+│   desktop)    │ │   liveview)   │ │   mobile)     │ │   tui)        │
+├───────────────┤ ├───────────────┤ ├───────────────┤ ├───────────────┤
+│ UI + Tools    │ │ UI + Tools    │ │ UI + Tools    │ │ UI + Tools    │
+│ run locally   │ │ run on server │ │ run on device │ │ run locally   │
+└───────────────┘ └───────────────┘ └───────────────┘ └───────────────┘
+```
+
+Each app IS a connector - it registers with Strike48 and executes tools locally.
+
+## Support
+
+- **GitHub Issues:** [Strike48-public/pick/issues](https://github.com/Strike48-public/pick/issues)
+- **Strike48 Support:** Contact your administrator
+- **Security Issues:** security@strike48.com
+
+## Contributing
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for contribution guidelines (if available).
+
+## License
+
+MIT License - See [LICENSE](../LICENSE) file for details.

--- a/docs/RUNTIME_TROUBLESHOOTING.md
+++ b/docs/RUNTIME_TROUBLESHOOTING.md
@@ -1,0 +1,331 @@
+# Runtime Troubleshooting Guide
+
+Common runtime errors and how to fix them.
+
+## Resource Seeding Errors
+
+### Error: "Failed to validate base directory: No such file or directory"
+
+**Full error message:**
+```
+ERROR pentest_core::seed: Failed to seed required resource 'RockYou Wordlist': 
+Tool execution error: Failed to validate base directory: No such file or directory (os error 2)
+```
+
+**Cause:** The workspace resources directory doesn't exist yet. This happens on first run.
+
+**Fix:** This is automatically fixed in v0.1.1+. The directory is now created automatically.
+
+**Manual fix (if needed):**
+```bash
+# Create the resources directory
+mkdir -p ~/.pick/resources
+
+# Or use custom workspace path from .env
+mkdir -p $WORKSPACE_PATH/resources
+```
+
+**What are these resources?**
+Pick downloads penetration testing resources (wordlists, payloads, etc.) on first run:
+- **Required:** RockYou wordlist, common passwords (~135MB)
+- **Optional:** XSS payloads, SQL injection payloads, reverse shells, etc.
+
+These are downloaded once and cached locally for offline use.
+
+### Error: Resource download fails
+
+**Error message:**
+```
+ERROR pentest_core::seed: Failed to seed required resource 'RockYou Wordlist': 
+Network error: connection timeout
+```
+
+**Causes:**
+- No internet connection
+- Firewall blocking downloads
+- GitHub/source unavailable
+
+**Fix:**
+
+**Option 1: Skip optional resources**
+Optional resources will show as warnings (WARN) not errors. Only required resources block startup.
+
+**Option 2: Manual download**
+```bash
+# Download required resources manually
+mkdir -p ~/.pick/resources/wordlists/passwords
+
+# RockYou wordlist (134MB)
+curl -L -o ~/.pick/resources/wordlists/passwords/rockyou.txt \
+  https://github.com/brannondorsey/naive-hashcat/releases/download/data/rockyou.txt
+
+# Common passwords (1MB)
+curl -L -o ~/.pick/resources/wordlists/passwords/common-10k.txt \
+  https://raw.githubusercontent.com/danielmiessler/SecLists/master/Passwords/Common-Credentials/10k-most-common.txt
+```
+
+**Option 3: Use corporate proxy**
+```bash
+# Set proxy environment variables
+export HTTP_PROXY=http://proxy.corp.com:8080
+export HTTPS_PROXY=http://proxy.corp.com:8080
+
+# Then start Pick
+./run-pentest.sh headless dev
+```
+
+**Option 4: Disable auto-seeding** (not recommended)
+If you don't need wordlists/payloads, you can skip the seed check by setting:
+```bash
+export SKIP_RESOURCE_SEED=true
+```
+
+## Connection Errors
+
+### Error: "Connection refused"
+
+**Full error message:**
+```
+ERROR strike48_connector: Failed to connect to Strike48 backend: 
+Connection refused (os error 111)
+```
+
+**Cause:** Strike48 backend is not running or wrong host configured.
+
+**Fix:**
+
+1. **Verify backend is running:**
+   ```bash
+   # Check your .env configuration
+   grep STRIKE48_HOST .env
+   
+   # Try to reach the host
+   ping your-backend-hostname
+   curl -v https://your-backend-hostname
+   ```
+
+2. **Check `.env` configuration:**
+   ```bash
+   # Required variables
+   STRIKE48_HOST=wss://your-server.example.com
+   STRIKE48_TENANT=your-tenant-id
+   MATRIX_API_URL=https://your-server.example.com
+   MATRIX_TENANT_ID=your-tenant-id
+   ```
+
+3. **Verify firewall/network:**
+   - Check if firewall blocks outbound connections
+   - Verify VPN is connected (if required)
+   - Check if backend port is open
+
+### Error: "TLS certificate verification failed"
+
+**Full error message:**
+```
+ERROR strike48_connector: TLS error: 
+certificate verify failed: self signed certificate
+```
+
+**Cause:** Backend uses self-signed certificate (common in development).
+
+**Fix:**
+
+**For development only:**
+```bash
+# In .env file
+MATRIX_TLS_INSECURE=true
+```
+
+**For production:**
+- Use valid TLS certificates
+- Or provide CA certificate path
+- Never use `MATRIX_TLS_INSECURE=true` in production
+
+## Authentication Errors
+
+### Error: "Session token invalid"
+
+**Full error message:**
+```
+ERROR pentest_ui: Session token validation failed
+```
+
+**Cause:** Token expired or invalid.
+
+**Fix:**
+
+1. **Restart Pick** - It will request a new token
+2. **Check token in `.env`** (if using JWT instead of OTT):
+   ```bash
+   # Verify STRIKE48_TOKEN is set and not expired
+   grep STRIKE48_TOKEN .env
+   ```
+
+3. **Request new token from backend admin**
+
+## Permission Errors
+
+### Error: "Permission denied" on tool execution
+
+**Full error message:**
+```
+ERROR pentest_tools: Failed to execute tool 'wifi_scan': 
+Permission denied (os error 13)
+```
+
+**Cause:** Tool requires root privileges (WiFi scanning, packet capture).
+
+**Fix:**
+
+**Option 1: Run with sudo (recommended for desktop)**
+```bash
+sudo cargo run --package pentest-desktop
+# Or
+sudo ./run-pentest.sh desktop dev
+```
+
+**Option 2: Grant capabilities (Linux only)**
+```bash
+# Grant specific capabilities instead of full root
+sudo setcap cap_net_raw,cap_net_admin=eip target/debug/pentest-desktop
+
+# Then run without sudo
+./target/debug/pentest-desktop
+```
+
+**Option 3: Use headless mode** (runs as service with appropriate permissions)
+
+### Error: "Operation not permitted" on workspace directory
+
+**Full error message:**
+```
+ERROR pentest_core: Failed to write to workspace: 
+Operation not permitted (os error 1)
+```
+
+**Cause:** No write permission to workspace directory.
+
+**Fix:**
+
+1. **Check workspace path:**
+   ```bash
+   # Default: ~/.local/share/pentest-workspace
+   # Or from .env:
+   grep WORKSPACE_PATH .env
+   ```
+
+2. **Fix permissions:**
+   ```bash
+   # For default location
+   mkdir -p ~/.local/share/pentest-workspace
+   chmod 755 ~/.local/share/pentest-workspace
+   
+   # Or for custom location
+   mkdir -p $WORKSPACE_PATH
+   chmod 755 $WORKSPACE_PATH
+   ```
+
+3. **Check disk space:**
+   ```bash
+   df -h ~/.local/share/
+   ```
+
+## Workspace Errors
+
+### Error: "Workspace path does not exist"
+
+**Cause:** `WORKSPACE_PATH` in `.env` points to non-existent directory.
+
+**Fix:**
+
+```bash
+# Check .env
+grep WORKSPACE_PATH .env
+
+# Create the directory
+mkdir -p /path/from/env
+chmod 755 /path/from/env
+
+# Or use default by commenting out WORKSPACE_PATH
+# WORKSPACE_PATH=/custom/workspace/path
+```
+
+## Still Stuck?
+
+### Generate Diagnostic Report
+
+```bash
+# Capture full logs
+RUST_LOG=debug ./run-pentest.sh headless dev 2>&1 | tee pick-debug.log
+
+# Check first 100 lines of errors
+grep ERROR pick-debug.log | head -100
+
+# Check what resources are missing
+ls -la ~/.pick/resources/
+
+# Check workspace
+ls -la ~/.local/share/pentest-workspace/
+```
+
+### Getting Help
+
+**Include this information when asking for help:**
+
+1. Full error message (not just first line)
+2. Output of:
+   ```bash
+   cat .env  # (remove sensitive tokens first!)
+   ls -la ~/.pick/resources/
+   ls -la ~/.local/share/pentest-workspace/
+   uname -a
+   cargo --version
+   rustc --version
+   ```
+3. Steps to reproduce
+4. What you've tried already
+
+**Where to get help:**
+- GitHub Issues: [Strike48-public/pick/issues](https://github.com/Strike48-public/pick/issues)
+- Tag issues with `runtime-error` label
+
+## Prevention
+
+### Pre-flight Checks
+
+Before running Pick:
+
+```bash
+# 1. Verify configuration
+cat .env
+
+# 2. Test backend connectivity
+ping $(grep STRIKE48_HOST .env | cut -d= -f2 | sed 's/wss\?:\/\///')
+
+# 3. Create workspace directories
+mkdir -p ~/.pick/resources
+mkdir -p ~/.local/share/pentest-workspace
+
+# 4. Check disk space (need ~500MB for resources)
+df -h ~/.pick/
+```
+
+### Development vs Production
+
+**Development setup:**
+```bash
+# .env for development
+STRIKE48_HOST=ws://localhost:3030
+STRIKE48_TLS=false
+MATRIX_TLS_INSECURE=true
+RUST_LOG=debug
+```
+
+**Production setup:**
+```bash
+# .env for production
+STRIKE48_HOST=wss://connectors.example.com
+STRIKE48_TLS=true
+MATRIX_TLS_INSECURE=false
+RUST_LOG=info
+```


### PR DESCRIPTION
> [!NOTE]
> **The failing `Docker Build` check is NOT caused by this PR.** It's a pre-existing CI infrastructure issue where `Dockerfile:3` runs `cargo install cargo-chef` unlocked, so Cargo resolves the newly-published `cargo-platform@0.3.3` which requires rustc 1.91 — but the base image pins `FROM rust:1.88-bookworm`. Cargo itself prints the recommended fix: *"Try re-running `cargo install` with `--locked`"*. That one-line fix is in #79. Once #79 merges, re-running Docker Build on this PR will go green. All 17 other checks pass, including every Rust check (Format, Clippy, Check, Test, Build amd64/arm64, Check macOS, Analyze rust) and every security/compliance check (Gitleaks, Dependency Audit, SBOM, CodeQL).

## Summary

Adds the docs index and companion guides for installing and running Pick, plus a standalone dependency validator script that pairs with `install.sh` for users who skip the installer.

- `check-deps.sh` (executable) — prerequisite validator, bash with `set -euo pipefail`.
- `docs/README.md` — documentation index.
- `docs/INSTALLATION.md` — full installation guide (410 lines).
- `docs/QUICK_INSTALL.md` — 5-minute quickstart (88 lines).
- `docs/RUNTIME_TROUBLESHOOTING.md` — common runtime errors and fixes (331 lines).
- `docs/PICK_CUSTOMER_FEATURES.md` — feature overview (462 lines).

## Notes

- These files were created in earlier sessions but never staged. No code changes, no behavior changes.
- Content scanned for tenant/customer names and internal URLs — none found.
- `COMPETITIVE_ANALYSIS_TRIAGE.md` in the working tree is intentionally **not** included; its own header marks it `DO NOT COMMIT` per the repo's Agent Notes Policy.

## Test plan

- [ ] (reviewer) Read `docs/README.md` and confirm the document linking is coherent.
- [ ] (reviewer) `bash check-deps.sh` on a clean machine and verify the validator runs.
- [ ] (reviewer) Confirm `docs/PICK_CUSTOMER_FEATURES.md` is appropriate for a public repo (it's customer-facing, not internal-only).
