### PR TITLE
fix(clippy): collapse else-if block in webwright workspace copy

### DIFF
--- a/crates/tools/src/webwright/workspace.rs
+++ b/crates/tools/src/webwright/workspace.rs
@@ -190,10 +190,8 @@ impl WebwrightWorkspace {
                         let dst_path = dst.join(entry.file_name());
                         if src_path.is_dir() {
                             count += copy_dir(&src_path, &dst_path);
-                        } else {
-                            if std::fs::copy(&src_path, &dst_path).is_ok() {
-                                count += 1;
-                            }
+                        } else if std::fs::copy(&src_path, &dst_path).is_ok() {
+                            count += 1;
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

- `cargo clippy --workspace -- -D warnings` (the CI Clippy gate) currently fails on `main` at `crates/tools/src/webwright/workspace.rs:193` with `collapsible_else_if`.
- This collapses the `else { if .. }` into `else if`. No behavior change.
- Unblocks the workspace Clippy job for any branch based on `main`.

## Why separate

Surfaced while branching a feature off `main`. Kept as a standalone one-line fix so it can merge independently and is not entangled with feature review.

## Test plan

- [x] `cargo clippy -p pentest-tools --all-targets -- -D warnings` passes
- [x] `cargo clippy -p pentest-core --all-targets -- -D warnings` passes
- [x] `cargo fmt` clean
- [ ] CI workspace Clippy job green