### PR TITLE
fix: scope connector identity per env and harden registration auth

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -203,6 +203,50 @@ impl ConnectorConfig {
         Ok(format!("{}{}", inferred, bare))
     }
 
+    /// Derive a stable, env-scoped instance id from the persistent `device_id`
+    /// and the target `host`.
+    ///
+    /// Saved credentials and connector approval are keyed by instance id. With a
+    /// single global instance id, one credential is reused for every env, so a
+    /// token minted for env A is rejected by env B's gateway. Folding a host slug
+    /// into the instance id gives each Strike48 instance its own credential +
+    /// approval. The mapping is deterministic — the same host always yields the
+    /// same id — so approval persists across restarts and env switches "just work".
+    pub fn env_scoped_instance_id(device_id: &str, host: &str) -> String {
+        let slug = Self::host_slug(host);
+        if slug.is_empty() {
+            device_id.to_string()
+        } else {
+            format!("{device_id}-{slug}")
+        }
+    }
+
+    /// Reduce a host URL to a short, stable identifier slug: scheme and port are
+    /// stripped and any run of non-alphanumeric characters collapses to a single
+    /// `-` (e.g. `wss://studio.example.com:443` -> `studio-example-com`).
+    fn host_slug(host: &str) -> String {
+        let after_scheme = host.rsplit("://").next().unwrap_or(host);
+        let authority = after_scheme.split('/').next().unwrap_or(after_scheme);
+        // Drop a trailing :port (last colon only, so IPv6 forms degrade gracefully).
+        let hostname = authority
+            .rsplit_once(':')
+            .map(|(h, _)| h)
+            .unwrap_or(authority);
+
+        let mut slug = String::with_capacity(hostname.len());
+        let mut prev_dash = false;
+        for c in hostname.chars() {
+            if c.is_ascii_alphanumeric() {
+                slug.push(c.to_ascii_lowercase());
+                prev_dash = false;
+            } else if !prev_dash {
+                slug.push('-');
+                prev_dash = true;
+            }
+        }
+        slug.trim_matches('-').to_string()
+    }
+
     /// Convert to the SDK's ConnectorConfig
     pub fn to_sdk_config(&self) -> strike48_connector::ConnectorConfig {
         let mut sdk_config = strike48_connector::ConnectorConfig {
@@ -447,10 +491,18 @@ pub fn load_connector_config(args: &[String]) -> ConfigLoadResult {
     // Preserve the original URL (including scheme) so that to_sdk_config()
     // can auto-detect transport type (WebSocket vs gRPC) and TLS from the scheme.
 
-    // Validate config before returning (SSRF protection, required fields, etc.)
-    if let Err(e) = config.validate() {
-        tracing::warn!("Config validation failed: {}", e);
-        return ConfigLoadResult::ValidationFailed(e);
+    // Validate config before returning (SSRF protection, required fields, etc.).
+    // Under StrikeHub the host is chosen by the trusted local launcher and may
+    // legitimately be a private-IP / self-hosted studio, so skip the SSRF host
+    // check in that mode — main() already intends to skip validation when launched
+    // by StrikeHub, but this earlier check would otherwise reject it first.
+    // Standalone mode keeps full validation.
+    let is_strikehub = std::env::var("STRIKEHUB_SOCKET").is_ok();
+    if !is_strikehub {
+        if let Err(e) = config.validate() {
+            tracing::warn!("Config validation failed: {}", e);
+            return ConfigLoadResult::ValidationFailed(e);
+        }
     }
 
     ConfigLoadResult::Ok(config)
@@ -533,5 +585,51 @@ mod tests {
     fn normalize_host_scheme_matching_is_case_insensitive() {
         let out = ConnectorConfig::normalize_host("WSS://Studio.Example.com:443").unwrap();
         assert_eq!(out, "WSS://Studio.Example.com:443");
+    }
+
+    #[test]
+    fn host_slug_strips_scheme_and_port() {
+        assert_eq!(
+            ConnectorConfig::host_slug("wss://studio.example.com:443"),
+            "studio-example-com"
+        );
+        assert_eq!(
+            ConnectorConfig::host_slug("connectors.example.org:443"),
+            "connectors-example-org"
+        );
+        assert_eq!(
+            ConnectorConfig::host_slug("grpc://localhost:50061"),
+            "localhost"
+        );
+    }
+
+    #[test]
+    fn host_slug_is_empty_for_empty_host() {
+        assert_eq!(ConnectorConfig::host_slug(""), "");
+    }
+
+    #[test]
+    fn env_scoped_instance_id_differs_per_host() {
+        let device = "device-0001";
+        let a = ConnectorConfig::env_scoped_instance_id(device, "wss://studio.example.com:443");
+        let b = ConnectorConfig::env_scoped_instance_id(device, "wss://studio.example.org:443");
+        assert_eq!(a, format!("{device}-studio-example-com"));
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn env_scoped_instance_id_is_stable_for_same_host() {
+        let device = "device-0001";
+        let a = ConnectorConfig::env_scoped_instance_id(device, "wss://studio.example.com:443");
+        let b = ConnectorConfig::env_scoped_instance_id(device, "wss://studio.example.com:443");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn env_scoped_instance_id_falls_back_to_device_id_when_host_empty() {
+        assert_eq!(
+            ConnectorConfig::env_scoped_instance_id("dev-1", ""),
+            "dev-1"
+        );
     }
 }

--- a/crates/ui/src/connector_app.rs
+++ b/crates/ui/src/connector_app.rs
@@ -337,7 +337,6 @@ pub fn connector_app(cfg: ConnectorAppConfig) -> Element {
     // ---- connect handler ----
     let mut on_connect = move |(mut new_config, remember): (ConnectorConfig, bool)| {
         let device_id = settings.peek().device_id.clone();
-        new_config.instance_id = device_id;
 
         match ConnectorConfig::normalize_host(&new_config.host) {
             Ok(h) => new_config.host = h,
@@ -346,6 +345,12 @@ pub fn connector_app(cfg: ConnectorAppConfig) -> Element {
                 return;
             }
         }
+
+        // Scope the connector identity per env so each Strike48 host gets its own
+        // credential + approval. A single global device_id reuses one credential
+        // for every env, so a token minted for env A is rejected by env B.
+        new_config.instance_id =
+            ConnectorConfig::env_scoped_instance_id(&device_id, &new_config.host);
         config.set(new_config.clone());
         status.set(ConnectorStatus::Connecting);
         connecting_step.set(Some(ConnectingStep::Connecting));

--- a/crates/ui/src/liveview_connector/mod.rs
+++ b/crates/ui/src/liveview_connector/mod.rs
@@ -94,6 +94,13 @@ const JWT_REFRESH_FALLBACK_SECS: u64 = 240;
 /// Retry delay when a proactive JWT refresh fails.
 const JWT_REFRESH_RETRY_SECS: u64 = 30;
 
+/// Number of consecutive registration rejections to tolerate before treating
+/// the saved credential as unusable for this host and falling back to the
+/// approval flow. A token minted for a different env registers fine at the auth
+/// layer but is rejected here forever, so without this the connector loops
+/// silently.
+const REGISTRATION_FAILURE_RETRY_LIMIT: u32 = 3;
+
 /// Parse remaining seconds until expiry from a JWT (3-part `header.payload.signature`).
 fn jwt_remaining_secs(token: &str) -> Option<i64> {
     let payload_b64 = token.split('.').nth(1)?;
@@ -258,6 +265,10 @@ pub struct LiveViewConnector {
     pub(crate) matrix_client: Arc<RwLock<Option<pentest_core::matrix::MatrixChatClient>>>,
     /// Total specialists spawned across reconnects (persists across ScanState resets)
     pub(crate) total_specialists_spawned: Arc<AtomicUsize>,
+    /// Consecutive registration rejections, reset on a successful registration.
+    /// Used to break the silent retry loop when a credential is valid but minted
+    /// for a different env than the connection host.
+    pub(crate) registration_failures: u32,
 }
 
 impl LiveViewConnector {
@@ -301,6 +312,7 @@ impl LiveViewConnector {
             active_scan: Arc::new(RwLock::new(None)),
             matrix_client: Arc::new(RwLock::new(None)),
             total_specialists_spawned: Arc::new(AtomicUsize::new(0)),
+            registration_failures: 0,
         }
     }
 
@@ -707,27 +719,21 @@ impl LiveViewConnector {
             self.config.host
         ))));
 
-        // If we already have a saved auth token, set the Matrix credentials
-        // immediately so the workspace chat panel can use them.
         tracing::info!(
             "[ConnectAndRun] auth_token from config: len={} empty={}",
             self.config.auth_token.len(),
             self.config.auth_token.is_empty(),
         );
-        if !self.config.auth_token.is_empty() {
-            tracing::info!("[ConnectAndRun] Emitting CredentialsUpdated from saved token");
-            self.send_event(ConnectorEvent::CredentialsUpdated {
-                auth_token: self.config.auth_token.clone(),
-                api_url: self.derive_matrix_api_url(),
-            });
-        } else {
-            tracing::info!("[ConnectAndRun] No saved auth_token — trying pre-approval auth");
 
-            // Auth initialization follows the SDK's priority order:
-            // 1. Direct config (cert-manager / K8s secrets)
-            // 2. Pre-approval OTT (env var / file)
-            // 3. Saved credentials (loaded here, token fetched per-iteration)
-            // 4. Post-approval (wait for admin via CredentialsIssued)
+        // Auth precedence:
+        // 1. Direct config (cert-manager / K8s secrets)
+        // 2. Pre-approval OTT (env var / file) — explicit, env-correct provisioning
+        //    (e.g. StrikeHub). Takes precedence over a saved auth_token, which may be
+        //    stale or minted for a different env than the host we're connecting to.
+        // 3. Saved JWT from a prior approval (settings.json)
+        // 4. Saved OTT credentials on disk (token fetched per loop iteration)
+        // 5. Post-approval (wait for admin via CredentialsIssued)
+        {
             let connector_type = "pentest-connector".to_string();
             let instance_id = self.config.instance_id.clone();
             let mut ott_provider =
@@ -792,6 +798,14 @@ impl LiveViewConnector {
                         );
                     }
                 }
+            } else if !self.config.auth_token.is_empty() {
+                // Saved JWT from a prior approval. Set Matrix credentials immediately
+                // so the workspace chat panel can use them.
+                tracing::info!("[ConnectAndRun] Using saved auth token");
+                self.send_event(ConnectorEvent::CredentialsUpdated {
+                    auth_token: self.config.auth_token.clone(),
+                    api_url: self.derive_matrix_api_url(),
+                });
             } else if ott_provider
                 .load_saved_credentials(&connector_type, Some(&instance_id))
                 .is_some()
@@ -800,6 +814,10 @@ impl LiveViewConnector {
                 // each connection loop iteration (matching kubestudio's pattern).
                 tracing::info!("Loaded saved credentials, will use JWT authentication");
                 *self.ott_provider.write().await = Some(ott_provider);
+            } else {
+                tracing::info!(
+                    "[ConnectAndRun] No auth source available — registering for admin approval"
+                );
             }
         }
 
@@ -1122,6 +1140,7 @@ impl LiveViewConnector {
                     match msg.message {
                         Some(Message::RegisterResponse(resp)) => {
                             if resp.success {
+                                self.registration_failures = 0;
                                 tracing::info!("Registered: {}", resp.connector_arn);
                                 self.send_event(ConnectorEvent::Log(
                                     TerminalLine::success("Registered with Strike48")
@@ -1138,16 +1157,35 @@ impl LiveViewConnector {
                                 // across reconnects so ChatPanel doesn't need a fresh fetch.
                                 self.send_event(ConnectorEvent::StatusChanged(ConnectorStatus::Registered));
                             } else {
-                                tracing::error!("Registration failed: {}", resp.error);
+                                self.registration_failures =
+                                    self.registration_failures.saturating_add(1);
+                                tracing::error!(
+                                    "Registration failed (attempt {}): {}",
+                                    self.registration_failures, resp.error
+                                );
 
-                                // If auth failed (expired/invalid token), clear it and retry
-                                if resp.error.contains("expired") || resp.error.contains("invalid") ||
-                                   resp.error.contains("auth") || resp.error.contains("jwt") {
-                                    tracing::info!("Auth token expired/invalid, clearing and will retry");
+                                // Clear the saved credential and re-run approval when:
+                                //  - the server reports an explicit auth problem, or
+                                //  - a generic rejection persists across retries — a token
+                                //    minted for a different env passes the auth layer but is
+                                //    rejected here forever, so the credential is unusable for
+                                //    this host.
+                                let auth_error = resp.error.contains("expired")
+                                    || resp.error.contains("invalid")
+                                    || resp.error.contains("auth")
+                                    || resp.error.contains("jwt");
+                                let exhausted = self.registration_failures
+                                    >= REGISTRATION_FAILURE_RETRY_LIMIT;
+
+                                if auth_error || exhausted {
+                                    tracing::info!(
+                                        "Clearing saved credentials (auth_error={}, attempts={}) and re-running approval",
+                                        auth_error, self.registration_failures
+                                    );
                                     self.config.auth_token.clear();
-                                    // Clear the OTT provider so we don't try to refresh stale credentials
+                                    // Clear the OTT provider so we don't refresh stale credentials
                                     *self.ott_provider.write().await = None;
-                                    // Delete stale saved credentials file to break the retry loop
+                                    // Delete the stale saved credentials file to break the loop
                                     let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
                                     let stale = format!(
                                         "{}/.strike48/credentials/pentest-connector_{}.json",
@@ -1161,13 +1199,16 @@ impl LiveViewConnector {
                                         auth_token: String::new(),
                                         api_url: String::new(),
                                     });
-                                    self.send_event(ConnectorEvent::Log(
-                                        TerminalLine::info("Token expired, will re-register for approval")
-                                    ));
+                                    self.send_event(ConnectorEvent::Log(TerminalLine::info(
+                                        "Registration rejected — clearing credentials and re-running approval for this env",
+                                    )));
+                                    self.registration_failures = 0;
                                     // Don't return - let the reconnect loop handle it
                                     return;
                                 }
 
+                                // Early/transient failure: surface it and let the
+                                // connection loop retry before we give up on the credential.
                                 self.send_event(ConnectorEvent::Log(
                                     TerminalLine::error(format!("Registration failed: {}", resp.error))
                                 ));


### PR DESCRIPTION
## Summary

Pick reused one global credential/identity for every Strike48 environment, so a token minted for one env was rejected by another and registration looped on the opaque "Registration failed". This addresses that across both the desktop GUI and the StrikeHub-launched headless connector.

- **Per-env identity** — derive `instance_id` from `device_id` + a slug of the target host, so saved credentials and connector approval are scoped per studio. Switching environments now "just works" (each env gets its own approval). Deterministic, so the same host maps to the same id across restarts.
- **OTT precedence** — prefer a pre-approval OTT / direct config over a non-empty saved `auth_token`. Fixes the StrikeHub-launched connector reusing a stale token from the shared `settings.json` instead of the fresh OTT it was provisioned with.
- **Registration-failure recovery** — after N consecutive `RegisterResponse{success:false}`, clear the credential and re-run approval instead of looping forever. Previously a valid-but-wrong-env token looped silently (token fetch succeeded, and the bare "Registration failed" string didn't match the auth-error keywords).
- **SSRF guard in StrikeHub mode** — `load_connector_config` no longer rejects the studio host when launched by StrikeHub, so private-IP / self-hosted studios are allowed. Aligns with `main.rs`'s existing `if !is_strikehub` intent.

## Migration note

Because `instance_id` now includes the host, existing installs re-approve **once per environment** the first time they connect after upgrading. Subsequent connects (and env switches) reuse the per-env credential with no re-approval.

## Security note

The SSRF change relaxes the **studio-connection** host check **only** in StrikeHub/IPC mode (`STRIKEHUB_SOCKET` set), where the host is chosen by the trusted local launcher. Standalone headless keeps full SSRF validation, and all tool-target scan validation (ffuf / nikto / gobuster / dirb) is untouched.

## Test plan

- [x] `cargo fmt --all`, `cargo check --all-targets`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib --bins` (incl. new `config` tests)
- [x] Desktop: switch between local / staging / prod studios — each registers under its own per-env instance
- [x] StrikeHub: pick registers via OTT against local (private-IP), staging, and prod studios