### PR TITLE
fix: silence unused parameter warning in get_wifi_networks

### DIFF
--- a/crates/platform/src/desktop/system.rs
+++ b/crates/platform/src/desktop/system.rs
@@ -391,10 +391,10 @@ async fn scan_specific_interface(interface: &str) -> Result<Vec<WifiNetwork>> {
 ///
 /// # Arguments
 /// * `interface` - Optional WiFi interface to scan (e.g., "wlan1"). If None, uses auto-detect.
-pub async fn get_wifi_networks(interface: Option<String>) -> Result<Vec<WifiNetwork>> {
+pub async fn get_wifi_networks(_interface: Option<String>) -> Result<Vec<WifiNetwork>> {
     // If interface specified, use iw command (Linux only)
     #[cfg(target_os = "linux")]
-    if let Some(iface) = interface {
+    if let Some(iface) = _interface {
         return scan_specific_interface(&iface).await;
     }
 


### PR DESCRIPTION
## Summary

Fixes pre-existing clippy warning in `crates/platform/src/desktop/system.rs:394` about unused `interface` variable on non-Linux platforms.

The `interface` parameter in `get_wifi_networks()` is conditionally used only on Linux (`#[cfg(target_os = "linux")]`). On macOS and Windows builds, this triggers an unused variable warning.

## Changes

- Renamed `interface` → `_interface` to explicitly mark it as potentially unused
- Updated the reference inside the Linux-only block to use `_interface`

## Testing

- Verified clippy passes: `cargo clippy --all-targets -- -D warnings`
- No functional changes - parameter still used correctly on Linux

---

Closes issue raised by @[teammate] during theme PR review.