### PR TITLE
Fix Strikekit issue #2274, send Pick interface IPs to orchestrator in…

### DIFF
--- a/crates/platform/src/desktop/mod.rs
+++ b/crates/platform/src/desktop/mod.rs
@@ -11,6 +11,34 @@ mod wifi_attack;
 // Re-export sandbox control functions
 pub use command::{is_sandbox_enabled, set_use_sandbox};
 
+/// Returns all local non-loopback IPv4 addresses (synchronous).
+/// Used by connectors to report their host interfaces during registration.
+#[cfg(feature = "network-interface")]
+pub fn get_local_ipv4_addresses() -> Option<Vec<String>> {
+    use network_interface::{NetworkInterface as NI, NetworkInterfaceConfig};
+
+    let interfaces = NI::show().ok()?;
+    let ips: Vec<String> = interfaces
+        .into_iter()
+        .flat_map(|iface| iface.addr)
+        .filter_map(|addr| {
+            let ip = addr.ip();
+            if ip.is_ipv4() && !ip.is_loopback() {
+                Some(ip.to_string())
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if ips.is_empty() { None } else { Some(ips) }
+}
+
+#[cfg(not(feature = "network-interface"))]
+pub fn get_local_ipv4_addresses() -> Option<Vec<String>> {
+    None
+}
+
 // Re-export capture session management (single source of truth)
 pub use capture::{
     get_current_packets, is_capture_active, is_pcap_available, start_current_capture,

--- a/crates/platform/src/desktop/mod.rs
+++ b/crates/platform/src/desktop/mod.rs
@@ -31,7 +31,11 @@ pub fn get_local_ipv4_addresses() -> Option<Vec<String>> {
         })
         .collect();
 
-    if ips.is_empty() { None } else { Some(ips) }
+    if ips.is_empty() {
+        None
+    } else {
+        Some(ips)
+    }
 }
 
 #[cfg(not(feature = "network-interface"))]

--- a/crates/ui/src/liveview_connector/mod.rs
+++ b/crates/ui/src/liveview_connector/mod.rs
@@ -63,8 +63,8 @@ use strike48_connector::{
 };
 use strike48_proto::proto::{
     stream_message::Message, ConnectorCapabilities, InstanceMetadata, RegisterConnectorRequest,
-    StreamMessage, WebSocketCloseRequest, WebSocketFrame, WebSocketFrameType,
-    WebSocketOpenRequest, WebSocketOpenResponse,
+    StreamMessage, WebSocketCloseRequest, WebSocketFrame, WebSocketFrameType, WebSocketOpenRequest,
+    WebSocketOpenResponse,
 };
 use tokio::sync::{broadcast, mpsc, RwLock};
 use tokio_tungstenite::tungstenite::Message as WsMessage;

--- a/crates/ui/src/liveview_connector/mod.rs
+++ b/crates/ui/src/liveview_connector/mod.rs
@@ -62,9 +62,9 @@ use strike48_connector::{
     PayloadEncoding,
 };
 use strike48_proto::proto::{
-    stream_message::Message, ConnectorCapabilities, RegisterConnectorRequest, StreamMessage,
-    WebSocketCloseRequest, WebSocketFrame, WebSocketFrameType, WebSocketOpenRequest,
-    WebSocketOpenResponse,
+    stream_message::Message, ConnectorCapabilities, InstanceMetadata, RegisterConnectorRequest,
+    StreamMessage, WebSocketCloseRequest, WebSocketFrame, WebSocketFrameType,
+    WebSocketOpenRequest, WebSocketOpenResponse,
 };
 use tokio::sync::{broadcast, mpsc, RwLock};
 use tokio_tungstenite::tungstenite::Message as WsMessage;
@@ -1086,12 +1086,30 @@ impl LiveViewConnector {
             jwt_token: self.config.auth_token.clone(),
             session_token: String::new(),
             scope: 0,
-            instance_metadata: None,
+            instance_metadata: Some(InstanceMetadata {
+                display_name: String::new(),
+                tags: vec![],
+                metadata: Self::collect_host_interfaces(),
+            }),
         };
 
         StreamMessage {
             message: Some(Message::RegisterRequest(register_request)),
         }
+    }
+
+    /// Collect all local IPv4 addresses for infrastructure self-exclusion.
+    /// Reported to Matrix Studio via instance_metadata so the orchestrator can
+    /// exclude this connector's host from engagement scanning.
+    fn collect_host_interfaces() -> HashMap<String, String> {
+        let mut metadata = HashMap::new();
+
+        if let Some(ips) = pentest_platform::desktop::get_local_ipv4_addresses() {
+            tracing::info!("Reporting host interfaces for exclusion: {:?}", ips);
+            metadata.insert("host_interfaces".to_string(), ips.join(","));
+        }
+
+        metadata
     }
 
     /// Run the message processing loop.


### PR DESCRIPTION
… Matrix studio side to be added in the excluded scope.

  Pick: Report host interfaces for infrastructure self-exclusion (StrikeKit #2274)
  
  Summary

  Pairs with Matrix PR https://github.com/Strike48/matrix/pull/2410 to address StrikeKit issue #2274 (https://github.com/Strike48/matrix/issues/2274) — preventing the engagement orchestrator
  from scanning Pick's own host interfaces and reporting them as targets.

  Per the issue's resolution direction (per @jtomek-strike48: "We will land this in Pick not in StrikeKit"), Pick is the source of truth for the IPs that should be excluded. Pick now
  enumerates its local IPv4 interfaces at connector registration and ships them to Matrix Studio in InstanceMetadata.metadata["host_interfaces"]. Matrix's orchestrator merges those IPs into
  the engagement's out_of_scope list at execution start.
  
  Without this change, Pick registered with instance_metadata: None and Matrix had no way to know which IPs belong to the connector host, so the LLM agent would happily scan and "find" Pick
  itself, generating false positives like Nexpose Host Multi-Homed and Credential Harvest from Scanner.

  Changes

  crates/platform/src/desktop/mod.rs

  Added pub fn get_local_ipv4_addresses() -> Option<Vec<String>>:

  - Feature-gated on network-interface — when the feature is enabled, enumerates all interfaces via NetworkInterface::show() and filters to non-loopback IPv4 addresses, returning each as a
  String.
  - Fallback when the feature is disabled — returns None. Keeps non-desktop targets buildable without dragging in the network-interface dependency.
  - Returns None instead of Some(vec![]) when no qualifying interfaces are found, so callers can use if let Some(ips) = ... without an empty-vec edge case.

  crates/ui/src/liveview_connector/mod.rs

  - Added InstanceMetadata to the strike48_proto imports.
  - Changed connector registration to populate instance_metadata instead of sending None:

  instance_metadata: Some(InstanceMetadata {
      display_name: String::new(),
      tags: vec![],
      metadata: Self::collect_host_interfaces(),
  }),
  - Added fn collect_host_interfaces() -> HashMap<String, String>:
    - Calls pentest_platform::desktop::get_local_ipv4_addresses().
    - On Some(ips), joins them comma-separated and inserts under the "host_interfaces" key.
    - On None, the metadata map is left empty (no key) — Matrix's InfraExclusion already handles missing/empty values gracefully via its parse_host_interfaces clauses.
    - Logs the reported IPs at tracing::info level so the Pick→Studio flow is visible in connector logs during debugging.

  Wire format

  The reported metadata key/value contract is:

  metadata["host_interfaces"] = "10.0.0.145,10.5.0.1,100.96.2.11"

  Matrix-side parsing (in StrikekitCore.InfraExclusion.parse_host_interfaces/1):

  - Comma-split, trim whitespace, drop empties.
  - No format validation beyond that — Matrix treats any non-empty trimmed string as an IP literal and merges it into out_of_scope. This keeps the wire format stable across future additions
  (IPv6, CIDR ranges) without requiring schema changes.

  No protobuf changes — uses the existing InstanceMetadata.metadata map field, which was already in the wire format but unused by Pick.

  Test coverage

  - Server-side coverage for the receive/merge side lives in Matrix PR #2410:
    - apply_exclusions/2 deduplication, nil-handling, preserve-existing-out_of_scope assertions.
    - ScopeValidator integration tests for the deny path.
  - Client-side: no automated tests added in this PR. The get_local_ipv4_addresses function is a thin wrapper over network-interface crate's show(), and the registration-path change is one
  struct-field flip. Behavior is exercised by manual e2e verification (below).

  If reviewers want a unit test for get_local_ipv4_addresses, happy to add one — it would just assert the function returns Some on a host with at least one non-loopback interface, and that
  returned strings are valid IPv4. Let me know.

  End-to-end verification

  Tested against Matrix branch feat/matrix/strikit-2274-excl-self (the branch backing PR #2410) on a local Talos K8s cluster with Pick running as a Mac binary:

  1. Pick log on registration:
  INFO Reporting host interfaces for exclusion: ["100.96.2.11", "10.5.0.1", "10.0.0.145"]
  2. Matrix Studio log on engagement execution start:
  [InfraExclusion] Excluding connector infrastructure IPs:
    ["100.96.2.11", "10.5.0.1", "10.0.0.145"] (connectors=3)
  3. Cross-checked with a temporary sentinel IP (192.168.99.99) injected into Pick's reported list — the sentinel appeared in Matrix's exclusion log, confirming the full Pick → gRPC register
  → Matrix ETS connector registry → tenant-slug filter → engagement.out_of_scope pipeline. Sentinel was removed before this commit.

  Related

  - StrikeKit issue: https://github.com/Strike48/matrix/issues/2274
  - Matrix companion PR: https://github.com/Strike48/matrix/pull/2410
  - Original PR adding the InfraExclusion module: https://github.com/Strike48/matrix/pull/2401

