### PR TITLE
fix(desktop): don't auto-open browser on connect, show Pending Approval callout

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -143,26 +143,48 @@ impl ConnectorConfig {
         !self.auth_token.is_empty()
     }
 
-    /// Strip any URL scheme prefix from the host and return the bare `host:port`.
+    /// Validate `host` and return it with its scheme preserved so that transport
+    /// auto-detection in [`Self::to_sdk_config`] can distinguish WebSocket
+    /// (`wss://`) from gRPC (`grpc://`, `grpcs://`, or no scheme).
     ///
-    /// Handles `grpc://`, `grpcs://`, `http://`, `https://`, `ws://`, `wss://`.
-    /// Returns `Err` if the result is empty or missing a port (no `:`).
+    /// If no scheme is present and the host ends with `:443`, `wss://` is
+    /// prepended — Cloudflare-fronted Strike48 deployments (the common case
+    /// for port 443) do not proxy arbitrary gRPC over HTTP/2 and require
+    /// WebSocket. This mirrors what a user would type into a browser and
+    /// keeps saved settings from previous versions working.
+    ///
+    /// Returns `Err` if the bare `host:port` is missing or malformed.
     pub fn normalize_host(host: &str) -> Result<String, String> {
         let schemes = [
             "grpc://", "grpcs://", "http://", "https://", "ws://", "wss://",
         ];
-        let mut h = host.trim();
-        for scheme in &schemes {
-            if let Some(stripped) = h.strip_prefix(scheme) {
-                h = stripped;
-                break;
-            }
+        let trimmed = host.trim();
+        let lower = trimmed.to_lowercase();
+
+        let (scheme, bare) = schemes
+            .iter()
+            .find_map(|s| {
+                lower
+                    .strip_prefix(s)
+                    .map(|_| (&trimmed[..s.len()], &trimmed[s.len()..]))
+            })
+            .unwrap_or(("", trimmed));
+
+        if bare.is_empty() || !bare.contains(':') {
+            return Err(
+                "Invalid host format. Use scheme://host:port (e.g., wss://strike48.example.com:443)"
+                    .to_string(),
+            );
         }
 
-        if h.is_empty() || !h.contains(':') {
-            return Err("Invalid host format. Use host:port (e.g., localhost:50061)".to_string());
+        if !scheme.is_empty() {
+            return Ok(format!("{}{}", scheme, bare));
         }
-        Ok(h.to_string())
+
+        // No scheme: Strike48 behind Cloudflare on :443 must use WebSocket;
+        // other ports default to gRPC (SDK's default transport).
+        let inferred = if bare.ends_with(":443") { "wss://" } else { "" };
+        Ok(format!("{}{}", inferred, bare))
     }
 
     /// Convert to the SDK's ConnectorConfig
@@ -378,7 +400,6 @@ pub fn load_connector_config(args: &[String]) -> ConfigLoadResult {
 
     // Preserve the original URL (including scheme) so that to_sdk_config()
     // can auto-detect transport type (WebSocket vs gRPC) and TLS from the scheme.
-    // normalize_host used to strip the scheme here, which broke WSS detection.
 
     ConfigLoadResult::Ok(config)
 }
@@ -407,5 +428,58 @@ impl AppSettings {
             instance_id: self.device_id.clone(),
             ..base_config
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_host_preserves_wss_scheme() {
+        let out = ConnectorConfig::normalize_host("wss://studio.example.com:443").unwrap();
+        assert_eq!(out, "wss://studio.example.com:443");
+    }
+
+    #[test]
+    fn normalize_host_preserves_grpc_scheme() {
+        let out = ConnectorConfig::normalize_host("grpc://localhost:50061").unwrap();
+        assert_eq!(out, "grpc://localhost:50061");
+    }
+
+    #[test]
+    fn normalize_host_infers_wss_for_port_443() {
+        let out = ConnectorConfig::normalize_host("studio.example.com:443").unwrap();
+        assert_eq!(out, "wss://studio.example.com:443");
+    }
+
+    #[test]
+    fn normalize_host_leaves_non_443_bare() {
+        let out = ConnectorConfig::normalize_host("localhost:50061").unwrap();
+        assert_eq!(out, "localhost:50061");
+    }
+
+    #[test]
+    fn normalize_host_trims_whitespace() {
+        let out = ConnectorConfig::normalize_host("  wss://x.example.com:443  ").unwrap();
+        assert_eq!(out, "wss://x.example.com:443");
+    }
+
+    #[test]
+    fn normalize_host_rejects_missing_port() {
+        assert!(ConnectorConfig::normalize_host("studio.example.com").is_err());
+        assert!(ConnectorConfig::normalize_host("wss://studio.example.com").is_err());
+    }
+
+    #[test]
+    fn normalize_host_rejects_empty() {
+        assert!(ConnectorConfig::normalize_host("").is_err());
+        assert!(ConnectorConfig::normalize_host("   ").is_err());
+    }
+
+    #[test]
+    fn normalize_host_scheme_matching_is_case_insensitive() {
+        let out = ConnectorConfig::normalize_host("WSS://Studio.Example.com:443").unwrap();
+        assert_eq!(out, "WSS://Studio.Example.com:443");
     }
 }

--- a/crates/core/src/settings.rs
+++ b/crates/core/src/settings.rs
@@ -34,6 +34,8 @@ pub fn load_settings() -> AppSettings {
         Ok(contents) => {
             let mut settings: AppSettings = serde_json::from_str(&contents).unwrap_or_default();
 
+            let mut dirty = false;
+
             // Validate and clear expired auth token
             if let Some(last_config) = &mut settings.last_config {
                 if let Some(validated) =
@@ -41,17 +43,37 @@ pub fn load_settings() -> AppSettings {
                 {
                     last_config.auth_token = validated;
                 } else {
-                    // Token is expired or invalid, clear it
                     tracing::info!("Cleared expired/invalid auth token from settings");
                     last_config.auth_token.clear();
+                    dirty = true;
+                }
+            }
 
-                    // Save the updated settings to persist the change
-                    if let Err(e) = save_settings(&settings) {
-                        tracing::warn!(
-                            "Failed to save settings after clearing expired token: {}",
-                            e
-                        );
+            // Migrate saved hosts written by older versions that stripped the
+            // URL scheme. Without a scheme the SDK defaults to gRPC, which
+            // fails on Cloudflare-fronted Strike48 deployments. Re-running
+            // normalize_host now re-introduces wss:// for :443 hosts.
+            if let Some(last_config) = &mut settings.last_config {
+                if !last_config.host.is_empty() {
+                    if let Ok(normalized) =
+                        crate::config::ConnectorConfig::normalize_host(&last_config.host)
+                    {
+                        if normalized != last_config.host {
+                            tracing::info!(
+                                "Migrated saved host {} -> {}",
+                                last_config.host,
+                                normalized
+                            );
+                            last_config.host = normalized;
+                            dirty = true;
+                        }
                     }
+                }
+            }
+
+            if dirty {
+                if let Err(e) = save_settings(&settings) {
+                    tracing::warn!("Failed to save settings after migration: {}", e);
                 }
             }
 

--- a/crates/ui/src/components/config_form.rs
+++ b/crates/ui/src/components/config_form.rs
@@ -54,7 +54,7 @@ pub fn ConfigForm(
                     label { "Strike48 Host" }
                     input {
                         r#type: "text",
-                        placeholder: "grpc://localhost:50061",
+                        placeholder: "wss://strike48.example.com:443",
                         value: "{host}",
                         disabled: is_connecting,
                         oninput: move |e| host.set(e.value()),

--- a/crates/ui/src/components/connecting_screen.rs
+++ b/crates/ui/src/components/connecting_screen.rs
@@ -2,6 +2,8 @@
 
 use dioxus::prelude::*;
 
+use crate::components::icons::Shield;
+
 /// Steps shown in the connecting screen UI.
 /// Mirrors the enum in liveview_connector but lives in the shared UI crate
 /// so any frontend can render it.
@@ -38,7 +40,7 @@ pub fn ConnectingScreen(
     let status_text = match step {
         ConnectingStep::Connecting => "Opening connection...",
         ConnectingStep::Registering => "Registering connector...",
-        ConnectingStep::WaitingForApproval => "Awaiting approval",
+        ConnectingStep::WaitingForApproval => "Pending approval",
         ConnectingStep::ExchangingToken => "Exchanging credentials...",
         ConnectingStep::Finalizing => "Finalizing session...",
     };
@@ -84,12 +86,18 @@ pub fn ConnectingScreen(
 
             // Status text
             if step == ConnectingStep::WaitingForApproval {
-                div { class: "approval-instruction",
-                    "{status_text}"
-                }
-                div {
-                    class: "connecting-hint",
-                    "Open the Strike48 web UI and accept this connector."
+                div { class: "approval-callout",
+                    div { class: "approval-callout-icon",
+                        Shield { size: 28 }
+                    }
+                    div { class: "approval-callout-body",
+                        div { class: "approval-callout-title",
+                            "{status_text}"
+                        }
+                        div { class: "approval-callout-hint",
+                            "Open Prospector Studio and approve this connector to continue."
+                        }
+                    }
                 }
             } else {
                 div {

--- a/crates/ui/src/components/css/connecting_screen.css
+++ b/crates/ui/src/components/css/connecting_screen.css
@@ -65,12 +65,52 @@
     text-align: center;
 }
 
-.approval-instruction {
-    font-size: 1.25rem;
-    font-weight: 600;
-    text-align: center;
+/* Callout card shown while waiting for admin approval in Prospector Studio.
+   Uses --warning (amber) to signal "this needs human attention" without
+   implying an error. */
+.approval-callout {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 16px;
+    max-width: 420px;
+    padding: 20px 24px;
+    border-radius: 12px;
+    background-color: color-mix(in oklch, var(--warning) 10%, var(--background));
+    border: 1px solid color-mix(in oklch, var(--warning) 55%, transparent);
     color: var(--foreground);
-    animation: pulse-attention 2s ease-in-out infinite;
+    animation: pulse-callout 2.4s ease-in-out infinite;
+}
+
+.approval-callout-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background-color: color-mix(in oklch, var(--warning) 20%, var(--background));
+    color: var(--warning);
+}
+
+.approval-callout-body {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.approval-callout-title {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--warning);
+    letter-spacing: 0.01em;
+}
+
+.approval-callout-hint {
+    font-size: 0.9rem;
+    color: var(--muted-foreground);
+    line-height: 1.4;
 }
 
 .connecting-cancel-btn {
@@ -95,7 +135,11 @@
     50% { transform: scale(1.3); opacity: 0.7; }
 }
 
-@keyframes pulse-attention {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.6; }
+@keyframes pulse-callout {
+    0%, 100% {
+        box-shadow: 0 0 0 0 color-mix(in oklch, var(--warning) 25%, transparent);
+    }
+    50% {
+        box-shadow: 0 0 0 8px color-mix(in oklch, var(--warning) 0%, transparent);
+    }
 }

--- a/crates/ui/src/liveview_connector/auth.rs
+++ b/crates/ui/src/liveview_connector/auth.rs
@@ -71,7 +71,7 @@ impl LiveViewConnector {
         if std::env::var("STRIKEHUB_SOCKET").is_ok() {
             tracing::info!("[RegisterResponse] StrikeHub mode: waiting for admin approval");
             self.send_event(ConnectorEvent::Log(TerminalLine::info(
-                "Waiting for admin approval in Studio…",
+                "Pending approval — accept this connector in Prospector Studio.",
             )));
             self.send_event(ConnectorEvent::StepChanged(
                 ConnectingStep::WaitingForApproval,
@@ -92,7 +92,7 @@ impl LiveViewConnector {
         } else {
             tracing::info!("[RegisterResponse] No JWT, waiting for admin approval in Studio");
             self.send_event(ConnectorEvent::Log(TerminalLine::info(
-                "Waiting for admin approval in Studio…",
+                "Pending approval — accept this connector in Prospector Studio.",
             )));
             self.send_event(ConnectorEvent::StepChanged(
                 ConnectingStep::WaitingForApproval,

--- a/crates/ui/src/liveview_connector/auth.rs
+++ b/crates/ui/src/liveview_connector/auth.rs
@@ -49,11 +49,24 @@ impl LiveViewConnector {
         }
     }
 
-    /// Handle post-registration auth: wait for admin approval or browser fallback.
+    /// Handle post-registration auth: wait for admin approval (default) or
+    /// opt into a browser-based OAuth fallback.
     ///
-    /// Called from the message loop when registration succeeds but no JWT is present.
-    /// Saved credentials are now loaded *before* the connection loop (in connect_and_run)
-    /// to avoid disrupting an already-successful registration with a reconnect cycle.
+    /// Called from the message loop when registration succeeds but no JWT is
+    /// present. The normal flow is: admin approves in Prospector Studio,
+    /// server emits `CredentialsIssued`, and `handle_credentials_issued`
+    /// performs the OTT exchange over the already-open wss stream — no
+    /// browser involvement.
+    ///
+    /// The browser-based OAuth path is disabled by default because it opens
+    /// a system browser tab on every connect, which is intrusive UX for
+    /// users who only care about connector auth (the overwhelming common
+    /// case). Set `PICK_ENABLE_BROWSER_AUTH=1` to opt back in, or run in
+    /// StrikeHub mode (which has its own IPC auth).
+    ///
+    /// Saved credentials are now loaded *before* the connection loop (in
+    /// `connect_and_run`) to avoid disrupting an already-successful
+    /// registration with a reconnect cycle.
     pub(crate) async fn handle_post_registration_auth(&mut self) {
         if std::env::var("STRIKEHUB_SOCKET").is_ok() {
             tracing::info!("[RegisterResponse] StrikeHub mode: waiting for admin approval");
@@ -63,9 +76,27 @@ impl LiveViewConnector {
             self.send_event(ConnectorEvent::StepChanged(
                 ConnectingStep::WaitingForApproval,
             ));
-        } else {
-            tracing::info!("[RegisterResponse] No JWT, trying browser login fallback");
+            return;
+        }
+
+        let browser_auth_enabled = std::env::var("PICK_ENABLE_BROWSER_AUTH")
+            .map(|v| matches!(v.as_str(), "1" | "true" | "yes"))
+            .unwrap_or(false);
+
+        if browser_auth_enabled {
+            tracing::info!(
+                "[RegisterResponse] No JWT, PICK_ENABLE_BROWSER_AUTH=1 \
+                 — trying browser login fallback"
+            );
             self.try_fetch_matrix_token_fallback().await;
+        } else {
+            tracing::info!("[RegisterResponse] No JWT, waiting for admin approval in Studio");
+            self.send_event(ConnectorEvent::Log(TerminalLine::info(
+                "Waiting for admin approval in Studio…",
+            )));
+            self.send_event(ConnectorEvent::StepChanged(
+                ConnectingStep::WaitingForApproval,
+            ));
         }
     }
 

--- a/crates/ui/src/liveview_connector/mod.rs
+++ b/crates/ui/src/liveview_connector/mod.rs
@@ -753,16 +753,22 @@ impl LiveViewConnector {
                                     TerminalLine::success("Registered with Strike48")
                                 ));
                                 if self.config.auth_token.is_empty() {
-                                    // No JWT yet — try loading saved OTT credentials.
-                                    // This may trigger a reconnect, so await it before
-                                    // transitioning to Registered.
+                                    // No JWT yet — the server accepted our registration
+                                    // request but authorization is still pending admin
+                                    // approval. Keep the UI on the connecting screen so
+                                    // the "Pending approval" callout is visible. The
+                                    // status transitions to Registered later, inside
+                                    // handle_credentials_issued, after the OTT exchange
+                                    // returns a JWT.
                                     self.handle_post_registration_auth().await;
+                                } else {
+                                    // JWT case: Matrix chat token comes from the __st
+                                    // query param injected by the Strike48 proxy when
+                                    // the LiveView WebSocket connects (see handle_ws_open).
+                                    // The session store persists it across reconnects so
+                                    // ChatPanel doesn't need a fresh fetch.
+                                    self.send_event(ConnectorEvent::StatusChanged(ConnectorStatus::Registered));
                                 }
-                                // JWT case: Matrix chat token comes from the __st query param
-                                // injected by the Strike48 proxy when the LiveView WebSocket
-                                // connects (see handle_ws_open). The session store persists it
-                                // across reconnects so ChatPanel doesn't need a fresh fetch.
-                                self.send_event(ConnectorEvent::StatusChanged(ConnectorStatus::Registered));
                             } else {
                                 tracing::error!("Registration failed: {}", resp.error);
 


### PR DESCRIPTION
> [!CAUTION]
> **Do not merge — blocked by #85.** Post-merge testing revealed this PR regresses the Chat panel and Device Info quick action on desktop: after disabling browser-OAuth by default, the desktop webview has no way to obtain the Matrix session token required for GraphQL calls, so ChatPanel can't list agents and nothing gets auto-selected. Headless is unaffected. Needs investigation into alternative token-acquisition paths before shipping. See #85 for full analysis.

> [!IMPORTANT]
> **This is a stacked PR on top of #77.** Please review and merge #77 first. GitHub will auto-retarget this PR to `main` when #77 merges. The diff below shows only the changes on top of #77.

## Summary

Two linked UX problems made post-registration approval on the desktop confusing or invisible:

1. Clicking **Connect** opened a system browser tab on every attempt. That tab was trying to pre-fetch a Matrix chat token (separate from the connector JWT), but the path is flaky (tracked in #81) and the chat token isn't required for the connector to function. **The browser now stays closed by default**, gated behind `PICK_ENABLE_BROWSER_AUTH=1` for anyone who still needs it. StrikeHub mode's IPC auth path is unchanged.

2. The desktop flipped to the **Dashboard as soon as the wss handshake succeeded** — even though the server response carried no JWT (authorization was still pending admin approval). Users saw a non-functional Dashboard with "Pending approval" buried in the Recent Activity feed. **The status now stays `Connecting` until a JWT actually exists**, and the connecting screen renders a **bordered amber callout card** telling the user exactly what to do.

## What the callout looks like

```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃  [shield icon]                          ┃
┃  Pending approval                       ┃
┃                                         ┃
┃  Open Prospector Studio and approve     ┃
┃  this connector to continue.            ┃
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
```

- Icon in a circular amber bubble (uses the existing `--warning` token — warm oklch amber that's already defined across all 8 themes)
- Title in warning-amber, hint in muted-foreground
- Gentle outward box-shadow pulse (2.4s period)

## Files changed

- `crates/ui/src/components/connecting_screen.rs` — replace single text line with structured callout; rename `Awaiting approval` -> `Pending approval`.
- `crates/ui/src/components/css/connecting_screen.css` — add `.approval-callout`, `.approval-callout-icon`, `.approval-callout-body`, `.approval-callout-title`, `.approval-callout-hint` styles and `pulse-callout` keyframes. Removed the old `.approval-instruction` style since it's no longer used.
- `crates/ui/src/liveview_connector/auth.rs` — default browser-OAuth path off, gate behind `PICK_ENABLE_BROWSER_AUTH=1`. Update log copy to match new UI wording.
- `crates/ui/src/liveview_connector/mod.rs` — only emit `StatusChanged(Registered)` when a JWT is actually present; otherwise leave the status as `Connecting` so the approval callout stays visible.

## Test plan

- [x] `cargo check -p pentest-desktop` / `cargo check -p pentest-headless` — clean.
- [x] `cargo clippy -p pentest-desktop -- -D warnings` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] Manual desktop test against Strike48:
  - Wipe saved creds and settings, launch desktop.
  - Enter host in the Connect form, click Connect.
  - **No browser tab opens.**
  - Desktop stays on connecting screen with the amber "Pending approval" callout.
  - Approve the connector in Prospector Studio.
  - Desktop transitions through "Exchanging credentials..." to the Dashboard. Recent Activity shows the full flow with the updated copy.
- [x] Manual headless test against Strike48: env vars -> registers -> waits for approval with `[step] WaitingForApproval` -> OTT exchange -> JWT -> fully registered.
- [ ] **(blocker)** Resolve the Chat/Device Info regression described in #85.
- [ ] (reviewer) Verify the callout renders correctly in each theme (Dark, Light, Dracula, Gruvbox, TokyoNight, Matrix, Cyberpunk, Nord) since it uses `--warning` which varies by theme.
- [ ] (reviewer) Confirm `PICK_ENABLE_BROWSER_AUTH=1` still fires the old browser fallback for anyone who needs it.

## Related

- Builds on #77 (URL scheme preservation).
- Reduces user-facing impact of #81 (browser OAuth CORS/port fallback failure), though that issue remains a latent bug on the opt-in path.
- Regresses Chat panel and Device Info quick action on desktop (#85) — needs resolution before merge.
