### PR TITLE
fix(strikekit #2524): add exclude parameter to nmap/masscan scan tools

### DIFF
--- a/crates/tools/src/external/masscan.rs
+++ b/crates/tools/src/external/masscan.rs
@@ -15,7 +15,7 @@ use serde_json::{json, Value};
 use std::time::Duration;
 
 use super::install::ensure_tool_installed;
-use super::runner::{param_str_or, read_sandbox_file, CommandBuilder};
+use super::runner::{param_exclude_list, param_str_or, read_sandbox_file, CommandBuilder};
 use crate::util::param_u64;
 
 /// Masscan internet-scale port scanner
@@ -43,7 +43,9 @@ impl PentestTool for MasscanTool {
             .param(ToolParam::required(
                 "target",
                 ParamType::String,
-                "Target IP/CIDR (e.g., '10.0.0.0/8', '192.168.1.1')",
+                "Target IP, CIDR, or IPv4 dash range. Prefer CIDR ('10.0.0.0/8') or a simple \
+                 IP1-IP2 range ('10.0.0.1-10.0.5.20'); multi-octet ranges are not scope-checked \
+                 and may be rejected.",
             ))
             .param(ToolParam::optional(
                 "ports",
@@ -68,6 +70,12 @@ impl PentestTool for MasscanTool {
                 ParamType::Integer,
                 "Overall timeout in seconds (default: 600, range: 30-3600)",
                 json!(600),
+            ))
+            .param(ToolParam::optional(
+                "exclude",
+                ParamType::Array,
+                "Hosts/CIDRs to exclude from the scan (maps to masscan --exclude). Use this to scan a range while skipping specific hosts, e.g. target='10.0.0.0/8' exclude=['10.0.0.1']. Out-of-scope hosts are also injected here automatically by the platform.",
+                json!([]),
             ))
             .platforms(vec![Platform::Desktop, Platform::Tui])
     }
@@ -110,6 +118,10 @@ impl PentestTool for MasscanTool {
                 pentest_core::timeout::categorize_tool("masscan"),
             );
 
+            // Exclude list (issue #2524): out-of-scope hosts the scan must skip.
+            // Validated as IP/CIDR/hostname to prevent injection via this param.
+            let exclude = param_exclude_list(&params, "exclude")?;
+
             // Build masscan command
             let output_file = "/tmp/masscan-output.json";
             let mut builder = CommandBuilder::new()
@@ -117,6 +129,10 @@ impl PentestTool for MasscanTool {
                 .arg("-p", &ports)
                 .arg("--rate", &rate.to_string())
                 .arg("-oJ", output_file); // JSON output
+
+            if let Some(exclude) = exclude {
+                builder = builder.arg("--exclude", &exclude);
+            }
 
             if banner {
                 builder = builder.flag("--banners");
@@ -189,4 +205,46 @@ fn parse_masscan_json(json_str: &str, target: &str) -> Result<Value> {
         "count": hosts.len(),
         "summary": format!("Found {} host(s) with open ports", hosts.len()),
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Tests for the --exclude wiring (issue #2524). execute() builds the command
+    // inline; these replicate the exact `param_exclude_list` +
+    // `CommandBuilder.arg("--exclude", ...)` composition it uses, so a wiring
+    // regression (dropped flag, wrong join, emitted when empty) is caught.
+
+    fn build_exclude_args(params: &Value) -> Vec<String> {
+        let exclude = param_exclude_list(params, "exclude").expect("valid exclude");
+        let mut builder = CommandBuilder::new()
+            .positional("10.0.0.0/8")
+            .arg("-p", "80");
+        if let Some(exclude) = exclude {
+            builder = builder.arg("--exclude", &exclude);
+        }
+        builder.build()
+    }
+
+    #[test]
+    fn exclude_array_produces_exclude_flag() {
+        let params = json!({"exclude": ["10.0.0.1"]});
+        let args = build_exclude_args(&params);
+        assert!(args.windows(2).any(|w| w == ["--exclude", "10.0.0.1"]));
+    }
+
+    #[test]
+    fn absent_exclude_produces_no_flag() {
+        let params = json!({"target": "10.0.0.0/8"});
+        let args = build_exclude_args(&params);
+        assert!(!args.iter().any(|a| a == "--exclude"));
+    }
+
+    #[test]
+    fn empty_exclude_array_produces_no_flag() {
+        let params = json!({"exclude": []});
+        let args = build_exclude_args(&params);
+        assert!(!args.iter().any(|a| a == "--exclude"));
+    }
 }

--- a/crates/tools/src/external/nmap.rs
+++ b/crates/tools/src/external/nmap.rs
@@ -16,7 +16,7 @@ use serde_json::{json, Value};
 use std::time::Duration;
 
 use super::install::ensure_tool_installed;
-use super::runner::{param_str_opt, param_str_or, CommandBuilder};
+use super::runner::{param_exclude_list, param_str_opt, param_str_or, CommandBuilder};
 use crate::provenance_support::{format_full_command, tool_version};
 use crate::util::{param_bool, param_u64};
 
@@ -45,7 +45,10 @@ impl PentestTool for NmapTool {
             .param(ToolParam::required(
                 "target",
                 ParamType::String,
-                "Target IP, hostname, or CIDR range (e.g., '192.168.1.0/24', 'example.com')",
+                "Target IP, hostname, or range. Supported range forms: CIDR ('192.168.1.0/24'), \
+                 or IPv4 dash ranges — last-octet ('10.0.0.1-50') or full-IP ('10.0.0.1-10.0.5.20'). \
+                 Prefer CIDR or a simple IP1-IP2 dash range; nmap's multi-octet form ('10.0.0-1.1-254') \
+                 is not scope-checked and may be rejected.",
             ))
             .param(ToolParam::optional(
                 "scan_type",
@@ -94,6 +97,12 @@ impl PentestTool for NmapTool {
                 ParamType::Boolean,
                 "Skip host discovery (-Pn, treat all hosts as online)",
                 json!(false),
+            ))
+            .param(ToolParam::optional(
+                "exclude",
+                ParamType::Array,
+                "Hosts/CIDRs to exclude from the scan (maps to nmap --exclude). Use this to scan a range while skipping specific hosts, e.g. target='10.0.0.0/24' exclude=['10.0.0.1','10.0.0.2']. Out-of-scope hosts are also injected here automatically by the platform.",
+                json!([]),
             ))
             .param(ToolParam::optional(
                 "timeout",
@@ -229,6 +238,12 @@ impl PentestTool for NmapTool {
 
                     builder = builder.arg("--script", &scripts);
                 }
+            }
+
+            // Exclude list (issue #2524): out-of-scope hosts the scan must skip.
+            // Validated as IP/CIDR/hostname to prevent injection via this param.
+            if let Some(exclude) = param_exclude_list(&params, "exclude")? {
+                builder = builder.arg("--exclude", &exclude);
             }
 
             // Output format: XML for parsing
@@ -834,6 +849,47 @@ mod tests {
         assert!("smb-*".contains('*'));
         assert!("http-?".contains('?'));
         assert!("smb-vuln-*".contains('*'));
+    }
+
+    // ========================================
+    // Tests for the --exclude wiring (issue #2524)
+    // ========================================
+    //
+    // execute() builds the command inline; these tests replicate the exact
+    // `param_exclude_list` + `CommandBuilder.arg("--exclude", ...)` composition
+    // it uses, so a regression in the wiring (dropped flag, wrong join, emitted
+    // when empty) is caught without standing up a mock platform.
+
+    fn build_exclude_args(params: &serde_json::Value) -> Vec<String> {
+        let mut builder = CommandBuilder::new();
+        if let Some(exclude) =
+            super::super::runner::param_exclude_list(params, "exclude").expect("valid exclude")
+        {
+            builder = builder.arg("--exclude", &exclude);
+        }
+        builder.positional("10.0.0.0/24").build()
+    }
+
+    #[test]
+    fn exclude_array_produces_exclude_flag() {
+        let params = serde_json::json!({"exclude": ["10.0.0.1", "10.0.0.2"]});
+        let args = build_exclude_args(&params);
+        assert_eq!(args, vec!["--exclude", "10.0.0.1,10.0.0.2", "10.0.0.0/24"]);
+    }
+
+    #[test]
+    fn absent_exclude_produces_no_flag() {
+        let params = serde_json::json!({"target": "10.0.0.0/24"});
+        let args = build_exclude_args(&params);
+        assert_eq!(args, vec!["10.0.0.0/24"]);
+        assert!(!args.iter().any(|a| a == "--exclude"));
+    }
+
+    #[test]
+    fn empty_exclude_array_produces_no_flag() {
+        let params = serde_json::json!({"exclude": []});
+        let args = build_exclude_args(&params);
+        assert!(!args.iter().any(|a| a == "--exclude"));
     }
 
     #[test]

--- a/crates/tools/src/external/runner.rs
+++ b/crates/tools/src/external/runner.rs
@@ -25,6 +25,56 @@ pub fn param_str_opt(params: &Value, key: &str) -> Option<String> {
         .map(|s| s.to_string())
 }
 
+/// Extract and validate an "exclude" list parameter for scan tools.
+///
+/// Matrix injects the engagement's out-of-scope hosts into this parameter
+/// (issue #2524) so the scanner natively skips them. The value may arrive as a
+/// JSON array of strings (the canonical form Matrix sends) or as a
+/// comma-separated string (defensive, in case the LLM supplies one). Each entry
+/// is validated as an IP / CIDR / hostname via [`validate_target`] to prevent
+/// command injection through this newly-exposed parameter.
+///
+/// Returns:
+/// - `Ok(Some(joined))` — a comma-joined, validated exclusion list to pass to
+///   the tool's native `--exclude` flag,
+/// - `Ok(None)` — no exclusions present,
+/// - `Err(_)` — an entry failed validation.
+pub fn param_exclude_list(params: &Value, key: &str) -> Result<Option<String>> {
+    let raw_entries: Vec<String> = match params.get(key) {
+        None | Some(Value::Null) => return Ok(None),
+        Some(Value::Array(items)) => items
+            .iter()
+            .filter_map(|v| v.as_str())
+            .map(|s| s.to_string())
+            .collect(),
+        Some(Value::String(s)) => s.split(',').map(|p| p.trim().to_string()).collect(),
+        Some(other) => {
+            return Err(Error::InvalidParams(format!(
+                "{} must be an array of hosts or a comma-separated string, got {}",
+                key, other
+            )))
+        }
+    };
+
+    let mut validated = Vec::new();
+    for entry in raw_entries {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            continue;
+        }
+        // Reuse the same target validator the `target` parameter uses, so an
+        // exclude entry can never smuggle in shell metacharacters.
+        let valid = pentest_core::validation::validate_target(entry)?;
+        validated.push(valid);
+    }
+
+    if validated.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(validated.join(",")))
+    }
+}
+
 /// Build command arguments with common options
 pub struct CommandBuilder {
     args: Vec<String>,
@@ -194,5 +244,64 @@ mod tests {
         let params = serde_json::json!({"key": "value"});
         assert_eq!(param_str_opt(&params, "key"), Some("value".to_string()));
         assert_eq!(param_str_opt(&params, "missing"), None);
+    }
+
+    // --- param_exclude_list (issue #2524) ---------------------------------
+
+    #[test]
+    fn exclude_list_absent_or_null_is_none() {
+        assert_eq!(
+            param_exclude_list(&serde_json::json!({}), "exclude").unwrap(),
+            None
+        );
+        assert_eq!(
+            param_exclude_list(&serde_json::json!({"exclude": null}), "exclude").unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn exclude_list_empty_array_is_none() {
+        let params = serde_json::json!({"exclude": []});
+        assert_eq!(param_exclude_list(&params, "exclude").unwrap(), None);
+    }
+
+    #[test]
+    fn exclude_list_array_is_joined() {
+        let params = serde_json::json!({"exclude": ["10.0.0.1", "10.0.0.2"]});
+        assert_eq!(
+            param_exclude_list(&params, "exclude").unwrap(),
+            Some("10.0.0.1,10.0.0.2".to_string())
+        );
+    }
+
+    #[test]
+    fn exclude_list_accepts_cidr_entries() {
+        let params = serde_json::json!({"exclude": ["10.0.0.0/24"]});
+        assert_eq!(
+            param_exclude_list(&params, "exclude").unwrap(),
+            Some("10.0.0.0/24".to_string())
+        );
+    }
+
+    #[test]
+    fn exclude_list_comma_string_is_normalized() {
+        let params = serde_json::json!({"exclude": "10.0.0.1, 10.0.0.2"});
+        assert_eq!(
+            param_exclude_list(&params, "exclude").unwrap(),
+            Some("10.0.0.1,10.0.0.2".to_string())
+        );
+    }
+
+    #[test]
+    fn exclude_list_rejects_injection_attempt() {
+        let params = serde_json::json!({"exclude": ["; rm -rf /"]});
+        assert!(param_exclude_list(&params, "exclude").is_err());
+    }
+
+    #[test]
+    fn exclude_list_rejects_non_array_non_string() {
+        let params = serde_json::json!({"exclude": 1234});
+        assert!(param_exclude_list(&params, "exclude").is_err());
     }
 }


### PR DESCRIPTION
  Part of #2524 (StrikeKit out-of-scope enforcement). Pairs with the Matrix PR #2568,
  https://github.com/Strike48/matrix/pull/2568 .

  > Background and root cause are in #2524. This is the connector-side change.

  ## What this does

  The scan tools (nmap, masscan) natively support `--exclude`, but the **tool-call
  schemas never declared an `exclude` parameter** — so the LLM had no structured
  way to say "scan this range *except* these hosts." That's half the reason
  out-of-scope IPs leaked into scans (#2524): even a cooperative LLM couldn't
  express an exclusion through the tool call.

  This PR adds the `exclude` parameter and wires it to the tools' native
  `--exclude` flag.

  ## Changes

  - **`nmap.rs` / `masscan.rs`** — add an optional `exclude` array param to the
    tool schema (documents supported notations: IP, CIDR, IPv4 dash range), and
    emit `--exclude <comma-joined>` when present.
  - **`runner.rs`** — new `param_exclude_list/2` helper: accepts a JSON array (the
    canonical form Matrix sends) or a comma-separated string, **validates every
    entry via `validate_target`** (so the newly-exposed param can't smuggle shell
    metacharacters — injection guard), and returns the comma-joined `--exclude`
    value. Returns `None` for absent/empty so no stray flag is emitted.

  The `target` schema descriptions also now document supported range notations
  (CIDR, last-octet `10.0.0.1-50`, full-IP `10.0.0.1-10.0.5.20`) so the LLM
  prefers parseable forms.

  ## How it's used

  Matrix's `ScopeGate` (the paired PR) unions the engagement's mandatory
  out-of-scope hosts into this `exclude` arg before dispatch. With the param now
  present, the end-to-end test showed the **LLM also began populating `exclude` on
  its own** — confirming the schema gap was the blocker. Matrix degrades safely
  (denies the scan) for tools that lack this param, so the two PRs are
  order-independent but best merged together.

  ## Test coverage

  - **`runner.rs`** — `param_exclude_list` tests: array form, comma-string form,
    CIDR entries, empty/absent → no flag, **injection attempt (`"; rm -rf /"`)
    rejected**, non-array/non-string rejected.
  - **`nmap.rs` / `masscan.rs`** — command-builder tests asserting `--exclude
    <joined>` appears when an exclude list is present and is absent when empty.

  Gates: `cargo fmt --check`, `cargo check`, `cargo test -p pentest-tools --lib`
  (95 pass) all clean.

  ### Verified end-to-end (local Studio + Pick)

  Real engagement scans showed the wiring working: e.g.
  `nmap -sn --exclude 10.0.0.10 … 10.0.0.1-15` and
  `nmap -sn --exclude 10.0.0.20 … 10.0.0.16/28` — the excluded host correctly
  passed through to the native flag, scoped per range.

