### PR TITLE
fix(ci): use --locked when installing cargo-chef to unblock Docker Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # ── Stage 1: Chef ──────────────────────────────────────────────
 FROM rust:1.88-bookworm AS chef
-RUN cargo install cargo-chef
+RUN cargo install cargo-chef --locked
 WORKDIR /app
 
 # ── Stage 2: Planner ──────────────────────────────────────────


### PR DESCRIPTION
## Summary

\`Dockerfile:3\` ran \`cargo install cargo-chef\` unlocked. Cargo then resolved the newest compatible version of every transitive dependency at build time. \`cargo-platform\` 0.3.3 was recently published requiring rustc 1.91, but the base image pins \`FROM rust:1.88-bookworm\`. Every Docker Build job started failing with:

\`\`\`
cargo-platform@0.3.3 requires rustc 1.91
rustc 1.88.0 is not supported
\`\`\`

Adding \`--locked\` pins cargo-chef's own lockfile so the install is reproducible against the pinned toolchain. This mirrors what \`Dockerfile.scratch:16\` and \`Dockerfile.scratch:41\` already do on the same command.

## Files changed

- \`Dockerfile\`: one-line change on line 3.

## Impact

Unblocks Docker Build on every open PR (including #77 and #78) once merged.

## Test plan

- [ ] (reviewer) CI's Docker Build job should go green on this PR.
- [ ] (reviewer) After merge, rebase/re-run #77 and #78 so they pick up the fix.