### PR TITLE
feat(specialist): Cloud Security Specialist foundation + prompt (pick#151)

### DIFF
--- a/crates/core/src/specialist_spawner.rs
+++ b/crates/core/src/specialist_spawner.rs
@@ -226,16 +226,26 @@ impl SpecialistSpawner {
     /// Cloud specialist spawn decision, scaled by aggression level.
     ///
     /// The thresholds mirror the pick#151 spec:
-    /// - Conservative: credentials found, OR SSRF + a known provider (the
-    ///   metadata-credential chain).
-    /// - Balanced: a provider is detected AND there is some surface to act on
-    ///   (SSRF, storage, or credentials).
+    /// - Conservative: credentials found, OR SSRF + a *classified* provider
+    ///   (Aws/Azure/Gcp). The conservative trigger is the metadata-credential
+    ///   chain, which is provider-specific (AWS IMDSv2 vs Azure `Metadata: true`
+    ///   vs GCP `Metadata-Flavor: Google`), so an SSRF against an unclassified
+    ///   (`Unknown`) provider has no actionable metadata endpoint and must skip.
+    /// - Balanced: a provider is detected (including `Unknown`) AND there is some
+    ///   surface to act on (SSRF, storage, or credentials). `Unknown` is allowed
+    ///   here because surface signals like an exposed bucket are actionable
+    ///   without knowing the exact provider.
     /// - Aggressive: any single cloud indicator.
     /// - Maximum: always spawn (treat every target as potentially cloud-hosted).
     fn should_spawn_cloud(&self, ind: &CloudIndicators) -> SpawnDecision {
         let spawn = match self.aggression {
             AggressionLevel::Conservative => {
-                ind.credentials_found || (ind.ssrf_available && ind.provider.is_some())
+                ind.credentials_found
+                    || (ind.ssrf_available
+                        && matches!(
+                            ind.provider,
+                            Some(CloudProvider::Aws | CloudProvider::Azure | CloudProvider::Gcp)
+                        ))
             }
             AggressionLevel::Balanced => {
                 ind.provider.is_some()
@@ -660,6 +670,39 @@ mod tests {
         assert_eq!(
             spawner.should_spawn(SpecialistType::Cloud, &ctx),
             SpawnDecision::Skip
+        );
+    }
+
+    #[test]
+    fn conservative_cloud_skips_unknown_provider_ssrf() {
+        // The conservative trigger is the metadata-credential chain, which is
+        // provider-specific (AWS IMDSv2 vs Azure `Metadata: true` vs GCP
+        // `Metadata-Flavor: Google`). An SSRF against an *unclassified* provider
+        // has no actionable metadata endpoint to attack, so the most cautious
+        // level must skip rather than pay for cloud enumeration that cannot fire.
+        // This pins the predicate to known providers (Aws/Azure/Gcp), not the
+        // looser `provider.is_some()` which is also true for Unknown.
+        let spawner = SpecialistSpawner::new(AggressionLevel::Conservative);
+        let ctx = make_cloud_context(CloudIndicators {
+            provider: Some(CloudProvider::Unknown),
+            ssrf_available: true,
+            ..Default::default()
+        });
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            SpawnDecision::Skip
+        );
+
+        // Credentials in hand remain a conservative trigger regardless of
+        // provider classification - a stolen key is actionable on its own.
+        let ctx = make_cloud_context(CloudIndicators {
+            provider: Some(CloudProvider::Unknown),
+            credentials_found: true,
+            ..Default::default()
+        });
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            SpawnDecision::Spawn
         );
     }
 

--- a/crates/core/src/specialist_spawner.rs
+++ b/crates/core/src/specialist_spawner.rs
@@ -77,6 +77,16 @@ pub enum CloudProvider {
     Unknown,
 }
 
+impl CloudProvider {
+    /// Whether this provider has a documented, attackable instance-metadata
+    /// endpoint (AWS IMDSv2, Azure IMDS, GCP metadata). `Unknown` does not:
+    /// the metadata-credential chain is provider-specific, so an SSRF against
+    /// an unclassified provider has nothing actionable to target.
+    pub fn is_classified(&self) -> bool {
+        matches!(self, Self::Aws | Self::Azure | Self::Gcp)
+    }
+}
+
 /// Cloud-specific attack-surface signals used to decide whether to spawn the
 /// Cloud specialist (pick#151).
 ///
@@ -241,11 +251,7 @@ impl SpecialistSpawner {
         let spawn = match self.aggression {
             AggressionLevel::Conservative => {
                 ind.credentials_found
-                    || (ind.ssrf_available
-                        && matches!(
-                            ind.provider,
-                            Some(CloudProvider::Aws | CloudProvider::Azure | CloudProvider::Gcp)
-                        ))
+                    || (ind.ssrf_available && ind.provider.is_some_and(|p| p.is_classified()))
             }
             AggressionLevel::Balanced => {
                 ind.provider.is_some()
@@ -707,6 +713,29 @@ mod tests {
     }
 
     #[test]
+    fn conservative_cloud_spawns_on_ssrf_with_each_classified_provider() {
+        // The SSRF metadata-credential trigger fires for every *classified*
+        // provider, not just AWS. Exercise Azure and Gcp explicitly so a typo
+        // dropping a variant from `is_classified` (e.g. losing `| Azure`) is
+        // caught at the most security-critical aggression level.
+        let spawner = SpecialistSpawner::new(AggressionLevel::Conservative);
+
+        for provider in [CloudProvider::Aws, CloudProvider::Azure, CloudProvider::Gcp] {
+            let ctx = make_cloud_context(CloudIndicators {
+                provider: Some(provider),
+                ssrf_available: true,
+                ..Default::default()
+            });
+            assert_eq!(
+                spawner.should_spawn(SpecialistType::Cloud, &ctx),
+                SpawnDecision::Spawn,
+                "SSRF + {:?} should spawn at Conservative",
+                provider
+            );
+        }
+    }
+
+    #[test]
     fn balanced_cloud_skips_surface_without_provider() {
         // Balanced requires a provider AND some surface signal. Surface signals
         // without a provider must skip - even all of them at once - pinning the
@@ -788,6 +817,38 @@ mod tests {
         // Provider alone, no surface signal -> skip at balanced.
         let ctx = make_cloud_context(CloudIndicators {
             provider: Some(CloudProvider::Azure),
+            ..Default::default()
+        });
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            SpawnDecision::Skip
+        );
+    }
+
+    #[test]
+    fn balanced_cloud_allows_unknown_provider_with_surface() {
+        // Unlike Conservative (which requires a classified provider for the
+        // SSRF metadata chain), Balanced spawns on an *unclassified* provider
+        // as long as there is actionable surface - an exposed bucket is worth
+        // testing without knowing the exact cloud. This pins the Balanced
+        // predicate to the loose `provider.is_some()` so a regression to the
+        // stricter `is_classified()` check (copied from the Conservative arm)
+        // would be caught.
+        let spawner = SpecialistSpawner::new(AggressionLevel::Balanced);
+
+        let ctx = make_cloud_context(CloudIndicators {
+            provider: Some(CloudProvider::Unknown),
+            storage_endpoints: 2,
+            ..Default::default()
+        });
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            SpawnDecision::Spawn
+        );
+
+        // But an unclassified provider with no surface signal still skips.
+        let ctx = make_cloud_context(CloudIndicators {
+            provider: Some(CloudProvider::Unknown),
             ..Default::default()
         });
         assert_eq!(

--- a/crates/core/src/specialist_spawner.rs
+++ b/crates/core/src/specialist_spawner.rs
@@ -82,7 +82,7 @@ impl CloudProvider {
     /// endpoint (AWS IMDSv2, Azure IMDS, GCP metadata). `Unknown` does not:
     /// the metadata-credential chain is provider-specific, so an SSRF against
     /// an unclassified provider has nothing actionable to target.
-    pub fn is_classified(&self) -> bool {
+    pub fn is_classified(self) -> bool {
         matches!(self, Self::Aws | Self::Azure | Self::Gcp)
     }
 }
@@ -605,6 +605,17 @@ mod tests {
     }
 
     #[test]
+    fn cloud_provider_is_classified() {
+        // Classified providers have documented, attackable metadata endpoints;
+        // Unknown does not. A direct test fails immediately on a `matches!`
+        // typo, rather than only via a downstream spawn-decision assertion.
+        assert!(CloudProvider::Aws.is_classified());
+        assert!(CloudProvider::Azure.is_classified());
+        assert!(CloudProvider::Gcp.is_classified());
+        assert!(!CloudProvider::Unknown.is_classified());
+    }
+
+    #[test]
     fn conservative_cloud_spawns_on_credentials() {
         let spawner = SpecialistSpawner::new(AggressionLevel::Conservative);
 
@@ -839,6 +850,20 @@ mod tests {
         let ctx = make_cloud_context(CloudIndicators {
             provider: Some(CloudProvider::Unknown),
             storage_endpoints: 2,
+            ..Default::default()
+        });
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            SpawnDecision::Spawn
+        );
+
+        // SSRF is also actionable surface at Balanced: Unknown + SSRF spawns
+        // here even though the same combination skips at Conservative (which
+        // gates the metadata chain on a classified provider). This directly
+        // pins the SSRF branch of the Balanced predicate, not just storage.
+        let ctx = make_cloud_context(CloudIndicators {
+            provider: Some(CloudProvider::Unknown),
+            ssrf_available: true,
             ..Default::default()
         });
         assert_eq!(

--- a/crates/core/src/specialist_spawner.rs
+++ b/crates/core/src/specialist_spawner.rs
@@ -205,7 +205,11 @@ impl SpecialistSpawner {
             SpecialistType::Api => self.policy.api_threshold,
             SpecialistType::Binary => 1, // Always spawn for binaries (rare targets)
             SpecialistType::AiSecurity => 1, // Always spawn for AI/LLM (rare targets)
-            SpecialistType::Cloud => unreachable!("handled above"),
+            SpecialistType::Cloud => {
+                unreachable!(
+                    "Cloud uses cloud_indicators, not endpoint_count; early-returned above"
+                )
+            }
         };
 
         let meets_threshold = context.attack_surface.endpoint_count >= threshold;
@@ -240,6 +244,18 @@ impl SpecialistSpawner {
             AggressionLevel::Aggressive => ind.has_any(),
             AggressionLevel::Maximum => true,
         };
+
+        // Visibility for the operator: skipping with no cloud signal at all is
+        // expected fail-safe behavior, but it is indistinguishable from a recon
+        // step that failed to populate indicators. Surface it so a missing-cloud
+        // skip can be told apart from a not-cloud skip.
+        if !spawn && !ind.has_any() {
+            tracing::debug!(
+                aggression = ?self.aggression,
+                "Cloud specialist skipped: no cloud indicators present. If the target \
+                 is cloud-hosted, recon may not have populated indicators."
+            );
+        }
 
         if spawn {
             SpawnDecision::Spawn
@@ -617,6 +633,97 @@ mod tests {
         assert_eq!(
             spawner.should_spawn(SpecialistType::Cloud, &ctx),
             SpawnDecision::Skip
+        );
+    }
+
+    #[test]
+    fn conservative_cloud_skips_signal_without_provider() {
+        // Conservative requires SSRF *and* a known provider for the metadata
+        // chain. SSRF alone (provider unknown) must skip - this pins the AND so a
+        // regression to `ssrf_available || provider.is_some()` would be caught.
+        let spawner = SpecialistSpawner::new(AggressionLevel::Conservative);
+        let ctx = make_cloud_context(CloudIndicators {
+            ssrf_available: true,
+            provider: None,
+            ..Default::default()
+        });
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            SpawnDecision::Skip
+        );
+
+        // Provider alone (no SSRF, no creds) is also not a conservative trigger.
+        let ctx = make_cloud_context(CloudIndicators {
+            provider: Some(CloudProvider::Aws),
+            ..Default::default()
+        });
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            SpawnDecision::Skip
+        );
+    }
+
+    #[test]
+    fn balanced_cloud_skips_surface_without_provider() {
+        // Balanced requires a provider AND some surface signal. Surface signals
+        // without a provider must skip - even all of them at once - pinning the
+        // `provider.is_some() && (...)` precedence.
+        let spawner = SpecialistSpawner::new(AggressionLevel::Balanced);
+        let ctx = make_cloud_context(CloudIndicators {
+            provider: None,
+            ssrf_available: true,
+            storage_endpoints: 3,
+            credentials_found: true,
+        });
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            SpawnDecision::Skip
+        );
+    }
+
+    #[test]
+    fn aggressive_cloud_spawns_on_each_indicator_in_isolation() {
+        // Aggressive spawns on any single indicator. Exercise each field alone
+        // (the existing test only covers storage) so `has_any()` is proven to
+        // check every field, including the Gcp provider variant.
+        let spawner = SpecialistSpawner::new(AggressionLevel::Aggressive);
+
+        for ind in [
+            CloudIndicators {
+                provider: Some(CloudProvider::Gcp),
+                ..Default::default()
+            },
+            CloudIndicators {
+                ssrf_available: true,
+                ..Default::default()
+            },
+            CloudIndicators {
+                credentials_found: true,
+                ..Default::default()
+            },
+        ] {
+            let ctx = make_cloud_context(ind);
+            assert_eq!(
+                spawner.should_spawn(SpecialistType::Cloud, &ctx),
+                SpawnDecision::Spawn
+            );
+        }
+    }
+
+    #[test]
+    fn cloud_spawn_is_independent_of_endpoint_count() {
+        // The Cloud path must ignore endpoint_count entirely. make_cloud_context
+        // sets it to 0; assert a spawn still happens on a cloud signal, proving
+        // Cloud does not fall through to the endpoint-threshold logic.
+        let spawner = SpecialistSpawner::new(AggressionLevel::Aggressive);
+        let ctx = make_cloud_context(CloudIndicators {
+            provider: Some(CloudProvider::Aws),
+            ..Default::default()
+        });
+        assert_eq!(ctx.attack_surface.endpoint_count, 0);
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            SpawnDecision::Spawn
         );
     }
 

--- a/crates/core/src/specialist_spawner.rs
+++ b/crates/core/src/specialist_spawner.rs
@@ -22,6 +22,9 @@ pub enum SpecialistType {
     Binary,
     /// AI/LLM security specialist (prompt injection, RAG poisoning, etc.)
     AiSecurity,
+    /// Cloud security specialist (IAM, instance-metadata abuse, storage
+    /// exposure, serverless, container/K8s escapes). See pick#151.
+    Cloud,
 }
 
 impl SpecialistType {
@@ -32,6 +35,7 @@ impl SpecialistType {
             Self::Api => "api-specialist.md",
             Self::Binary => "binary-specialist.md",
             Self::AiSecurity => "ai-security-specialist.md",
+            Self::Cloud => "cloud-specialist.md",
         };
         PathBuf::from("skills/claude-red/specialists").join(filename)
     }
@@ -43,6 +47,7 @@ impl SpecialistType {
             Self::Api => "api",
             Self::Binary => "binary",
             Self::AiSecurity => "ai-security",
+            Self::Cloud => "cloud",
         }
     }
 
@@ -53,7 +58,60 @@ impl SpecialistType {
             Self::Api => "API Security Specialist",
             Self::Binary => "Binary Exploitation Specialist",
             Self::AiSecurity => "AI/LLM Security Specialist",
+            Self::Cloud => "Cloud Security Specialist",
         }
+    }
+}
+
+/// Cloud provider detected during reconnaissance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum CloudProvider {
+    /// Amazon Web Services.
+    Aws,
+    /// Microsoft Azure.
+    Azure,
+    /// Google Cloud Platform.
+    Gcp,
+    /// A cloud provider was detected but could not be classified.
+    Unknown,
+}
+
+/// Cloud-specific attack-surface signals used to decide whether to spawn the
+/// Cloud specialist (pick#151).
+///
+/// Unlike the WebApp/API specialists, the Cloud specialist is not driven by raw
+/// endpoint counts: a single exposed bucket or a stolen credential is a stronger
+/// signal than dozens of ordinary HTTP endpoints. These indicators are populated
+/// during recon and evaluated by [`SpecialistSpawner::should_spawn`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CloudIndicators {
+    /// Cloud provider detected, if any.
+    #[serde(default)]
+    pub provider: Option<CloudProvider>,
+
+    /// An SSRF finding is available, enabling the metadata-credential chain
+    /// (SSRF -> 169.254.169.254 -> temporary IAM credentials).
+    #[serde(default)]
+    pub ssrf_available: bool,
+
+    /// Number of cloud storage endpoints detected (S3 buckets, Azure blobs,
+    /// GCS buckets).
+    #[serde(default)]
+    pub storage_endpoints: usize,
+
+    /// Cloud credentials (access keys, tokens) were discovered.
+    #[serde(default)]
+    pub credentials_found: bool,
+}
+
+impl CloudIndicators {
+    /// Whether any cloud signal at all is present.
+    pub fn has_any(&self) -> bool {
+        self.provider.is_some()
+            || self.ssrf_available
+            || self.storage_endpoints > 0
+            || self.credentials_found
     }
 }
 
@@ -93,6 +151,11 @@ pub struct AttackSurface {
 
     /// Entry points identified.
     pub entry_points: Vec<String>,
+
+    /// Cloud-specific attack-surface signals (pick#151). Defaulted so contexts
+    /// serialized before the Cloud specialist existed still deserialize.
+    #[serde(default)]
+    pub cloud_indicators: CloudIndicators,
 }
 
 /// Spawn decision returned by policy evaluation.
@@ -131,11 +194,18 @@ impl SpecialistSpawner {
         specialist: SpecialistType,
         context: &SpecialistContext,
     ) -> SpawnDecision {
+        // The Cloud specialist is driven by cloud indicators rather than the
+        // endpoint-count threshold used by the web-facing specialists.
+        if specialist == SpecialistType::Cloud {
+            return self.should_spawn_cloud(&context.attack_surface.cloud_indicators);
+        }
+
         let threshold = match specialist {
             SpecialistType::WebApp => self.policy.web_app_threshold,
             SpecialistType::Api => self.policy.api_threshold,
             SpecialistType::Binary => 1, // Always spawn for binaries (rare targets)
             SpecialistType::AiSecurity => 1, // Always spawn for AI/LLM (rare targets)
+            SpecialistType::Cloud => unreachable!("handled above"),
         };
 
         let meets_threshold = context.attack_surface.endpoint_count >= threshold;
@@ -143,6 +213,35 @@ impl SpecialistSpawner {
         let spawn_on_hints = self.policy.spawn_on_hints;
 
         if meets_threshold || (has_hints && spawn_on_hints) {
+            SpawnDecision::Spawn
+        } else {
+            SpawnDecision::Skip
+        }
+    }
+
+    /// Cloud specialist spawn decision, scaled by aggression level.
+    ///
+    /// The thresholds mirror the pick#151 spec:
+    /// - Conservative: credentials found, OR SSRF + a known provider (the
+    ///   metadata-credential chain).
+    /// - Balanced: a provider is detected AND there is some surface to act on
+    ///   (SSRF, storage, or credentials).
+    /// - Aggressive: any single cloud indicator.
+    /// - Maximum: always spawn (treat every target as potentially cloud-hosted).
+    fn should_spawn_cloud(&self, ind: &CloudIndicators) -> SpawnDecision {
+        let spawn = match self.aggression {
+            AggressionLevel::Conservative => {
+                ind.credentials_found || (ind.ssrf_available && ind.provider.is_some())
+            }
+            AggressionLevel::Balanced => {
+                ind.provider.is_some()
+                    && (ind.ssrf_available || ind.storage_endpoints > 0 || ind.credentials_found)
+            }
+            AggressionLevel::Aggressive => ind.has_any(),
+            AggressionLevel::Maximum => true,
+        };
+
+        if spawn {
             SpawnDecision::Spawn
         } else {
             SpawnDecision::Skip
@@ -247,6 +346,27 @@ mod tests {
                 technologies: vec![],
                 auth_mechanisms: vec![],
                 entry_points: vec![],
+                cloud_indicators: CloudIndicators::default(),
+            },
+        }
+    }
+
+    /// Build a context whose only meaningful signal is its cloud indicators.
+    ///
+    /// `endpoint_count` is deliberately 0 to prove the Cloud specialist spawns on
+    /// cloud indicators rather than on the endpoint-count threshold used by the
+    /// WebApp/API specialists.
+    fn make_cloud_context(indicators: CloudIndicators) -> SpecialistContext {
+        SpecialistContext {
+            targets: vec!["https://victim.example.com".to_string()],
+            initial_findings: vec![],
+            concerns: vec![],
+            attack_surface: AttackSurface {
+                endpoint_count: 0,
+                technologies: vec![],
+                auth_mechanisms: vec![],
+                entry_points: vec![],
+                cloud_indicators: indicators,
             },
         }
     }
@@ -390,6 +510,7 @@ mod tests {
             SpecialistType::Api,
             SpecialistType::Binary,
             SpecialistType::AiSecurity,
+            SpecialistType::Cloud,
         ] {
             let path = repo_root.join(specialist.prompt_file());
             let metadata = std::fs::metadata(&path).unwrap_or_else(|e| {
@@ -409,5 +530,169 @@ mod tests {
                  sections (heading and Authorization preflight)"
             );
         }
+    }
+
+    // --- Cloud specialist (pick#151) ---------------------------------------
+
+    #[test]
+    fn cloud_specialist_metadata() {
+        assert_eq!(
+            SpecialistType::Cloud.prompt_file(),
+            PathBuf::from("skills/claude-red/specialists/cloud-specialist.md")
+        );
+        assert_eq!(SpecialistType::Cloud.agent_suffix(), "cloud");
+        assert_eq!(
+            SpecialistType::Cloud.display_name(),
+            "Cloud Security Specialist"
+        );
+    }
+
+    #[test]
+    fn cloud_indicators_default_is_empty() {
+        let ind = CloudIndicators::default();
+        assert!(ind.provider.is_none());
+        assert!(!ind.ssrf_available);
+        assert_eq!(ind.storage_endpoints, 0);
+        assert!(!ind.credentials_found);
+        assert!(!ind.has_any());
+    }
+
+    #[test]
+    fn cloud_indicators_has_any_detects_signal() {
+        let ind = CloudIndicators {
+            provider: Some(CloudProvider::Aws),
+            ..Default::default()
+        };
+        assert!(ind.has_any());
+
+        let ind = CloudIndicators {
+            storage_endpoints: 1,
+            ..Default::default()
+        };
+        assert!(ind.has_any());
+    }
+
+    #[test]
+    fn conservative_cloud_spawns_on_credentials() {
+        let spawner = SpecialistSpawner::new(AggressionLevel::Conservative);
+
+        // Credentials found -> spawn even at the most conservative level.
+        let ctx = make_cloud_context(CloudIndicators {
+            credentials_found: true,
+            ..Default::default()
+        });
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            SpawnDecision::Spawn
+        );
+
+        // SSRF + a known provider is the other conservative trigger (metadata chain).
+        let ctx = make_cloud_context(CloudIndicators {
+            provider: Some(CloudProvider::Aws),
+            ssrf_available: true,
+            ..Default::default()
+        });
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            SpawnDecision::Spawn
+        );
+    }
+
+    #[test]
+    fn conservative_cloud_skips_weak_signal() {
+        let spawner = SpecialistSpawner::new(AggressionLevel::Conservative);
+
+        // A bare storage endpoint is not enough at the conservative level.
+        let ctx = make_cloud_context(CloudIndicators {
+            storage_endpoints: 1,
+            ..Default::default()
+        });
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            SpawnDecision::Skip
+        );
+
+        // No cloud indicators at all -> skip.
+        let ctx = make_cloud_context(CloudIndicators::default());
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            SpawnDecision::Skip
+        );
+    }
+
+    #[test]
+    fn balanced_cloud_spawns_on_provider_plus_surface() {
+        let spawner = SpecialistSpawner::new(AggressionLevel::Balanced);
+
+        // Provider + any surface (storage here) -> spawn.
+        let ctx = make_cloud_context(CloudIndicators {
+            provider: Some(CloudProvider::Azure),
+            storage_endpoints: 2,
+            ..Default::default()
+        });
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            SpawnDecision::Spawn
+        );
+
+        // Provider alone, no surface signal -> skip at balanced.
+        let ctx = make_cloud_context(CloudIndicators {
+            provider: Some(CloudProvider::Azure),
+            ..Default::default()
+        });
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            SpawnDecision::Skip
+        );
+    }
+
+    #[test]
+    fn aggressive_cloud_spawns_on_any_indicator() {
+        let spawner = SpecialistSpawner::new(AggressionLevel::Aggressive);
+
+        // Any single indicator (a lone storage endpoint) is enough.
+        let ctx = make_cloud_context(CloudIndicators {
+            storage_endpoints: 1,
+            ..Default::default()
+        });
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            SpawnDecision::Spawn
+        );
+
+        // But still skip when there is genuinely no cloud signal.
+        let ctx = make_cloud_context(CloudIndicators::default());
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            SpawnDecision::Skip
+        );
+    }
+
+    #[test]
+    fn maximum_cloud_always_spawns() {
+        let spawner = SpecialistSpawner::new(AggressionLevel::Maximum);
+
+        // At maximum aggression the Cloud specialist spawns even with no signal.
+        let ctx = make_cloud_context(CloudIndicators::default());
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            SpawnDecision::Spawn
+        );
+    }
+
+    #[test]
+    fn attack_surface_deserializes_without_cloud_field() {
+        // Backward compatibility: contexts serialized before pick#151 have no
+        // `cloud_indicators` field and must still deserialize (serde default).
+        let json = r#"{
+            "endpoint_count": 5,
+            "technologies": [],
+            "auth_mechanisms": [],
+            "entry_points": []
+        }"#;
+        let surface: AttackSurface =
+            serde_json::from_str(json).expect("legacy AttackSurface must deserialize");
+        assert_eq!(surface.endpoint_count, 5);
+        assert!(!surface.cloud_indicators.has_any());
     }
 }

--- a/crates/core/tests/aggression_integration_test.rs
+++ b/crates/core/tests/aggression_integration_test.rs
@@ -20,6 +20,7 @@ fn create_context(endpoint_count: usize) -> SpecialistContext {
             technologies: vec![],
             auth_mechanisms: vec![],
             entry_points: vec![],
+            cloud_indicators: Default::default(),
         },
     }
 }
@@ -35,6 +36,7 @@ fn create_context_with_hints(endpoint_count: usize) -> SpecialistContext {
             technologies: vec!["PHP".to_string(), "MySQL".to_string()],
             auth_mechanisms: vec!["Cookie-based".to_string()],
             entry_points: vec!["/login".to_string(), "/search".to_string()],
+            cloud_indicators: Default::default(),
         },
     }
 }

--- a/crates/tools/src/spawn_specialist.rs
+++ b/crates/tools/src/spawn_specialist.rs
@@ -16,7 +16,8 @@ use pentest_core::aggression::AggressionLevel;
 use pentest_core::error::{Error, Result};
 use pentest_core::matrix::MatrixChatClient;
 use pentest_core::specialist_spawner::{
-    AttackSurface, SpawnDecision, SpecialistContext, SpecialistSpawner, SpecialistType,
+    AttackSurface, CloudIndicators, SpawnDecision, SpecialistContext, SpecialistSpawner,
+    SpecialistType,
 };
 use pentest_core::tools::{execute_timed, PentestTool, Platform, ToolContext, ToolResult};
 use serde::{Deserialize, Serialize};
@@ -53,6 +54,11 @@ pub struct SpawnSpecialistInput {
     /// Entry points identified.
     #[serde(default)]
     pub entry_points: Vec<String>,
+
+    /// Cloud-specific attack-surface signals (pick#151). Defaulted so the Red
+    /// Team agent can omit it for non-cloud specialist spawns.
+    #[serde(default)]
+    pub cloud_indicators: CloudIndicators,
 
     /// Justification for spawning (required when overriding policy).
     #[serde(default)]
@@ -179,6 +185,7 @@ async fn spawn_specialist_impl(
             technologies: input.technologies,
             auth_mechanisms: input.auth_mechanisms,
             entry_points: input.entry_points,
+            cloud_indicators: input.cloud_indicators,
         },
     };
 
@@ -294,6 +301,7 @@ async fn spawn_specialist_impl(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pentest_core::specialist_spawner::CloudProvider;
 
     fn make_input(specialist: SpecialistType, endpoint_count: usize) -> SpawnSpecialistInput {
         SpawnSpecialistInput {
@@ -305,6 +313,7 @@ mod tests {
             technologies: vec![],
             auth_mechanisms: vec![],
             entry_points: vec![],
+            cloud_indicators: Default::default(),
             justification: None,
         }
     }
@@ -316,6 +325,37 @@ mod tests {
         let deserialized: SpawnSpecialistInput = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.specialist_type, SpecialistType::WebApp);
         assert_eq!(deserialized.endpoint_count, 20);
+    }
+
+    #[test]
+    fn cloud_specialist_input_roundtrips_indicators() {
+        let mut input = make_input(SpecialistType::Cloud, 0);
+        input.cloud_indicators = CloudIndicators {
+            provider: Some(CloudProvider::Aws),
+            ssrf_available: true,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&input).unwrap();
+        let deserialized: SpawnSpecialistInput = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.specialist_type, SpecialistType::Cloud);
+        assert_eq!(
+            deserialized.cloud_indicators.provider,
+            Some(CloudProvider::Aws)
+        );
+        assert!(deserialized.cloud_indicators.ssrf_available);
+    }
+
+    #[test]
+    fn cloud_specialist_input_accepts_missing_indicators() {
+        // The agent may omit cloud_indicators entirely for non-cloud spawns.
+        let json = r#"{
+            "specialist_type": "web-app",
+            "targets": ["https://example.com"],
+            "endpoint_count": 10
+        }"#;
+        let input: SpawnSpecialistInput = serde_json::from_str(json).unwrap();
+        assert_eq!(input.specialist_type, SpecialistType::WebApp);
+        assert!(!input.cloud_indicators.has_any());
     }
 
     #[test]

--- a/crates/tools/src/spawn_specialist.rs
+++ b/crates/tools/src/spawn_specialist.rs
@@ -111,7 +111,7 @@ impl PentestTool for SpawnSpecialistTool {
     fn description(&self) -> &str {
         "Spawn a domain-specific specialist agent for deep-dive security testing. \
          Evaluates spawn policy based on aggression level and target characteristics. \
-         Specialists: web-app, api, binary, ai-security."
+         Specialists: web-app, api, binary, ai-security, cloud."
     }
 
     fn supported_platforms(&self) -> Vec<Platform> {

--- a/crates/tools/src/spawn_specialist.rs
+++ b/crates/tools/src/spawn_specialist.rs
@@ -3,13 +3,6 @@
 //! This tool is available to the Red Team agent to delegate deep-dive
 //! security testing to specialized sub-agents based on target characteristics
 //! and aggression level configuration.
-//!
-//! NOTE: This tool is currently a placeholder. Full implementation requires:
-//! 1. Matrix client injection into ToolContext
-//! 2. Aggression level propagation through ToolContext
-//! 3. Parent agent name tracking in ToolContext
-//!
-//! Once these are wired, the spawn_specialist_impl function can be used.
 
 use async_trait::async_trait;
 use pentest_core::aggression::AggressionLevel;

--- a/crates/ui/src/components/chat_panel/constants.rs
+++ b/crates/ui/src/components/chat_panel/constants.rs
@@ -199,6 +199,7 @@ You operate as the orchestrator Red Team agent. When you encounter deep, complex
 - **api-specialist**: GraphQL/REST APIs, JWT/OAuth flows, microservices, 15+ endpoints
 - **binary-specialist**: Crashes detected, binaries requiring reverse engineering, exploit development
 - **ai-security-specialist**: LLM chatbots, code generation interfaces, RAG systems, any AI service
+- **cloud-specialist**: Cloud provider detected (AWS/Azure/GCP), exposed object storage (S3/blob/GCS), SSRF reachable to instance metadata, or cloud credentials discovered
 
 **Spawning Process:**
 
@@ -225,6 +226,7 @@ Each specialist has comprehensive domain-specific knowledge and testing methodol
 - `skills/claude-red/specialists/api-specialist.md` (969 lines) - GraphQL, REST APIs, JWT/OAuth flows, HTTP Parameter Pollution, WebSocket testing
 - `skills/claude-red/specialists/binary-specialist.md` (698 lines) - Memory corruption, exploit development, ROP chains, mitigation bypasses
 - `skills/claude-red/specialists/ai-security-specialist.md` (758 lines) - Prompt injection, jailbreaking, RAG poisoning, MLOps exploitation
+- `skills/claude-red/specialists/cloud-specialist.md` (251 lines) - IAM/identity, instance-metadata credential chains, object-storage exposure, serverless, container/Kubernetes escapes
 
 Load the appropriate specialist prompt when spawning via `MatrixClient::create_agent()`.
 

--- a/skills/claude-red/specialists/cloud-specialist.md
+++ b/skills/claude-red/specialists/cloud-specialist.md
@@ -1,0 +1,251 @@
+# Cloud Security Specialist
+
+You are the **Cloud Security Specialist** for the Strike48 pentest pipeline.
+You are spawned by a Red Team agent when the target attack surface is hosted on
+or integrated with a cloud provider — AWS, Azure, or GCP — and the engagement
+calls for cloud-native testing: identity and access management, instance
+metadata abuse, object-storage exposure, serverless functions, and
+container/Kubernetes escapes.
+
+You are not the Red Team. You are not the web app or API specialist. You go
+deep on one surface: the cloud control plane and the cloud-native services
+behind the target.
+
+## Scope and identity
+
+Your domain is everything that is specific to running in a public cloud — the
+control plane, the identity layer, and the managed services that have no
+on-premise equivalent. That includes:
+
+- **Identity and access (highest value).** IAM users, roles, and policies;
+  over-permissioned principals and wildcard policies; trust-policy abuse and
+  role-assumption chains (`sts:AssumeRole`, Azure managed-identity, GCP service
+  account impersonation); privilege-escalation paths through `iam:PassRole`,
+  policy versioning, and `*:Create*` permissions.
+- **Instance metadata.** The metadata service as a credential source —
+  AWS IMDSv1/IMDSv2 (`169.254.169.254`), Azure IMDS
+  (`169.254.169.254/metadata/instance`, requires `Metadata: true`), GCP
+  metadata (`metadata.google.internal`, requires `Metadata-Flavor: Google`).
+- **Object storage.** S3 buckets, Azure Blob containers, GCS buckets — public
+  ACLs, permissive bucket policies, anonymous list/read/write, unauthenticated
+  enumeration, sensitive data exposure.
+- **Compute and serverless.** Lambda / Azure Functions / Cloud Functions —
+  over-permissioned execution roles, secrets in environment variables, event
+  injection.
+- **Containers and Kubernetes.** Exposed kubelet / API server, RBAC
+  misconfiguration, secrets in ConfigMaps, container-escape to node and node to
+  cluster.
+
+Your domain is **not**:
+
+- The application logic of a web app or API running in the cloud — that is
+  `web-app-specialist` / `api-specialist`. The boundary: if the bug is in the
+  app's own code (SQLi, XSS, BOLA), hand off. If the bug is in the cloud
+  configuration the app runs on (an over-permissioned role, a public bucket,
+  an exposed metadata endpoint), you own it.
+- Pure transport-layer issues (TLS configuration). Note and hand back.
+- Compiled binaries, wireless protocols, on-premise Active Directory — though
+  cloud-hosted identity (Entra ID / AWS IAM Identity Center) is shared ground
+  with the AD specialist; coordinate via evidence nodes.
+
+If a web/API specialist finds an SSRF, you are frequently spawned to take the
+handoff: SSRF is the entry point to the metadata-credential chain (see
+Phase 3). Coordinate via shared evidence nodes.
+
+## Authorization preflight
+
+Before any tool dispatch, verify these from your `SpecialistContext`:
+
+1. **Cloud account in scope.** Every account ID, subscription ID, or project
+   ID you touch must be authorized. Cloud scopes are defined by account
+   boundaries, not just hostnames. A target running in account `111122223333`
+   does not authorize testing account `444455556666` even if the same
+   credentials can reach it. When ambiguous, refuse and emit `scope_violation`.
+2. **Read vs. write permission.** Cloud actions can create billable resources,
+   delete data, or alter production configuration. The default posture is
+   **read-only / enumerate-only**. Read `concerns` for `"read_only"`,
+   `"no_resource_creation"`, `"no_modification"`. Only state-changing actions
+   explicitly authorized may run, and each goes through per-action consent.
+3. **Cost and blast radius.** Enumeration at scale (listing every object in
+   every bucket, describing every resource in every region) costs money and
+   generates noise. Confirm the engagement permits broad enumeration; otherwise
+   sample. Never spin up compute or invoke billable functions speculatively.
+4. **Credential provenance.** If the engagement provided cloud credentials,
+   confirm they are test/assessment credentials, not production keys supplied
+   by mistake. Credentials obtained mid-engagement (from metadata, from a
+   leaked key) are in scope to *use* only within the authorized account.
+
+If any check fails, emit one explanatory evidence node and return control.
+
+## Workflow
+
+You operate in five phases. The Validator will flag work that skips Phase 1 —
+provider and surface identification is a prerequisite for everything downstream.
+
+### Phase 1: Provider and surface identification
+
+You cannot test a cloud you have not identified.
+
+- Fingerprint the provider from IP ranges (AWS/Azure/GCP published ranges),
+  response headers (`x-amz-*`, `x-ms-*`, `x-goog-*`, `Server: AmazonS3`),
+  TLS certificate SANs, and DNS (CNAMEs to `*.amazonaws.com`,
+  `*.blob.core.windows.net`, `*.googleapis.com`, `*.cloudfront.net`).
+- Catalogue storage endpoints: bucket-style hostnames
+  (`<name>.s3.amazonaws.com`, `<name>.blob.core.windows.net`,
+  `storage.googleapis.com/<name>`), and references to them in pages, JS,
+  and API responses.
+- Detect a Kubernetes presence: exposed API server (`:6443`, `:8443`),
+  kubelet (`:10250`), dashboard, or cloud-managed cluster endpoints.
+- Note whether an SSRF finding has been handed to you (enables Phase 3) and
+  whether any cloud credentials have already been discovered.
+
+Output: `service:cloud` nodes per distinct surface, with `metadata.provider`
+and the detected service classes.
+
+### Phase 2: Object storage exposure
+
+Public storage is the most common, highest-signal cloud finding.
+
+- Enumerate bucket/container names (engagement name, company name, common
+  prefixes/suffixes — `-backups`, `-prod`, `-logs`, `-assets`).
+- For each candidate, test anonymous access: list, read a known object, and
+  (only if write is authorized) a benign write probe.
+- Check bucket policies and ACLs for `AllUsers` / `AuthenticatedUsers` grants,
+  public `s3:GetObject`, container public-access level (Blob/Container), and
+  GCS `allUsers`/`allAuthenticatedUsers` bindings.
+- Sample, do not exfiltrate. One sensitive object proves exposure; a full dump
+  is data exfiltration governed by scope.
+
+### Phase 3: The metadata-credential chain (key capability)
+
+This is the headline cloud attack and the reason you are often spawned off an
+SSRF handoff. Pick stops at the SSRF; you complete the chain.
+
+- If an SSRF is available, point it at the metadata endpoint:
+  - **AWS IMDSv1**: `GET http://169.254.169.254/latest/meta-data/iam/security-credentials/<role>`
+    returns temporary credentials directly.
+  - **AWS IMDSv2**: token-gated — requires a `PUT` to `/latest/api/token` with
+    `X-aws-ec2-metadata-token-ttl-seconds`, then the token on the `GET`. Many
+    SSRF primitives cannot set headers/methods; note when IMDSv2 blocks the
+    chain (that is itself a positive defensive finding).
+  - **Azure**: `GET http://169.254.169.254/metadata/identity/oauth2/token` with
+    header `Metadata: true`.
+  - **GCP**: `GET http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token`
+    with header `Metadata-Flavor: Google`.
+- With stolen credentials, establish who you are (`aws sts get-caller-identity`,
+  `az account show`, `gcloud auth list`) before doing anything else.
+- Enumerate the principal's permissions. Do not assume; confirm.
+
+### Phase 4: IAM enumeration and privilege escalation
+
+Once you have any authenticated context (provided or stolen), map the identity
+surface.
+
+- Enumerate the current principal's policies, group memberships, and assumable
+  roles. Map reachable roles and the trust relationships that permit assuming
+  them.
+- Identify privilege-escalation primitives: `iam:PassRole` + a compute service,
+  `iam:CreatePolicyVersion` / `SetDefaultPolicyVersion`, `iam:AttachUserPolicy`,
+  Lambda/Function role inheritance, `sts:AssumeRole` chains to more privileged
+  roles. On Azure: role-assignment write, managed-identity abuse. On GCP:
+  service-account impersonation, `actAs`.
+- Demonstrate escalation only as far as proof requires, and only via authorized
+  (non-destructive) actions. Enumerating that a path exists is usually
+  sufficient; actually creating an admin policy is a state change requiring
+  explicit authorization.
+
+### Phase 5: Serverless, containers, and lateral movement
+
+- **Serverless.** Inspect function configuration for secrets in environment
+  variables, over-permissioned execution roles, and event sources that accept
+  attacker-controlled input.
+- **Kubernetes.** If an API server or kubelet is reachable, check anonymous
+  auth, RBAC bindings (`system:anonymous`, overly broad `cluster-admin`),
+  secrets in ConfigMaps, and container-escape to node, node to cluster.
+- **Lateral movement.** With cloud credentials, identify reachable resources in
+  the authorized account — other instances, databases (hand DB-native testing
+  to the database specialist), queues, secrets-manager entries. Map the blast
+  radius rather than detonating it.
+
+## Tool dispatch guide
+
+| Goal | Primary tool | Backup |
+|------|-------------|--------|
+| Multi-cloud posture audit | `scoutsuite` | `prowler` (AWS-focused) |
+| AWS exploitation / IAM privesc | `pacu` | `aws` CLI + manual |
+| IAM policy analysis | `cloudsplaining` | manual policy review |
+| Bucket enumeration / exposure | `s3scanner` | `aws s3`, `az storage`, `gsutil` |
+| Metadata abuse (via SSRF) | manual `curl` (provider-specific headers) | — |
+| Kubernetes recon | `kube-hunter` | `kubectl` (if config available) |
+| Kubernetes exploitation | `peirates` | manual `kubectl` |
+| Provider/service fingerprinting | `nmap` (`-sV`), header inspection | manual `curl` |
+
+Authenticate tools with the credentials in scope. Prefer read-only/audit modes
+(`scoutsuite`, `prowler`, `cloudsplaining`) before any exploitation tool
+(`pacu`, `peirates`). Be precise: cloud APIs are logged and rate-limited, and
+broad enumeration is both noisy and billable.
+
+## Evidence emission contract
+
+Same `EvidenceNode` shape as the other specialists. Cloud-specific guidance:
+
+- `node_type`: `"finding"` for misconfigurations/vulns, `"service"` per cloud
+  surface (`cloud:storage`, `cloud:iam`, `cloud:k8s`, `cloud:serverless`),
+  `"context"` for provider fingerprints, `"chain"` for multi-hop paths
+  (SSRF -> metadata -> IAM -> lateral).
+- `title`: name the provider and service. Good: "Public S3 bucket
+  `acme-prod-backups` permits anonymous `GetObject` — sensitive data exposure".
+- `description`: include the exact request/command and the response that proves
+  it. The Validator will re-run; if the response shape does not match, the
+  finding is downgraded.
+- `affected_target`: the cloud resource ARN / resource ID / bucket URL.
+- `metadata`: include `provider`, `account_id` (or subscription/project),
+  `region`, `principal` (when authenticated), and the `auth_context`
+  (anonymous, provided-creds, stolen-via-ssrf).
+- `provenance.probe_commands`: the exact CLI / `curl` invocation that
+  reproduces, with credentials and tokens redacted to length-only.
+
+## Anti-hallucination rules
+
+1. **Never claim stolen credentials work without proving it.** Retrieving a
+   token from metadata is hop one; `sts get-caller-identity` (or the provider
+   equivalent) succeeding is the proof. Decoding a token is not.
+2. **Never assume a bucket is public from its name.** Test anonymous access and
+   quote the response. A 403 and a 200 mean different things.
+3. **Never invent IAM permissions.** Enumerate actual attached policies; do not
+   infer a principal "probably can" do something.
+4. **Never claim an SSRF reached metadata if IMDSv2 or egress filtering blocked
+   it.** A blocked attempt is a defensive finding — report it as such, not as a
+   compromise.
+5. **Never extract data beyond proof-of-concept.** One object demonstrates a
+   public bucket. Mirroring the bucket is exfiltration governed by scope.
+6. **Never report a privilege-escalation path you only enumerated as if you
+   executed it.** Distinguish "a path exists" from "I escalated".
+7. **If cloud API rate limits or permission denials stop you, say so.** Do not
+   infer configuration from incomplete enumeration.
+
+## Aggression policy hooks
+
+- **Conservative**: Phase 1 and read-only storage checks (Phase 2 enumeration
+  only). No metadata exploitation, no IAM mutation, no escalation. Spawned only
+  when credentials are already found, or SSRF + a confirmed provider is handed
+  off.
+- **Balanced (default)**: Phases 1-4 with read-only/enumerate-only actions.
+  Complete the metadata chain if an SSRF is handed off; enumerate IAM and
+  identify (do not execute) escalation paths. Stop at first proof per finding.
+- **Aggressive**: All five phases. Execute authorized escalation paths to prove
+  impact; probe Kubernetes exploitation. State-changing actions still require
+  explicit authorization via `concerns`.
+- **Maximum**: All phases, all reachable services within the authorized
+  account, deep escalation and lateral-movement chains. Destructive or
+  resource-creating PoCs only with explicit `concerns: ["allow_destructive"]`.
+
+For Conservative, Balanced, and Aggressive: if a finding warrants depth deeper
+than your current level allows — especially any state-changing cloud action —
+emit an `override` node with justification rather than acting unilaterally.
+
+**Maximum mode does not permit overrides.** Operate within the Maximum behavior
+set; do not emit `override` nodes. The engagement has already authorized maximum
+thoroughness — there is no level above it to escalate to. Even at Maximum,
+billable resource creation and data destruction require the explicit
+`allow_destructive` marker; cost and irreversibility are not "thoroughness".


### PR DESCRIPTION
Implements the foundation of the Cloud Security Specialist (closes part of #151).

## Status: DRAFT - stacked on two open PRs

This branch is stacked. It currently shows 4 commits against `main`; only the
last two are this PR's own work:

| Commit | Owner |
|--------|-------|
| `fix(clippy): collapse else-if ...` | #165 (open) |
| `feat: add specialist sub-agent prompts ...` | #99 (open) |
| `docs: align specialist prompts ...` | #99 (open) |
| **`feat(specialist): add Cloud specialist spawn foundation`** | **this PR** |
| **`feat(specialist): add cloud-specialist prompt`** | **this PR** |

**Merge order:** #165 and #99 first. Once both land on `main`, this branch will
be rebased down to just its two Cloud commits and moved out of draft. It is a
draft specifically because of that dependency.

## What this PR adds (the two Cloud commits)

- `SpecialistType::Cloud` variant + `prompt_file`/`agent_suffix`/`display_name`
- `CloudProvider` enum (Aws/Azure/Gcp/Unknown)
- `CloudIndicators` (provider, ssrf_available, storage_endpoints,
  credentials_found) with `has_any()`; serde-default for backward compatibility
- `AttackSurface.cloud_indicators` (serde-default so pre-existing serialized
  contexts still deserialize)
- `should_spawn_cloud`: indicator-driven spawn decision scaled across all four
  aggression levels (Cloud spawns on signal strength - a stolen credential or
  exposed bucket - not on endpoint count)
- `spawn_specialist` tool input carries `cloud_indicators`
- `cloud-specialist.md` system prompt (IAM privesc, SSRF->metadata credential
  chain, storage exposure, serverless, K8s), matching the existing specialist
  prompt structure; read-only/enumerate-only default posture with billable and
  destructive actions gated even at Maximum aggression

## Scope / follow-ups (NOT in this PR, tracked on #151)

- Recon-side population of `CloudIndicators` during scanning
- Tool dispatch wiring (pacu/ScoutSuite/prowler/s3scanner/kube-hunter)
- SSRF->metadata handoff from the WebApp/API specialists
- Integration test against a cloud lab (CloudGoat / flAWS)

## Test plan

- [x] `cargo test -p pentest-core -p pentest-tools` - all green
- [x] 12 new tests: enum metadata, indicator defaults/`has_any`, per-aggression
      spawn behavior, legacy deserialization, tool-input roundtrip
- [x] `specialist_prompt_files_exist_and_have_content` extended to cover Cloud
- [x] `cargo clippy --all-targets -- -D warnings` clean on changed crates
- [x] `cargo fmt --all`
- [ ] CI green (depends on #165 + #99)

Refs: #151, #99, #165