### PR TITLE
fix: replace href="#" with button elements in file browser navigation

### DIFF
--- a/crates/ui/src/components/file_browser/directory.rs
+++ b/crates/ui/src/components/file_browser/directory.rs
@@ -71,11 +71,9 @@ pub(super) fn DirectoryListing(props: DirectoryListingProps) -> Element {
         div { class: "directory-listing",
             // Parent link
             if let Some(parent) = parent_path {
-                a {
+                button {
                     class: "parent-link",
-                    href: "#",
-                    onclick: move |e| {
-                        e.prevent_default();
+                    onclick: move |_| {
                         on_navigate.call(FileEntry {
                             name: "..".to_string(),
                             path: parent.clone(),

--- a/crates/ui/src/components/file_browser/file_viewer.rs
+++ b/crates/ui/src/components/file_browser/file_viewer.rs
@@ -60,11 +60,9 @@ pub(super) fn FileViewer(props: FileViewerProps) -> Element {
         div { class: "file-viewer",
             // Compact toolbar: <- filename . type  [Copy]
             div { class: "file-toolbar",
-                a {
+                button {
                     class: "file-toolbar-back",
-                    href: "#",
-                    onclick: move |e| {
-                        e.prevent_default();
+                    onclick: move |_| {
                         on_back.call(());
                     },
                     "\u{2190}"

--- a/crates/ui/src/components/file_browser/header.rs
+++ b/crates/ui/src/components/file_browser/header.rs
@@ -13,10 +13,8 @@ pub(super) fn Header(current_path: String, on_navigate: EventHandler<String>) ->
 
     rsx! {
         nav { class: "breadcrumbs",
-            a {
-                href: "#",
-                onclick: move |e| {
-                    e.prevent_default();
+            button {
+                onclick: move |_| {
                     on_navigate.call(String::new());
                 },
                 "Files"
@@ -26,10 +24,8 @@ pub(super) fn Header(current_path: String, on_navigate: EventHandler<String>) ->
                 {
                     let partial: String = parts[..=i].join("/");
                     rsx! {
-                        a {
-                            href: "#",
-                            onclick: move |e| {
-                                e.prevent_default();
+                        button {
+                            onclick: move |_| {
                                 on_navigate.call(partial.clone());
                             },
                             "{part}"

--- a/crates/ui/src/components/file_browser/image_viewer.rs
+++ b/crates/ui/src/components/file_browser/image_viewer.rs
@@ -59,11 +59,9 @@ pub(super) fn ImageViewer(props: ImageViewerProps) -> Element {
         div { class: "image-viewer",
             // Compact toolbar
             div { class: "file-toolbar",
-                a {
+                button {
                     class: "file-toolbar-back",
-                    href: "#",
-                    onclick: move |e| {
-                        e.prevent_default();
+                    onclick: move |_| {
                         on_back.call(());
                     },
                     "\u{2190}"


### PR DESCRIPTION
## Summary

Fixes #87 by converting anchor elements with `href="#"` to `button` elements throughout the file browser components. This prevents malformed URLs with trailing `#` characters when navigating back to parent directories.

## Changes

- **directory.rs**: Parent Directory link now uses `<button>` instead of `<a>`
- **file_viewer.rs**: Back button now uses `<button>` element
- **image_viewer.rs**: Back button now uses `<button>` element  
- **header.rs**: Breadcrumb navigation links now use `<button>` elements

## Technical Details

Using `<button>` elements for client-side navigation is semantically correct since these are not actual hyperlinks (they don't navigate to a different URL). This also eliminates the need for `prevent_default()` since buttons don't create URL fragments by default.

The `onclick` handlers remain unchanged and continue to call the appropriate navigation callbacks.

## Test Plan

- [ ] Navigate to Files page
- [ ] Click into Reports directory (or any subdirectory)
- [ ] Click "← Parent Directory" link
- [ ] Verify URL does not have trailing `#`
- [ ] Verify navigation to parent directory works correctly
- [ ] Test breadcrumb navigation in header
- [ ] Test back buttons in file viewer and image viewer
- [ ] Verify all file browser navigation still works as expected

## Validation

- ✅ `cargo check --all-targets` passes
- ✅ `cargo clippy --all-targets -- -D warnings` passes
- ✅ `cargo fmt --all -- --check` passes