### PR TITLE
fix: use macos-13 runner for x86_64 macOS builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
           - os: macos-latest
             target: aarch64-apple-darwin
@@ -385,7 +385,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
           - os: macos-latest
             target: aarch64-apple-darwin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,10 @@ on:
       version:
         description: 'Version to release (e.g., 0.1.0)'
         required: true
+      # TEMPORARY: macOS signing disabled by default during Apple developer account suspension.
+      # TODO: Change default back to true once account is restored.
       macos_signing:
-        description: 'Enable macOS code signing & notarization (requires active Apple developer account)'
+        description: 'Enable macOS code signing & notarization (default: false due to account suspension)'
         required: true
         default: false
         type: boolean
@@ -118,7 +120,7 @@ jobs:
         run: cargo build --package pentest-desktop --release --target ${{ matrix.target }} --features pentest-platform/desktop-pcap
 
       - name: Import Apple certificate
-        if: inputs.macos_signing == true
+        if: inputs.macos_signing
         env:
           APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -135,7 +137,7 @@ jobs:
           security list-keychains -d user -s $KEYCHAIN_PATH login.keychain-db
 
       - name: Sign macOS binary
-        if: inputs.macos_signing == true
+        if: inputs.macos_signing
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
@@ -145,7 +147,7 @@ jobs:
             target/${{ matrix.target }}/release/pentest-connector
 
       - name: Notarize macOS binary
-        if: inputs.macos_signing == true
+        if: inputs.macos_signing
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}
@@ -401,7 +403,7 @@ jobs:
         run: cargo build --package pentest-headless --release --target ${{ matrix.target }} --features pentest-platform/desktop-pcap
 
       - name: Import Apple certificate
-        if: inputs.macos_signing == true
+        if: inputs.macos_signing
         env:
           APPLE_CERTIFICATE_P12: ${{ secrets.APPLE_CERTIFICATE_P12 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -418,7 +420,7 @@ jobs:
           security list-keychains -d user -s $KEYCHAIN_PATH login.keychain-db
 
       - name: Sign macOS binary
-        if: inputs.macos_signing == true
+        if: inputs.macos_signing
         env:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
@@ -428,7 +430,7 @@ jobs:
             target/${{ matrix.target }}/release/pentest-agent
 
       - name: Notarize macOS binary
-        if: inputs.macos_signing == true
+        if: inputs.macos_signing
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_PASSWORD: ${{ secrets.APPLE_APP_PASSWORD }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,11 +95,15 @@ jobs:
           path: dist/pentest-connector-windows-x86_64.zip
 
   build-desktop-macos:
-    name: Desktop (macOS)
-    runs-on: macos-latest
+    name: Desktop (macOS ${{ matrix.target == 'aarch64-apple-darwin' && 'aarch64' || 'x86_64' }})
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        target: [x86_64-apple-darwin, aarch64-apple-darwin]
+        include:
+          - os: macos-13
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable
@@ -375,10 +379,14 @@ jobs:
 
   build-headless-macos:
     name: Headless (macOS ${{ matrix.target == 'aarch64-apple-darwin' && 'aarch64' || 'x86_64' }})
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        target: [x86_64-apple-darwin, aarch64-apple-darwin]
+        include:
+          - os: macos-13
+            target: x86_64-apple-darwin
+          - os: macos-latest
+            target: aarch64-apple-darwin
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Summary

- Use `macos-13` (Intel) for x86_64 macOS builds instead of `macos-latest` (now ARM-only)
- Restructures `build-desktop-macos` and `build-headless-macos` from simple target list to `include`-style matrix with per-target runner selection

## Problem

`macos-latest` now resolves to ARM-only runners where `cargo` resolves to `rustup-init` instead of the installed toolchain binary, causing x86_64 builds to fail with:

```
error: unexpected argument 'build' found
Usage: rustup-init[EXE] [OPTIONS]
```

## Fix

Switch to `include`-style matrix so each target gets its own runner:
- `x86_64-apple-darwin` → `macos-13` (Intel, native x86_64)
- `aarch64-apple-darwin` → `macos-latest` (ARM, native aarch64)

## Test plan

- [ ] macOS x86_64 desktop + headless builds pass
- [ ] macOS aarch64 desktop + headless builds remain unaffected