### PR TITLE
fix: build-android pipeline produces stale or broken APKs

### DIFF
--- a/justfile
+++ b/justfile
@@ -182,14 +182,38 @@ emulator-list:
 # Inject android-lib AAR module into a dx-generated Gradle project.
 # Symlinks the module, registers it in settings.gradle, and adds the dependency.
 # Idempotent — safe to call on every build.
+#
+# IMPORTANT: `dx build` regenerates settings.gradle and app/build.gradle.kts
+# on every run, wiping out our additions. Therefore this MUST be called AFTER
+# every `dx build` and BEFORE every gradle invocation. The recipe verifies the
+# additions are actually present and aborts loudly if not — silently dropping
+# the kotlin module produces a runtime ClassNotFoundException for
+# `com.strike48.pentest_connector.ConnectorBridge` that's painful to diagnose.
 _inject-android-lib proj:
     #!/usr/bin/env bash
     set -euo pipefail
     ln -sfn "$(pwd)/android-lib" "{{proj}}/android-lib"
-    grep -q "android-lib" "{{proj}}/settings.gradle" 2>/dev/null || \
-        echo "include ':android-lib'" >> "{{proj}}/settings.gradle"
-    grep -q "android-lib" "{{proj}}/app/build.gradle.kts" 2>/dev/null || \
-        echo 'dependencies { implementation(project(":android-lib")) }' >> "{{proj}}/app/build.gradle.kts"
+
+    settings_file="{{proj}}/settings.gradle"
+    build_file="{{proj}}/app/build.gradle.kts"
+
+    grep -q "android-lib" "$settings_file" 2>/dev/null || \
+        echo "include ':android-lib'" >> "$settings_file"
+    grep -q "android-lib" "$build_file" 2>/dev/null || \
+        echo 'dependencies { implementation(project(":android-lib")) }' >> "$build_file"
+
+    # Verify injection took. If `dx build` regenerated the files between
+    # the grep check and the echo (race), or if the project layout changed,
+    # we want to know now — not at runtime.
+    if ! grep -q "android-lib" "$settings_file" 2>/dev/null; then
+        echo "ERROR: failed to inject android-lib into $settings_file" >&2
+        exit 1
+    fi
+    if ! grep -q "android-lib" "$build_file" 2>/dev/null; then
+        echo "ERROR: failed to inject android-lib dependency into $build_file" >&2
+        exit 1
+    fi
+
     # Copy proot, busybox, and dependencies into jniLibs
     for arch in android-jniLibs/*/; do
         abi=$(basename "$arch")
@@ -199,6 +223,35 @@ _inject-android-lib proj:
         cp -n "$arch"lib*.so "$dest/" 2>/dev/null || true
         cp -n "$arch"lib*.so.* "$dest/" 2>/dev/null || true
     done
+
+# Verify the produced APK contains the kotlin bridge class.
+#
+# A silently-stripped `ConnectorBridge` class causes the app to crash on first
+# JNI call (FetchTokenFallback → setOAuthCallbackPort →
+# java.lang.ClassNotFoundException). This check catches the regression in
+# seconds instead of after a 5-minute install + manual test cycle.
+_verify-android-apk apk:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if [[ ! -f "{{apk}}" ]]; then
+        echo "ERROR: APK not found: {{apk}}" >&2
+        exit 1
+    fi
+    # APKs split classes across classes.dex, classes2.dex, etc. — scan all of them.
+    found=0
+    for dex in $(unzip -l "{{apk}}" 2>/dev/null | awk '/classes[0-9]*\.dex/ {print $4}'); do
+        if unzip -p "{{apk}}" "$dex" 2>/dev/null | strings | grep -q "ConnectorBridge"; then
+            found=1
+            break
+        fi
+    done
+    if [[ "$found" -ne 1 ]]; then
+        echo "ERROR: ConnectorBridge class not found in any classes*.dex in {{apk}}" >&2
+        echo "       This usually means _inject-android-lib didn't take. The app will" >&2
+        echo "       crash with ClassNotFoundException on first JNI call." >&2
+        exit 1
+    fi
+    echo "OK: ConnectorBridge present in APK"
 
 # Helper to set up Android NDK environment - prints the NDK bin path
 _android-ndk-bin:
@@ -217,6 +270,9 @@ _android-ndk-bin:
     echo "$NDK/toolchains/llvm/prebuilt/linux-x86_64/bin"
 
 # Build mobile app for Android (debug)
+#
+# By default builds both arm64 (physical devices) and x86_64 (emulators).
+# Override with: ANDROID_TARGETS="aarch64-linux-android" just build-android
 build-android:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -239,11 +295,33 @@ build-android:
     # Unset global CC/CXX that would override the target-specific ones
     unset CC CXX
 
-    {{dx}} build --platform android --package pentest-mobile
+    # Build each Rust target. Without --target, dx builds only the host arch
+    # (x86_64) and gradle silently packages stale arm64 .so files left over
+    # from previous successful builds — physical devices then run obsolete
+    # native code.
+    targets="${ANDROID_TARGETS:-aarch64-linux-android x86_64-linux-android}"
+    for target in $targets; do
+        echo "==> Building Rust for $target..."
+        {{dx}} build --platform android --package pentest-mobile --target "$target"
+    done
+
+    # Re-inject AFTER dx (which regenerates settings.gradle and build.gradle.kts).
     just _inject-android-lib target/dx/pentest-mobile/debug/android/app
-    cd target/dx/pentest-mobile/debug/android/app && ./gradlew assembleDebug
+
+    # `clean` is required: gradle's incremental task cache doesn't notice when
+    # `_inject-android-lib` adds the kotlin module (settings.gradle changes
+    # don't invalidate downstream task fingerprints), so without clean it can
+    # silently package a stale APK that omits ConnectorBridge.
+    pushd target/dx/pentest-mobile/debug/android/app > /dev/null
+    ./gradlew clean assembleDebug
+    popd > /dev/null
+
+    just _verify-android-apk target/dx/pentest-mobile/debug/android/app/app/build/outputs/apk/debug/app-debug.apk
 
 # Build mobile app for Android (release)
+#
+# By default builds both arm64 (physical devices) and x86_64 (emulators).
+# Override with: ANDROID_TARGETS="aarch64-linux-android" just build-android-release
 build-android-release:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -266,9 +344,22 @@ build-android-release:
     # Unset global CC/CXX that would override the target-specific ones
     unset CC CXX
 
-    {{dx}} build --platform android --package pentest-mobile --release
+    # Build each Rust target. See build-android comment for why this loop matters.
+    targets="${ANDROID_TARGETS:-aarch64-linux-android x86_64-linux-android}"
+    for target in $targets; do
+        echo "==> Building Rust for $target (release)..."
+        {{dx}} build --platform android --package pentest-mobile --release --target "$target"
+    done
+
+    # Re-inject AFTER dx (which regenerates settings.gradle and build.gradle.kts).
     just _inject-android-lib target/dx/pentest-mobile/release/android/app
-    cd target/dx/pentest-mobile/release/android/app && ./gradlew assembleRelease
+
+    # See build-android comment for why `clean` is required.
+    pushd target/dx/pentest-mobile/release/android/app > /dev/null
+    ./gradlew clean assembleRelease
+    popd > /dev/null
+
+    just _verify-android-apk target/dx/pentest-mobile/release/android/app/app/build/outputs/apk/release/app-release-unsigned.apk
 
 # Build, install, and launch Android app on connected device/emulator
 run-android:


### PR DESCRIPTION
Closes #127.

## Summary

Three latent bugs in the \`just build-android\` recipe combined to silently install broken APKs during PR #126 testing. Each bug masked the next, costing several hours to diagnose. This PR fixes all three and adds a sanity-check step that catches the regression in seconds rather than after a 5-minute install + manual test cycle.

## Bugs fixed

### 1. \`dx build\` was missing \`--target\`

Without \`--target\`, dx only builds for the host architecture (x86_64 on a Linux dev box). Gradle then packaged whatever stale arm64 \`libdioxusmain.so\` happened to be on disk from a prior successful arm64 build. During PR #126 testing this turned out to be a 12-day-old binary, so new Rust code never reached physical devices.

**Fix:** loop over \`\${ANDROID_TARGETS:-aarch64-linux-android x86_64-linux-android}\` and call \`dx build --target $T\` for each. Override via env var when needed:

\`\`\`bash
ANDROID_TARGETS=\"aarch64-linux-android\" just build-android
\`\`\`

### 2. \`_inject-android-lib\` modifications were wiped by \`dx build\`

\`dx build\` regenerates \`settings.gradle\` and \`app/build.gradle.kts\` on every run, wiping the \`include ':android-lib'\` and dependency lines added by \`_inject-android-lib\`. Without the kotlin module, the APK was missing \`com.strike48.pentest_connector.ConnectorBridge\`, and the app crashed at runtime on the first JNI call:

\`\`\`
java.lang.ClassNotFoundException: Didn't find class \"com.strike48.pentest_connector.ConnectorBridge\"
  at FetchTokenFallback → setOAuthCallbackPort
\`\`\`

**Fix:** the recipe already runs injection AFTER \`dx build\`. The bug was that injection failures were silent. The recipe now grep-verifies the inserted lines after writing them and exits with a clear error if either file is missing the marker.

### 3. Gradle's incremental cache silently served stale APKs

Even with injection in place, gradle's task cache doesn't notice that \`settings.gradle\` gained a new \`include\` directive. \`gradlew assembleDebug\` reported \"BUILD SUCCESSFUL in 6s\" while still packaging an APK without the kotlin classes. This is what produced the verifier failure during local testing of this PR.

**Fix:** use \`gradlew clean assembleDebug\` (and \`assembleRelease\`). Adds ~15s to the build cycle (~50s total) but eliminates an entire class of silent regressions.

## New: \`_verify-android-apk\` recipe

Scans every \`classes*.dex\` in the produced APK for \`ConnectorBridge\` and exits non-zero if missing. Runs at the end of \`build-android\` and \`build-android-release\`. Catches the bug class above and any future bug that produces an APK without the kotlin bridge.

## Files changed

\`justfile\` only — 99 insertions, 8 deletions across:

- \`build-android\`: multi-target loop, \`gradlew clean\`, post-build verification
- \`build-android-release\`: same
- \`_inject-android-lib\`: assertion that injection actually took effect
- \`_verify-android-apk\`: new recipe, called from \`build-android\` and \`build-android-release\`

## Test plan

- [x] Test \`_inject-android-lib\` happy path — silent success when files already injected
- [x] Test \`_verify-android-apk\` happy path — \"OK: ConnectorBridge present in APK\"
- [x] Test \`_verify-android-apk\` failure path — stripped a dex from a copy of the APK, verifier exited non-zero with clear error
- [x] Test \`build-android\` end-to-end — BUILD SUCCESSFUL in 52s, both arches built, ConnectorBridge present
- [x] Confirmed previous breakage reproduces without the fix (the verifier caught it during this PR's own development cycle)

## Out of scope

- \`run-android\` recipe: still works, will use the now-correct \`build-android\`. No changes needed.
- \`bundle-android\` recipe: not modified — different scope (release bundle generation), and the same bugs likely apply but no urgent need today.