### PR TITLE
ci: skip Docker build on PRs, only run on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,7 @@ jobs:
 
   docker:
     name: Docker Build
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

Optimizes CI pipeline by skipping the Docker build job on pull requests. Docker build will now only run when changes are merged to main.

## Problem

Docker build is the slowest CI job by far:

| Job | Duration |
|-----|----------|
| **Docker Build** | **12m 17s** |
| Test | 4m 9s |
| Dependency Audit | 3m 5s |
| Check | 2m 1s |
| Clippy | 1m 51s |

This makes Docker build **3x slower** than any other job. The slowness comes from:
1. Full Rust compilation inside Docker (even with cargo-chef caching)
2. Installing heavy Kali tools (metasploit, hashcat, etc.)

## Solution

Add `if: github.ref == 'refs/heads/main'` condition to Docker build job.

**Why this is safe:**
- Docker build validates the **runtime image**, not code correctness
- Code correctness is already validated by: tests, clippy, format, check
- UI changes (like most PRs) cannot break Docker build
- Main branch still validates Docker image works for releases

## Impact

- **PR CI time: 12+ minutes → ~4 minutes** (3x faster feedback)
- **Main branch CI: unchanged** (still validates Docker image)
- **Risk: minimal** - code correctness already verified before merge

## Test Plan

- [ ] Verify this PR's CI completes in ~4 minutes (no Docker build)
- [ ] After merge, verify main branch CI runs Docker build
- [ ] Confirm Docker image still builds successfully on main

## Validation

- ✅ One-line change to `.github/workflows/ci.yml`
- ✅ No changes to actual Docker build process
- ✅ Main branch protection ensures this can't break production