### PR TITLE
fix: add lazy browser-OAuth to ChatPanel for desktop auth

### DIFF
--- a/crates/ui/src/components/chat_panel/mod.rs
+++ b/crates/ui/src/components/chat_panel/mod.rs
@@ -191,6 +191,51 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
     }
 
     // -----------------------------------------------------------------------
+    // Lazy browser-OAuth: trigger on first Chat panel visit when token is missing
+    // -----------------------------------------------------------------------
+
+    // Track whether we've attempted browser auth
+    let mut browser_auth_attempted = use_signal(|| false);
+
+    // If Chat panel is visible, we don't have a token, and we haven't tried browser auth yet
+    if props.visible
+        && effective_token.is_empty()
+        && !api_url.is_empty()
+        && !browser_auth_attempted()
+        && !agents_loaded()
+    {
+        browser_auth_attempted.set(true);
+        let api_url_clone = api_url.clone();
+
+        crate::liveview_server::push_terminal_line(TerminalLine::info(
+            "[chat] No auth token — opening browser for authentication...",
+        ));
+
+        spawn(async move {
+            match pentest_core::matrix::fetch_matrix_token_browser(&api_url_clone).await {
+                Ok(token) => {
+                    tracing::info!(
+                        "[chat] Browser auth succeeded, token length: {}",
+                        token.len()
+                    );
+                    crate::liveview_server::set_matrix_credentials(&api_url_clone, &token);
+                    crate::session::set_auth_token(&token);
+                    crate::liveview_server::push_terminal_line(TerminalLine::success(
+                        "[chat] Authentication successful — chat ready",
+                    ));
+                }
+                Err(e) => {
+                    tracing::warn!("[chat] Browser auth failed: {}", e);
+                    crate::liveview_server::push_terminal_line(TerminalLine::error(format!(
+                        "[chat] Authentication failed: {}",
+                        e
+                    )));
+                }
+            }
+        });
+    }
+
+    // -----------------------------------------------------------------------
     // Fetch agents when we have a token
     // -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fixes #85 by implementing lazy browser-based OAuth authentication that triggers only when the Chat panel is opened without a Matrix session token. This restores Chat/Device Info functionality on desktop after PR #83 disabled automatic browser-OAuth on connect.

## Problem

After PR #83:
- Browser-OAuth gated behind `PICK_ENABLE_BROWSER_AUTH=1` env var
- Desktop webview doesn't receive `__st` token (no Strike48 proxy injection)
- Connector JWT cannot be exchanged for Matrix session token (no API exists)
- **Result:** Chat panel completely broken on desktop

## Investigation Results

Confirmed via code analysis:
1. **Desktop webview doesn't get `__st`** - it connects directly to local LiveView server without proxy
2. **No JWT exchange API** - connector JWT is gRPC-only, cannot become GraphQL session token
3. **Solution:** Lazy browser-OAuth (trigger on Chat panel visit)

## Solution

Implement lazy authentication that triggers only when user opens Chat:

```rust
// ChatPanel checks for empty token when becoming visible
if props.visible && effective_token.is_empty() && !browser_auth_attempted() {
    browser_auth_attempted.set(true);
    // Spawn async browser OAuth flow
    fetch_matrix_token_browser(&api_url).await
}
```

## Benefits

- ✅ Chat works on desktop without `PICK_ENABLE_BROWSER_AUTH=1`
- ✅ No browser popup on connect (only when Chat is clicked)
- ✅ Device Info / Network Scan quick actions work again
- ✅ Leverages existing browser OAuth (no new code paths)
- ✅ Minimal UX friction (auth happens when needed)

## Implementation Details

**Added to `crates/ui/src/components/chat_panel/mod.rs`:**
- `browser_auth_attempted` signal to track auth state
- Conditional check when panel becomes visible
- Async spawn of `fetch_matrix_token_browser()`
- Session store update on success
- User-visible logs for auth status

**Triggers when ALL true:**
- Chat panel visible
- `effective_token` is empty
- `api_url` is not empty
- Haven't attempted auth yet
- Agents not loaded

## Test Plan

- [ ] Launch desktop app without `PICK_ENABLE_BROWSER_AUTH` set
- [ ] Connect to Strike48 (no browser popup on connect)
- [ ] Click Chat tab
- [ ] Verify browser opens for OAuth
- [ ] Complete OAuth flow
- [ ] Verify Chat panel loads agents successfully
- [ ] Click Device Info quick action
- [ ] Verify it opens Chat with pre-filled prompt

## Related

- Fixes #85 (P1 bug)
- Unblocks PR #83 from merging
- Related to #81 (browser OAuth port issues)

## Validation

- ✅ `cargo check --all-targets` passes
- ✅ `cargo clippy --all-targets -- -D warnings` passes  
- ✅ `cargo fmt --all` passes
- ✅ No new dependencies added
- ✅ Leverages existing `fetch_matrix_token_browser()` code