### PR TITLE
fix: fail fast with clear error when OAuth callback ports are busy

### DIFF
--- a/crates/core/src/matrix/auth.rs
+++ b/crates/core/src/matrix/auth.rs
@@ -323,15 +323,18 @@ pub async fn fetch_matrix_token_browser(matrix_url: &str) -> crate::error::Resul
                     l
                 }
                 Err(_) => {
-                    tracing::warn!("[BROWSER_AUTH] Ports 4000 and 5173 busy, using random port (CORS may fail)");
-                    tokio::net::TcpListener::bind("127.0.0.1:0")
-                        .await
-                        .map_err(|e| {
-                            crate::error::Error::Matrix(format!(
-                                "Failed to bind callback server: {}",
-                                e
-                            ))
-                        })?
+                    // Ports 4000 and 5173 are required for CORS (Matrix server whitelist).
+                    // Using a random port would cause the callback to timeout due to CORS rejection.
+                    tracing::error!(
+                        "[BROWSER_AUTH] Ports 4000 and 5173 are busy. Browser OAuth requires one of these ports. \
+                         Stop the process using these ports (likely dev servers: `lsof -i :4000` and `lsof -i :5173`)."
+                    );
+                    return Err(crate::error::Error::Matrix(
+                        "matrix: Browser OAuth requires ports 4000 or 5173 to be available. \
+                         Both ports are currently in use. Stop any dev servers (Vite, Vue CLI, etc.) \
+                         or other processes using these ports and try again. \
+                         To check: `lsof -i :4000` and `lsof -i :5173`".to_string()
+                    ));
                 }
             }
         }

--- a/crates/ui/src/liveview_connector/auth.rs
+++ b/crates/ui/src/liveview_connector/auth.rs
@@ -108,66 +108,109 @@ impl LiveViewConnector {
             Some(self.config.instance_id.clone()),
         );
 
-        // Register public key with OTT
-        match ott_provider
-            .register_public_key_with_ott_data(
-                &creds.ott,
-                ott_api_url,
-                &creds.register_url,
-                &connector_type,
-                Some(&self.config.instance_id),
-            )
-            .await
-        {
-            Ok(response) => {
+        // Register public key with OTT (with retry for transient errors)
+        const MAX_RETRIES: u32 = 3;
+        let mut last_error = None;
+
+        for attempt in 1..=MAX_RETRIES {
+            if attempt > 1 {
+                let backoff_ms = 1000 * (1 << (attempt - 2)); // 1s, 2s, 4s
                 tracing::info!(
-                    "Registered public key with OTT. Client ID: {}",
-                    response.client_id
+                    "OTT registration attempt {} failed, retrying in {}ms",
+                    attempt - 1,
+                    backoff_ms
                 );
-                self.send_event(ConnectorEvent::Log(TerminalLine::success(format!(
-                    "Key registered: {}",
-                    response.client_id
+                self.send_event(ConnectorEvent::Log(TerminalLine::info(format!(
+                    "Retrying OTT registration (attempt {}/{}) in {}ms...",
+                    attempt, MAX_RETRIES, backoff_ms
                 ))));
+                tokio::time::sleep(tokio::time::Duration::from_millis(backoff_ms)).await;
+            }
 
-                // Get JWT using private_key_jwt
-                match ott_provider.get_token().await {
-                    Ok(jwt_token) => {
-                        tracing::info!("Obtained JWT, will reconnect with JWT authentication");
-                        self.send_event(ConnectorEvent::Log(TerminalLine::success(
-                            "JWT obtained, reconnecting...",
-                        )));
+            match ott_provider
+                .register_public_key_with_ott_data(
+                    &creds.ott,
+                    ott_api_url,
+                    &creds.register_url,
+                    &connector_type,
+                    Some(&self.config.instance_id),
+                )
+                .await
+            {
+                Ok(response) => {
+                    tracing::info!(
+                        "Registered public key with OTT (attempt {}). Client ID: {}",
+                        attempt,
+                        response.client_id
+                    );
+                    self.send_event(ConnectorEvent::Log(TerminalLine::success(format!(
+                        "Key registered: {}",
+                        response.client_id
+                    ))));
 
-                        // Update config with new JWT
-                        self.config.auth_token = jwt_token.clone();
+                    // Get JWT using private_key_jwt
+                    match ott_provider.get_token().await {
+                        Ok(jwt_token) => {
+                            tracing::info!("Obtained JWT, will reconnect with JWT authentication");
+                            self.send_event(ConnectorEvent::Log(TerminalLine::success(
+                                "JWT obtained, reconnecting...",
+                            )));
 
-                        // Notify main app to save credentials
-                        self.send_event(ConnectorEvent::CredentialsUpdated {
-                            auth_token: jwt_token,
-                            api_url: self.derive_matrix_api_url(),
-                        });
+                            // Update config with new JWT
+                            self.config.auth_token = jwt_token.clone();
 
-                        // Store OTT provider for token refresh
-                        *self.ott_provider.write().await = Some(ott_provider);
+                            // Notify main app to save credentials
+                            self.send_event(ConnectorEvent::CredentialsUpdated {
+                                auth_token: jwt_token,
+                                api_url: self.derive_matrix_api_url(),
+                            });
 
-                        // Set flag to trigger reconnection
-                        self.reconnect_with_jwt.store(true, Ordering::SeqCst);
+                            // Store OTT provider for token refresh
+                            *self.ott_provider.write().await = Some(ott_provider);
+
+                            // Set flag to trigger reconnection
+                            self.reconnect_with_jwt.store(true, Ordering::SeqCst);
+                        }
+                        Err(e) => {
+                            tracing::error!("Failed to get JWT: {}", e);
+                            self.send_event(ConnectorEvent::Log(TerminalLine::error(format!(
+                                "JWT exchange failed: {}",
+                                e
+                            ))));
+                        }
                     }
-                    Err(e) => {
-                        tracing::error!("Failed to get JWT: {}", e);
-                        self.send_event(ConnectorEvent::Log(TerminalLine::error(format!(
-                            "JWT exchange failed: {}",
-                            e
-                        ))));
+
+                    // Success - exit retry loop
+                    return;
+                }
+                Err(e) => {
+                    tracing::warn!("OTT registration attempt {} failed: {}", attempt, e);
+                    last_error = Some(e);
+
+                    // Don't retry on last attempt
+                    if attempt == MAX_RETRIES {
+                        break;
                     }
                 }
             }
-            Err(e) => {
-                tracing::error!("Failed to register public key with OTT: {}", e);
-                self.send_event(ConnectorEvent::Log(TerminalLine::error(format!(
-                    "OTT registration failed: {}",
-                    e
-                ))));
-            }
+        }
+
+        // All retries exhausted - report failure and return to waiting state
+        if let Some(e) = last_error {
+            tracing::error!(
+                "Failed to register public key with OTT after {} attempts: {}",
+                MAX_RETRIES,
+                e
+            );
+            self.send_event(ConnectorEvent::Log(TerminalLine::error(format!(
+                "OTT registration failed after {} attempts: {}. \
+                 Approval may need to be re-issued in Prospector Studio.",
+                MAX_RETRIES, e
+            ))));
+            // Return to waiting state - admin may need to re-approve
+            self.send_event(ConnectorEvent::StepChanged(
+                ConnectingStep::WaitingForApproval,
+            ));
         }
     }
 }

--- a/crates/ui/src/liveview_connector/mod.rs
+++ b/crates/ui/src/liveview_connector/mod.rs
@@ -814,11 +814,39 @@ impl LiveViewConnector {
             // Get fresh JWT if we have an OTT provider (matches kubestudio pattern:
             // fetch a token at the start of each iteration so reconnects always use
             // a valid token instead of a potentially expired cached one).
+            //
+            // On startup (connection_failures == 0), use a short 5s timeout to fail
+            // fast on unreachable auth URLs. On subsequent reconnects, allow the SDK's
+            // full retry budget (3x30s) since the credentials are known-good.
             {
                 let mut ott_guard = self.ott_provider.write().await;
                 if let Some(ref mut ott) = *ott_guard {
-                    match ott.get_token().await {
-                        Ok(token) => {
+                    // On first connection attempt, use a short 5s timeout to detect stale
+                    // credentials pointing at unreachable auth URLs. On subsequent reconnects,
+                    // allow the SDK's full retry budget since credentials are known-good.
+                    let token_result = if connection_failures == 0 {
+                        match tokio::time::timeout(
+                            tokio::time::Duration::from_secs(5),
+                            ott.get_token(),
+                        )
+                        .await
+                        {
+                            Ok(result) => Some(result),
+                            Err(_elapsed) => {
+                                tracing::warn!(
+                                    "Token refresh timed out after 5s (likely stale credentials pointing \
+                                     at unreachable auth URL). Will clean up stale credentials and fall \
+                                     through to OTT-approval flow."
+                                );
+                                None
+                            }
+                        }
+                    } else {
+                        Some(ott.get_token().await)
+                    };
+
+                    match token_result {
+                        Some(Ok(token)) => {
                             tracing::info!("Got fresh JWT via OttProvider (len={})", token.len());
                             self.config.auth_token = token.clone();
                             self.send_event(ConnectorEvent::CredentialsUpdated {
@@ -826,10 +854,26 @@ impl LiveViewConnector {
                                 api_url: self.derive_matrix_api_url(),
                             });
                         }
-                        Err(e) => {
+                        Some(Err(e)) => {
                             tracing::warn!("Failed to get JWT from saved credentials: {}", e);
                             self.config.auth_token.clear();
                             // Clean up stale credentials file
+                            let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+                            let stale = format!(
+                                "{}/.strike48/credentials/pentest-connector_{}.json",
+                                home, self.config.instance_id
+                            );
+                            if std::fs::remove_file(&stale).is_ok() {
+                                tracing::info!("Removed stale credentials file: {}", stale);
+                            }
+                            *ott_guard = None;
+                        }
+                        None => {
+                            // Timeout on first connection - clean up stale credentials
+                            tracing::warn!(
+                                "Token refresh timed out - cleaning up stale credentials"
+                            );
+                            self.config.auth_token.clear();
                             let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
                             let stale = format!(
                                 "{}/.strike48/credentials/pentest-connector_{}.json",


### PR DESCRIPTION
Fixes #81

## Summary

Browser OAuth callback previously fell back to a random OS-assigned port when both 4000 and 5173 were busy, then **silently timed out after 120 seconds** because the Matrix server's CORS whitelist only includes the fixed ports.

This PR removes the random-port fallback and **fails fast with a clear, actionable error message**.

**Changes:**
- Remove fallback to `127.0.0.1:0` (random port)
- Return immediate error with guidance:
  - Which ports are required (4000 or 5173)
  - How to check what's using them (`lsof -i :4000`, `lsof -i :5173`)
  - What to stop (dev servers: Vite, Vue CLI, etc.)
- Fail fast (immediate error) instead of 120s silent timeout

**Before:** 120s hang → "Login timed out" (no guidance)  
**After:** Immediate error with actionable steps

## Test Plan

- [ ] Manual test: Bind ports 4000 and 5173 (`python3 -m http.server 4000`, `python3 -m http.server 5173`)
- [ ] Attempt browser OAuth login
- [ ] Verify immediate clear error message (no 120s hang)
- [ ] Verify error message includes `lsof` guidance
- [ ] Stop blocking processes, verify OAuth succeeds

## Related

Part of bug-fixing sprint (all P1/P2/P3 issues). Follows PR #110 (startup timeout).