### PR TITLE
ci: disable macOS code signing by default

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,11 @@ on:
       version:
         description: 'Version to release (e.g., 0.1.0)'
         required: true
+      macos_signing:
+        description: 'Enable macOS code signing & notarization (requires active Apple developer account)'
+        required: true
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -109,6 +114,7 @@ jobs:
         run: cargo build --package pentest-desktop --release --target ${{ matrix.target }} --features pentest-platform/desktop-pcap
 
       - name: Import Apple certificate
+        if: inputs.macos_signing == true
         env:
           APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -125,6 +131,7 @@ jobs:
           security list-keychains -d user -s $KEYCHAIN_PATH login.keychain-db
 
       - name: Sign macOS binary
+        if: inputs.macos_signing == true
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
@@ -134,6 +141,7 @@ jobs:
             target/${{ matrix.target }}/release/pentest-connector
 
       - name: Notarize macOS binary
+        if: inputs.macos_signing == true
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
@@ -385,6 +393,7 @@ jobs:
         run: cargo build --package pentest-headless --release --target ${{ matrix.target }} --features pentest-platform/desktop-pcap
 
       - name: Import Apple certificate
+        if: inputs.macos_signing == true
         env:
           APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -401,6 +410,7 @@ jobs:
           security list-keychains -d user -s $KEYCHAIN_PATH login.keychain-db
 
       - name: Sign macOS binary
+        if: inputs.macos_signing == true
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
@@ -410,6 +420,7 @@ jobs:
             target/${{ matrix.target }}/release/pentest-agent
 
       - name: Notarize macOS binary
+        if: inputs.macos_signing == true
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}


### PR DESCRIPTION
## Summary

- Adds a `macos_signing` boolean input (default: **false**) to the existing `workflow_dispatch` trigger
- Gates all Apple certificate import, `codesign`, and `notarytool` notarization steps behind `inputs.macos_signing == true`
- macOS builds for both x86_64 and aarch64 still produce unsigned artifacts (desktop + headless)
- Windows and Linux builds are unaffected

## Context

The macOS developer account is temporarily suspended, causing all signing/notarization steps to fail on release runs.

## What's gated behind the flag

| Step | `build-desktop-macos` | `build-headless-macos` |
|------|----------------------|----------------------|
| Import Apple certificate | gated | gated |
| `codesign` binary | gated | gated |
| `notarytool` submit + wait | gated | gated |

## Re-enabling signing

When the account is restored, either:
1. Run the release workflow via **workflow_dispatch** with `macos_signing: true`
2. Flip the default back to `true` in the workflow file

## Test plan

- [ ] Trigger a workflow_dispatch release with `macos_signing: false` — verify macOS builds succeed without signing
- [ ] Verify unsigned macOS artifacts are produced for both architectures (desktop + headless)
- [ ] Verify Windows/Linux builds are unaffected