### PR TITLE
feat: detect agent ERROR status and surface token-limit notice

### DIFF
--- a/crates/core/src/matrix/auth.rs
+++ b/crates/core/src/matrix/auth.rs
@@ -283,6 +283,53 @@ pub fn cached_browser_token() -> Option<String> {
 #[cfg(not(feature = "browser-auth"))]
 pub fn clear_browser_token_cache() {}
 
+/// Open `url` in the host's system browser.
+///
+/// Reuses the same opener chain as the OAuth login flow (custom opener for
+/// Android Intent → `open::that()` fallback), so the URL launches in the user's
+/// real default browser rather than in a wry sub-WebView. The wry path is what
+/// makes Vite-style SPAs render blank with "origin: null" CORS failures, so any
+/// UI link that should land in the system browser must route through here.
+///
+/// Returns the underlying error as a String if every opener path fails.
+#[cfg(feature = "browser-auth")]
+pub fn open_url_in_browser(url: &str) -> Result<(), String> {
+    tracing::info!("[BROWSER_OPEN] Opening URL via system browser: {}", url);
+
+    if let Ok(opener_lock) = BROWSER_OPENER.lock() {
+        if let Some(ref opener) = *opener_lock {
+            match opener(url) {
+                Ok(()) => {
+                    tracing::info!("[BROWSER_OPEN] Opened via custom opener");
+                    return Ok(());
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "[BROWSER_OPEN] Custom opener failed: {} (falling back to open::that)",
+                        e
+                    );
+                }
+            }
+        }
+    }
+
+    match open::that(url) {
+        Ok(()) => {
+            tracing::info!("[BROWSER_OPEN] Opened via open::that()");
+            Ok(())
+        }
+        Err(e) => {
+            tracing::error!("[BROWSER_OPEN] open::that() failed: {}", e);
+            Err(e.to_string())
+        }
+    }
+}
+
+#[cfg(not(feature = "browser-auth"))]
+pub fn open_url_in_browser(_url: &str) -> Result<(), String> {
+    Err("browser-auth feature not enabled".to_string())
+}
+
 /// Fetch an access token by opening the system browser for login.
 ///
 /// Flow:

--- a/crates/core/src/matrix/client.rs
+++ b/crates/core/src/matrix/client.rs
@@ -501,6 +501,52 @@ const DELETE_CONVERSATION_QUERY: &str = r#"
     }
 "#;
 
+const GET_TOKEN_USAGE_STATS_QUERY: &str = r#"
+    query GetTokenUsageStats {
+        tokenUsageStats {
+            isLimited
+            daily { usage limit status }
+            weekly { usage limit status }
+            monthly { usage limit status }
+        }
+    }
+"#;
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GetTokenUsageStatsData {
+    token_usage_stats: Option<TokenUsageStatsNode>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TokenUsageStatsNode {
+    is_limited: bool,
+    daily: TokenUsagePeriodNode,
+    weekly: TokenUsagePeriodNode,
+    monthly: TokenUsagePeriodNode,
+}
+
+#[derive(Deserialize)]
+struct TokenUsagePeriodNode {
+    usage: i64,
+    limit: Option<i64>,
+    status: String,
+}
+
+impl TokenUsagePeriodNode {
+    fn into_period(self) -> TokenUsagePeriod {
+        TokenUsagePeriod {
+            usage: self.usage,
+            limit: self.limit,
+            status: self
+                .status
+                .parse::<TokenUsageStatus>()
+                .unwrap_or(TokenUsageStatus::Unknown),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Trait implementation
 // ---------------------------------------------------------------------------
@@ -724,6 +770,21 @@ impl ChatClient for MatrixChatClient {
             .await?;
 
         Ok(())
+    }
+
+    async fn get_token_usage_stats(&self) -> crate::error::Result<Option<TokenUsageStats>> {
+        self.require_auth()?;
+
+        let data: GetTokenUsageStatsData = self
+            .execute_gql(GET_TOKEN_USAGE_STATS_QUERY, serde_json::json!({}))
+            .await?;
+
+        Ok(data.token_usage_stats.map(|node| TokenUsageStats {
+            is_limited: node.is_limited,
+            daily: node.daily.into_period(),
+            weekly: node.weekly.into_period(),
+            monthly: node.monthly.into_period(),
+        }))
     }
 }
 

--- a/crates/core/src/matrix/types.rs
+++ b/crates/core/src/matrix/types.rs
@@ -157,6 +157,75 @@ pub struct ConversationInfo {
 }
 
 // ---------------------------------------------------------------------------
+// Token usage tracking
+// ---------------------------------------------------------------------------
+
+/// Per-period rate limit status returned by the Matrix `tokenUsageStats` query.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenUsageStatus {
+    /// Token usage tracking is disabled for this user/tenant.
+    Disabled,
+    /// User or tenant is exempt from rate limiting.
+    Exempt,
+    /// Usage is within normal range.
+    Ok,
+    /// Usage has crossed the warning threshold but not the hard limit.
+    Warning,
+    /// Usage has reached or exceeded the hard limit — requests will be rejected.
+    Exceeded,
+    /// Any value the server returns that we don't recognize.
+    Unknown,
+}
+
+impl std::str::FromStr for TokenUsageStatus {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s.to_uppercase().as_str() {
+            "DISABLED" => Self::Disabled,
+            "EXEMPT" => Self::Exempt,
+            "OK" => Self::Ok,
+            "WARNING" => Self::Warning,
+            "EXCEEDED" => Self::Exceeded,
+            _ => Self::Unknown,
+        })
+    }
+}
+
+/// Usage + limit for a single time period (daily / weekly / monthly).
+#[derive(Debug, Clone, Copy)]
+pub struct TokenUsagePeriod {
+    pub usage: i64,
+    pub limit: Option<i64>,
+    pub status: TokenUsageStatus,
+}
+
+/// Snapshot of the current user's token usage across the three tracked periods.
+#[derive(Debug, Clone, Copy)]
+pub struct TokenUsageStats {
+    pub daily: TokenUsagePeriod,
+    pub weekly: TokenUsagePeriod,
+    pub monthly: TokenUsagePeriod,
+    pub is_limited: bool,
+}
+
+impl TokenUsageStats {
+    /// Return the first period (daily → weekly → monthly) whose status is
+    /// `Exceeded`, if any. This is the period the operator most likely hit.
+    pub fn first_exceeded(&self) -> Option<(&'static str, TokenUsagePeriod)> {
+        if self.daily.status == TokenUsageStatus::Exceeded {
+            Some(("daily", self.daily))
+        } else if self.weekly.status == TokenUsageStatus::Exceeded {
+            Some(("weekly", self.weekly))
+        } else if self.monthly.status == TokenUsageStatus::Exceeded {
+            Some(("monthly", self.monthly))
+        } else {
+            None
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // CreateAgentInput
 // ---------------------------------------------------------------------------
 
@@ -256,4 +325,11 @@ pub trait ChatClient: Send + Sync {
         agent_id: Option<&str>,
     ) -> crate::error::Result<Vec<ConversationInfo>>;
     async fn delete_conversation(&self, conversation_id: &str) -> crate::error::Result<()>;
+
+    /// Fetch the current user's per-period token usage and limits.
+    ///
+    /// Returns `Ok(None)` when the server does not expose `tokenUsageStats`
+    /// (e.g. older Matrix versions, or when feature-flagged off). The caller
+    /// should treat a missing stat as "no information" rather than an error.
+    async fn get_token_usage_stats(&self) -> crate::error::Result<Option<TokenUsageStats>>;
 }

--- a/crates/ui/src/components/chat_panel/css/style.css
+++ b/crates/ui/src/components/chat_panel/css/style.css
@@ -280,6 +280,81 @@
     border-bottom: 1px solid var(--border);
 }
 
+/* Inline notice — sits above the chat input, quieter than .chat-error. */
+.chat-notice {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding: 0.5rem 0.625rem;
+    margin: 0 0.75rem 0.5rem 0.75rem;
+    border-radius: 0.375rem;
+    border: 1px solid var(--border);
+    background: var(--muted);
+    font-size: 0.75rem;
+    line-height: 1.35;
+}
+
+.chat-notice--limit {
+    border-color: color-mix(in srgb, #d97706 40%, var(--border));
+    background: color-mix(in srgb, #d97706 8%, var(--muted));
+}
+
+.chat-notice--error {
+    border-color: color-mix(in srgb, var(--destructive) 35%, var(--border));
+    background: color-mix(in srgb, var(--destructive) 6%, var(--muted));
+}
+
+.chat-notice__icon {
+    flex-shrink: 0;
+    font-size: 0.875rem;
+    line-height: 1.2;
+    margin-top: 0.05rem;
+}
+
+.chat-notice__body {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    /* Without flex-start the inline-flex <Button> would stretch to the full
+       body width (default align-items=stretch on a column flex container) and
+       then center its label, making "Open Studio" appear floating mid-line
+       instead of left-aligned under the detail text. */
+    align-items: flex-start;
+    gap: 0.15rem;
+}
+
+.chat-notice__title {
+    font-weight: 600;
+    color: var(--foreground);
+}
+
+.chat-notice__detail {
+    color: var(--muted-foreground);
+}
+
+/* The "Open Studio" affordance uses the shared <Button variant=Link> component
+   defined in components/button.{rs,css} — no custom .chat-notice__link styling
+   here. Earlier hand-rolled link buttons leaked WebKit's native hover state
+   into a "blob" over the text and triggered text-selection highlights, both of
+   which the Link variant already handles correctly. */
+
+.chat-notice__close {
+    flex-shrink: 0;
+    background: transparent;
+    border: none;
+    color: var(--muted-foreground);
+    cursor: pointer;
+    font-size: 1rem;
+    line-height: 1;
+    padding: 0 0.15rem;
+    margin-left: 0.25rem;
+}
+
+.chat-notice__close:hover {
+    color: var(--foreground);
+}
+
 .chat-messages-wrapper {
     flex: 1;
     display: flex;

--- a/crates/ui/src/components/chat_panel/mod.rs
+++ b/crates/ui/src/components/chat_panel/mod.rs
@@ -21,13 +21,14 @@ use pentest_core::terminal::TerminalLine;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use super::button::{Button, ButtonSize, ButtonVariant};
 use agent_selector::ChatHeader;
 pub use agent_selector::{ChatHeaderActions, ChatHeaderCtx};
 use constants::*;
 use history::HistoryDropdown;
 use input::ChatInput;
 use messages::MessageList;
-use polling::poll_and_update;
+use polling::{poll_and_update, ChatNoticeKind};
 pub use render::format_relative_time;
 use render::{CHART_PROCESSOR_JS, UTILS_JS};
 
@@ -77,6 +78,10 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
     let mut agent_thinking = use_signal(|| false);
     let mut agent_status_text = use_signal(String::new);
     let mut error_msg = use_signal(|| None::<String>);
+    // Subtle inline notice driven by poll_and_update — distinct from `error_msg`
+    // (which renders the loud red banner for call-failures). Used for things
+    // like "Token limit reached" where we want a softer, link-bearing message.
+    let mut chat_notice = use_signal(|| None::<polling::ChatNotice>);
 
     // Per-agent conversation tracking
     let mut agent_conversations: Signal<HashMap<String, String>> = use_signal(HashMap::new);
@@ -444,6 +449,7 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
 
             let agent = agents.peek().iter().find(|a| a.id == val).cloned();
             error_msg.set(None);
+            chat_notice.set(None);
             show_history.set(false);
             agent_thinking.set(false);
             agent_status_text.set(String::new());
@@ -469,6 +475,7 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
                                         agent_thinking,
                                         agent_status_text,
                                         error_msg,
+                                        chat_notice,
                                     )
                                     .await;
                                 }
@@ -524,6 +531,7 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
             let client = make_client();
             is_sending.set(true);
             error_msg.set(None);
+            chat_notice.set(None);
 
             spawn(async move {
                 let existing_id: Option<String> = conversation_id.peek().clone();
@@ -580,6 +588,7 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
                             agent_thinking,
                             agent_status_text,
                             error_msg,
+                            chat_notice,
                         )
                         .await;
                     }
@@ -637,6 +646,7 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
                                     agent_thinking,
                                     agent_status_text,
                                     error_msg,
+                                    chat_notice,
                                 )
                                 .await;
                             }
@@ -669,6 +679,7 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
             }
             show_history.set(false);
             error_msg.set(None);
+            chat_notice.set(None);
 
             if let Some(agent) = selected_agent.peek().as_ref() {
                 let agent_id = agent.id.clone();
@@ -783,6 +794,7 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
             messages.set(Vec::new());
             show_history.set(false);
             error_msg.set(None);
+            chat_notice.set(None);
             agent_thinking.set(false);
             agent_status_text.set(String::new());
 
@@ -830,6 +842,7 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
                             agent_thinking,
                             agent_status_text,
                             error_msg,
+                            chat_notice,
                         )
                         .await;
                     }
@@ -871,6 +884,7 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
                                 agent_thinking,
                                 agent_status_text,
                                 error_msg,
+                                chat_notice,
                             )
                             .await;
                         }
@@ -1068,7 +1082,7 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
                 }
             }
 
-            // Error banner
+            // Error banner — loud red strip for caller-side failures (send/load).
             if let Some(err) = error_msg.read().as_ref() {
                 div { class: "chat-error", "{err}" }
             }
@@ -1084,6 +1098,59 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
                 on_send: send_message.clone(),
                 conversation_list: conversation_list,
                 on_select_conversation: on_select_conversation,
+            }
+
+            // Inline notice — quieter than `chat-error`, sits above the input.
+            // Surfaced by polling when the agent backend returned an error
+            // (token limit, rate limit, generic upstream failure).
+            if let Some(notice) = chat_notice.read().as_ref() {
+                {
+                    let kind_class = match notice.kind {
+                        ChatNoticeKind::TokenLimit => "chat-notice chat-notice--limit",
+                        ChatNoticeKind::UpstreamError => "chat-notice chat-notice--error",
+                    };
+                    let icon = match notice.kind {
+                        ChatNoticeKind::TokenLimit => "⏱",
+                        ChatNoticeKind::UpstreamError => "⚠",
+                    };
+                    let title = notice.title.clone();
+                    let detail = notice.detail.clone();
+                    let studio_url = notice.studio_url.clone();
+                    rsx! {
+                        div { class: "{kind_class}",
+                            span { class: "chat-notice__icon", "{icon}" }
+                            div { class: "chat-notice__body",
+                                div { class: "chat-notice__title", "{title}" }
+                                div { class: "chat-notice__detail", "{detail}" }
+                                if let Some(url) = studio_url {
+                                    // Use the existing Link-variant Button rather than a raw
+                                    // <button> with custom CSS — it already has properly-tested
+                                    // hover/focus/active states that won't bleed WebKit's
+                                    // native button chrome (the "blob on hover" bug). A real
+                                    // <button> element is required (vs. <a href>) so that the
+                                    // browser can't follow a link in the connector iframe
+                                    // while open::that() is also opening the system browser.
+                                    Button {
+                                        variant: ButtonVariant::Link,
+                                        size: ButtonSize::Small,
+                                        on_click: move |_| {
+                                            if let Err(e) = pentest_core::matrix::open_url_in_browser(&url) {
+                                                tracing::warn!("Failed to open Studio URL: {}", e);
+                                            }
+                                        },
+                                        "Open Studio →"
+                                    }
+                                }
+                            }
+                            button {
+                                class: "chat-notice__close",
+                                aria_label: "Dismiss",
+                                onclick: move |_| chat_notice.set(None),
+                                "×"
+                            }
+                        }
+                    }
+                }
             }
 
             // Input area

--- a/crates/ui/src/components/chat_panel/polling.rs
+++ b/crates/ui/src/components/chat_panel/polling.rs
@@ -1,12 +1,84 @@
 //! Conversation polling helper with live status updates.
 
 use dioxus::prelude::*;
-use pentest_core::matrix::{AgentStatus, ChatClient, ChatMessage, MatrixChatClient};
+use pentest_core::matrix::{
+    AgentStatus, ChatClient, ChatMessage, MatrixChatClient, TokenUsageStatus,
+};
 use std::sync::Arc;
 
 use super::constants::{MAX_POLL_ATTEMPTS, POLL_INTERVAL_MS};
 
+/// Severity for an inline chat notice. Drives styling, not behaviour.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ChatNoticeKind {
+    /// The server hit a hard limit (token/rate). User action required.
+    TokenLimit,
+    /// Some other upstream failure — usually transient.
+    UpstreamError,
+}
+
+/// A small, less-shouty status message rendered inline near the chat input.
+///
+/// Polling produces these when it observes `AgentStatus::Error`. The actual
+/// error reason ships on the `conversationEvents` GraphQL subscription
+/// (`AgentStatusEvent.error`), which polling never sees — so we cross-reference
+/// `tokenUsageStats` to tell "limit exceeded" from "generic upstream blip".
+#[derive(Debug, Clone, PartialEq)]
+pub struct ChatNotice {
+    pub kind: ChatNoticeKind,
+    pub title: String,
+    pub detail: String,
+    /// Optional URL to the Studio session (e.g. for checking token usage).
+    pub studio_url: Option<String>,
+}
+
+/// Build a Studio web-app URL from the Matrix API base.
+///
+/// `MATRIX_API_URL` is the Matrix GraphQL host (e.g. `https://studio.example:443`);
+/// the Studio SPA is served at `/studio/` on the same host. We:
+///
+/// * Strip the default port (`:443` for https, `:80` for http) — keeps the URL
+///   shape identical to what a hand-typed Studio URL looks like, which avoids
+///   bizarre browser security-context mismatches.
+/// * Append `#/` so the hash-routed SPA bootstraps at the root route instead
+///   of landing on a bare `/studio/` that some Vite builds will white-screen on.
+fn studio_url_from_api(api_url: &str) -> Option<String> {
+    let trimmed = api_url.trim_end_matches('/');
+    if trimmed.is_empty() {
+        return None;
+    }
+    let normalized = strip_default_port(trimmed);
+    Some(format!("{}/studio/#/", normalized))
+}
+
+/// Remove `:443` after an `https://` host, or `:80` after an `http://` host.
+/// Leaves any other port (or absent port) untouched.
+fn strip_default_port(url: &str) -> String {
+    if let Some(rest) = url.strip_prefix("https://") {
+        if let Some(stripped_host) = strip_port_suffix(rest, ":443") {
+            return format!("https://{}", stripped_host);
+        }
+    } else if let Some(rest) = url.strip_prefix("http://") {
+        if let Some(stripped_host) = strip_port_suffix(rest, ":80") {
+            return format!("http://{}", stripped_host);
+        }
+    }
+    url.to_string()
+}
+
+/// Strip `port_suffix` from the host portion of `rest` (everything up to the
+/// first `/`). Returns `None` if the port isn't present at that position.
+fn strip_port_suffix(rest: &str, port_suffix: &str) -> Option<String> {
+    let (host_part, path_part) = match rest.find('/') {
+        Some(i) => (&rest[..i], &rest[i..]),
+        None => (rest, ""),
+    };
+    let stripped_host = host_part.strip_suffix(port_suffix)?;
+    Some(format!("{}{}", stripped_host, path_part))
+}
+
 /// Poll a conversation until the agent finishes, updating signals along the way.
+#[allow(clippy::too_many_arguments)]
 pub async fn poll_and_update(
     client: Arc<MatrixChatClient>,
     conv_id: String,
@@ -15,6 +87,7 @@ pub async fn poll_and_update(
     mut agent_thinking: Signal<bool>,
     mut agent_status_text: Signal<String>,
     mut error_msg: Signal<Option<String>>,
+    mut chat_notice: Signal<Option<ChatNotice>>,
 ) {
     /// Check if the UI is currently showing this conversation.
     fn is_active(active: &Signal<Option<String>>, conv_id: &str) -> bool {
@@ -25,6 +98,13 @@ pub async fn poll_and_update(
             .unwrap_or(false)
     }
 
+    // Sticky flag: once we observe AgentStatus::Error, treat the conversation as
+    // failed even if the backend transitions back to IDLE without producing an
+    // agent message. The error reason itself only ships on the subscription
+    // (`AgentStatusEvent.error`), which polling never sees — so we surface a
+    // generic message that points the operator at the most likely causes.
+    let mut saw_error = false;
+
     for _attempt in 0..MAX_POLL_ATTEMPTS {
         match client.get_conversation(&conv_id).await {
             Ok(state) => {
@@ -33,14 +113,16 @@ pub async fn poll_and_update(
                     .messages
                     .iter()
                     .any(|m| m.sender_type != "USER" && !m.text.is_empty());
+                saw_error |= matches!(state.agent_status, AgentStatus::Error);
                 if _attempt < 5 || _attempt % 10 == 0 {
                     tracing::info!(
-                        "[ChatPoll] #{}: status={} msgs={} done={} has_agent_msg={}",
+                        "[ChatPoll] #{}: status={} msgs={} done={} has_agent_msg={} saw_error={}",
                         _attempt,
                         state.agent_status,
                         state.messages.len(),
                         done,
                         has_agent_msg,
+                        saw_error,
                     );
                 }
 
@@ -60,14 +142,27 @@ pub async fn poll_and_update(
                         messages.set(state.messages.clone());
                     }
 
+                    // The agent backend hit an error. Cross-reference the
+                    // tokenUsageStats query (same data Studio uses to render its
+                    // sidebar usage widget) so we can tell "limit exceeded" from
+                    // a generic upstream blip and surface a specific notice with
+                    // a link the operator can click to verify in Studio.
+                    if saw_error {
+                        let notice = build_error_notice(&client).await;
+                        chat_notice.set(Some(notice));
+                        agent_thinking.set(false);
+                        agent_status_text.set(String::new());
+                        return;
+                    }
+
                     if done && has_agent_msg {
                         messages.set(state.messages);
                         agent_thinking.set(false);
                         agent_status_text.set(String::new());
                         return;
                     }
-                } else if done && has_agent_msg {
-                    // Conversation finished while user was viewing another one.
+                } else if saw_error || (done && has_agent_msg) {
+                    // Conversation finished (success or error) while user was viewing another one.
                     return;
                 }
             }
@@ -92,5 +187,148 @@ pub async fn poll_and_update(
         }
         agent_thinking.set(false);
         agent_status_text.set(String::new());
+    }
+}
+
+/// Build a `ChatNotice` describing why the conversation transitioned to
+/// `AgentStatus::Error`. Queries `tokenUsageStats` to distinguish a real
+/// limit-hit from a generic upstream blip; falls back to a generic notice
+/// if that query fails or the server doesn't expose usage stats.
+async fn build_error_notice(client: &MatrixChatClient) -> ChatNotice {
+    let studio_url = studio_url_from_api(client.api_url());
+
+    match client.get_token_usage_stats().await {
+        Ok(Some(stats)) => match stats.first_exceeded() {
+            Some((period, p)) => {
+                let detail = match p.limit {
+                    Some(limit) => format!(
+                        "{} token limit reached ({} / {}). Wait for the window to reset, or \
+                         contact your tenant admin to raise the limit.",
+                        capitalize_period(period),
+                        format_with_commas(p.usage),
+                        format_with_commas(limit),
+                    ),
+                    None => format!(
+                        "{} token limit reached ({} tokens used). Wait for the window to \
+                         reset, or contact your tenant admin to raise the limit.",
+                        capitalize_period(period),
+                        format_with_commas(p.usage),
+                    ),
+                };
+                ChatNotice {
+                    kind: ChatNoticeKind::TokenLimit,
+                    title: "Token limit reached".to_string(),
+                    detail,
+                    studio_url,
+                }
+            }
+            None => generic_upstream_notice(studio_url, stats.daily.status),
+        },
+        Ok(None) => generic_upstream_notice(studio_url, TokenUsageStatus::Unknown),
+        Err(e) => {
+            tracing::warn!("[ChatPoll] tokenUsageStats query failed after ERROR: {}", e);
+            generic_upstream_notice(studio_url, TokenUsageStatus::Unknown)
+        }
+    }
+}
+
+fn generic_upstream_notice(
+    studio_url: Option<String>,
+    daily_status: TokenUsageStatus,
+) -> ChatNotice {
+    // If the daily period is in WARNING, mention it — the operator may be
+    // about to hit the limit and benefits from the heads-up.
+    let detail = if matches!(daily_status, TokenUsageStatus::Warning) {
+        "The agent backend returned an error and no reply was produced. You're close to your \
+         daily token limit — check Studio for current usage."
+            .to_string()
+    } else {
+        "The agent backend returned an error and no reply was produced. This is usually \
+         transient — try again, or start a new chat."
+            .to_string()
+    };
+    ChatNotice {
+        kind: ChatNoticeKind::UpstreamError,
+        title: "Agent error".to_string(),
+        detail,
+        studio_url,
+    }
+}
+
+fn capitalize_period(p: &str) -> &'static str {
+    match p {
+        "daily" => "Daily",
+        "weekly" => "Weekly",
+        "monthly" => "Monthly",
+        _ => "Period",
+    }
+}
+
+fn format_with_commas(n: i64) -> String {
+    let s = n.abs().to_string();
+    let bytes = s.as_bytes();
+    let mut out = String::with_capacity(s.len() + s.len() / 3);
+    for (i, b) in bytes.iter().enumerate() {
+        if i > 0 && (bytes.len() - i).is_multiple_of(3) {
+            out.push(',');
+        }
+        out.push(*b as char);
+    }
+    if n < 0 {
+        format!("-{}", out)
+    } else {
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_with_commas_handles_small_and_large() {
+        assert_eq!(format_with_commas(0), "0");
+        assert_eq!(format_with_commas(42), "42");
+        assert_eq!(format_with_commas(1_234), "1,234");
+        assert_eq!(format_with_commas(1_080_000), "1,080,000");
+        assert_eq!(format_with_commas(-1_234), "-1,234");
+    }
+
+    #[test]
+    fn studio_url_strips_default_ports_and_appends_hash_route() {
+        assert_eq!(
+            studio_url_from_api("https://example.test:443/"),
+            Some("https://example.test/studio/#/".to_string())
+        );
+        assert_eq!(
+            studio_url_from_api("https://example.test:443"),
+            Some("https://example.test/studio/#/".to_string())
+        );
+        assert_eq!(
+            studio_url_from_api("http://example.test:80"),
+            Some("http://example.test/studio/#/".to_string())
+        );
+        assert_eq!(studio_url_from_api(""), None);
+    }
+
+    #[test]
+    fn studio_url_preserves_non_default_ports() {
+        assert_eq!(
+            studio_url_from_api("https://example.test:8443"),
+            Some("https://example.test:8443/studio/#/".to_string())
+        );
+        assert_eq!(
+            studio_url_from_api("http://localhost:4000"),
+            Some("http://localhost:4000/studio/#/".to_string())
+        );
+    }
+
+    #[test]
+    fn strip_port_suffix_only_matches_at_host_boundary() {
+        // ":443" appearing in a path must not be stripped
+        assert_eq!(
+            strip_default_port("https://example.test/foo:443/bar"),
+            "https://example.test/foo:443/bar"
+        );
     }
 }


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/27fa56d3-60d9-45c4-bfc2-8eaf830b1188



- Chat polling now treats `AgentStatus::Error` as a terminal state with a sticky `saw_error` flag, so a transient ERROR → IDLE flip can't slip past the panel and leave the user stuck on "Waiting for response…".
- When ERROR is observed, query `tokenUsageStats` (the same query Studio's sidebar uses) and render an inline notice above the chat input that distinguishes daily/weekly/monthly limit hits — with the actual usage/limit numbers — from generic upstream errors.
- The notice carries an "Open Studio" link that goes through `open::that()` (reusing the existing OAuth opener chain) so the system browser opens Studio with its real origin, instead of the wry sub-WebView path that loads the Vite SPA with `origin=null` and trips SRI/CORS.

## Why

Before this change, when a user hit their tenant token limit the connector would receive a terminal ERROR conversation status but the chat panel would keep polling forever, showing "Waiting for response…" with no signal that anything went wrong. The error reason itself only ships on the `conversationEvents` GraphQL subscription as `AgentStatusEvent.error`, which Pick doesn't subscribe to — so the polled fallback combines `Conversation.agentStatus = ERROR` with a `tokenUsageStats` lookup to derive a specific reason without needing a subscription.

Relates to https://github.com/Strike48/forge/issues/150.

## What changed

- `crates/core/src/matrix/auth.rs` — new `open_url_in_browser(url)` helper exposing the existing custom-opener → `open::that()` fallback chain (gated by `browser-auth`, with a no-op for builds without it).
- `crates/core/src/matrix/{types.rs,client.rs}` — `TokenUsageStats` / `TokenUsagePeriod` / `TokenUsageStatus` types and a `ChatClient::get_token_usage_stats()` method backed by the `tokenUsageStats` GraphQL query.
- `crates/ui/src/components/chat_panel/polling.rs` — sticky `saw_error` detection, `ChatNotice` type with `TokenLimit` vs `UpstreamError` kinds, and `build_error_notice` that cross-references token usage to pick the right message. Studio URL is built by stripping the default `:443`/`:80` and appending `#/` so the hash-routed SPA bootstraps. New unit tests cover the helpers.
- `crates/ui/src/components/chat_panel/mod.rs` — new `chat_notice` signal threaded through every `poll_and_update` call site, cleared on agent switch / send / new conversation / report seed. Notice renders as a small inline pill above the input using the shared `Button` component with `ButtonVariant::Link` so hover/focus/active states match the rest of the app.
- `crates/ui/src/components/chat_panel/css/style.css` — `.chat-notice` container + amber/red modifiers, icon, body, title, detail, dismiss button. No changes to the shared `button.css` — other buttons are unaffected.

## Known limitation

The exact server-side error string (e.g. _"Rate limit exceeded: daily token limit (1080/500)"_) only ships on the `conversationEvents` subscription. Polling can detect that an error occurred and (via `tokenUsageStats`) infer whether it was a limit-hit vs something else, but the verbatim message isn't reachable through queries. A follow-up that adds subscription support would let the notice render the actual reason string; flagged but out of scope here.

## Test plan

- [x] `cargo check --all-targets` — passes locally.
- [x] `cargo clippy --all-targets -- -D warnings` — passes locally.
- [x] `cargo fmt --all -- --check` — passes locally.
- [x] `cargo test --lib --bins -p pentest-ui --features "liveview,shell-ws,connector" -p pentest-core` — 153 + 34 passing locally (2 new unit tests for `format_with_commas` + `studio_url_from_api`).
- [x] Manual: with a token-limited user, send a message via the pentest-connector. Verify the inline notice appears within ~1s of the ERROR status, shows the correct daily/weekly/monthly usage/limit numbers, and that clicking "Open Studio →" opens a new system-browser tab to `${MATRIX_API_URL}/studio/#/` (Studio loads, sidebar shows live token usage) **without** the connector iframe also navigating.
- [x] Manual: dismiss the notice via the × button; verify it clears and a follow-up send doesn't re-display the stale notice.