### PR TITLE
fix(ci): pin Kali apt sources to kali.download CDN

### DIFF
--- a/Dockerfile.scratch
+++ b/Dockerfile.scratch
@@ -91,8 +91,14 @@ RUN RUST_TARGET=$(cat /tmp/rust-target) && \
 # ----------------------------------------------------------
 FROM kalilinux/kali-rolling AS runtime
 
-# Install common pentest tools + runtime deps
-RUN apt-get update && \
+# Pin sources.list to the kali.download CDN before updating. The default Kali
+# mirror rotation occasionally serves an apt index ahead of one or more backing
+# mirrors, which produces 404s during the install step for transitive deps
+# (e.g. libexpat1, libatomic1, libgomp1, netcat-openbsd). kali.download is the
+# official CDN and has been the most consistent source in CI.
+RUN printf 'deb http://kali.download/kali kali-rolling main contrib non-free non-free-firmware\n' \
+        > /etc/apt/sources.list \
+    && apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
         openssl \


### PR DESCRIPTION
## Summary

- Unblocks the `Multi-Arch Docker` workflow, which has been failing on every PR and every push to `main` since `2026-05-26 15:19` (last green: `2026-05-24 02:20`).
- Pins the Kali apt sources.list to `http://kali.download/kali` before `apt-get update` in `Dockerfile.scratch`'s runtime stage.

## Root cause

The runtime stage builds `FROM kalilinux/kali-rolling` and installs ~30 pentest tools via apt. The default Kali mirror rotation occasionally lands `apt-get` on a backing mirror that hasn't synced the current apt index, producing 404s for the exact `.deb` filenames the index points to:

```
E: Failed to fetch http://http.kali.org/kali/pool/main/e/expat/libexpat1_2.8.0-1_amd64.deb       404
E: Failed to fetch http://http.kali.org/kali/pool/main/g/gcc-16/libatomic1_16-20260322-1_amd64.deb  404
E: Failed to fetch http://http.kali.org/kali/pool/main/g/gcc-16/libgomp1_16-20260322-1_amd64.deb    404
E: Failed to fetch http://http.kali.org/kali/pool/main/n/netcat-openbsd/netcat-openbsd_1.234-2_amd64.deb 404
```

In the same logs `kali.download` continued to serve. Pinning to that single CDN endpoint avoids the rotation entirely.

## Test plan

- [ ] CI: `Build amd64` and `Build arm64` should turn green on this PR.
- [ ] Confirm the resulting image still installs the same package set (no new mirror-specific availability issues for `metasploit-framework`, `wpscan`, `nuclei`, etc.).

## Follow-ups (not in this PR)

- If `kali.download` itself drifts in the future, consider pinning the base image to a digest (`kalilinux/kali-rolling@sha256:<digest>`) and bumping it deliberately, accepting the trade-off of losing automatic Kali security updates between bumps.