### PR TITLE
fix: add 30m timeout and retry logic to macOS notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,11 +140,24 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           ditto -c -k --keepParent target/${{ matrix.target }}/release/pentest-connector $RUNNER_TEMP/pentest-connector.zip
-          xcrun notarytool submit $RUNNER_TEMP/pentest-connector.zip \
-            --apple-id "$APPLE_ID" \
-            --password "$APPLE_APP_PASSWORD" \
-            --team-id "$APPLE_TEAM_ID" \
-            --wait
+          for attempt in 1 2 3; do
+            echo "Notarization attempt $attempt..."
+            if xcrun notarytool submit $RUNNER_TEMP/pentest-connector.zip \
+              --apple-id "$APPLE_ID" \
+              --password "$APPLE_APP_PASSWORD" \
+              --team-id "$APPLE_TEAM_ID" \
+              --wait --timeout 30m; then
+              echo "Notarization succeeded."
+              break
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "Notarization failed, retrying in 30s..."
+              sleep 30
+            else
+              echo "Notarization failed after $attempt attempts."
+              exit 1
+            fi
+          done
 
       - name: Package
         run: |
@@ -403,11 +416,24 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
           ditto -c -k --keepParent target/${{ matrix.target }}/release/pentest-agent $RUNNER_TEMP/pentest-agent.zip
-          xcrun notarytool submit $RUNNER_TEMP/pentest-agent.zip \
-            --apple-id "$APPLE_ID" \
-            --password "$APPLE_APP_PASSWORD" \
-            --team-id "$APPLE_TEAM_ID" \
-            --wait
+          for attempt in 1 2 3; do
+            echo "Notarization attempt $attempt..."
+            if xcrun notarytool submit $RUNNER_TEMP/pentest-agent.zip \
+              --apple-id "$APPLE_ID" \
+              --password "$APPLE_APP_PASSWORD" \
+              --team-id "$APPLE_TEAM_ID" \
+              --wait --timeout 30m; then
+              echo "Notarization succeeded."
+              break
+            fi
+            if [ "$attempt" -lt 3 ]; then
+              echo "Notarization failed, retrying in 30s..."
+              sleep 30
+            else
+              echo "Notarization failed after $attempt attempts."
+              exit 1
+            fi
+          done
 
       - name: Package
         run: |


### PR DESCRIPTION
## Summary
- Add `--timeout 30m` to all `xcrun notarytool submit --wait` calls to prevent the macOS runner from losing its network connection before Apple finishes processing
- Wrap each notarization call in a retry loop (up to 3 attempts with 30s delay) so transient failures don't break the release

Affects both `build-desktop-macos` and `build-headless-macos` notarization steps.

## Test plan
- [ ] Trigger a release workflow (tag or workflow_dispatch) and verify macOS notarization completes
- [ ] Confirm retry logic activates if Apple's service is slow (visible in logs)
