### PR TITLE
feat(specialist): Database Security Specialist + SpecialistType refactor (pick#161)

### DIFF
--- a/crates/core/src/specialist_spawner.rs
+++ b/crates/core/src/specialist_spawner.rs
@@ -832,6 +832,7 @@ mod tests {
             (SpecialistType::BINARY, "\"binary\""),
             (SpecialistType::AI_SECURITY, "\"ai-security\""),
             (SpecialistType::CLOUD, "\"cloud\""),
+            (SpecialistType::DATABASE, "\"database\""),
         ];
         for (variant, expected) in cases {
             assert_eq!(serde_json::to_string(&variant).unwrap(), expected);
@@ -1457,16 +1458,33 @@ mod tests {
     #[test]
     fn balanced_database_spawns_on_identified_engine_plus_surface() {
         let spawner = SpecialistSpawner::new(AggressionLevel::Balanced);
-        // Identified engine + any actionable surface (direct exposure here).
-        let ctx = make_database_context(DatabaseIndicators {
-            engines: vec![DbEngine::MySql],
-            direct_exposure: true,
-            ..Default::default()
-        });
-        assert_eq!(
-            spawner.should_spawn(SpecialistType::DATABASE, &ctx),
-            SpawnDecision::Spawn
-        );
+        // Identified engine + any one of the three actionable surface signals
+        // (direct exposure, SQLi, or credentials) must spawn. Exercise each
+        // branch of the OR so a regression dropping one is caught.
+        let surfaces = [
+            DatabaseIndicators {
+                engines: vec![DbEngine::MySql],
+                direct_exposure: true,
+                ..Default::default()
+            },
+            DatabaseIndicators {
+                engines: vec![DbEngine::MySql],
+                sqli_available: true,
+                ..Default::default()
+            },
+            DatabaseIndicators {
+                engines: vec![DbEngine::MySql],
+                credentials_found: true,
+                ..Default::default()
+            },
+        ];
+        for ind in surfaces {
+            let ctx = make_database_context(ind);
+            assert_eq!(
+                spawner.should_spawn(SpecialistType::DATABASE, &ctx),
+                SpawnDecision::Spawn
+            );
+        }
     }
 
     #[test]

--- a/crates/core/src/specialist_spawner.rs
+++ b/crates/core/src/specialist_spawner.rs
@@ -1389,9 +1389,25 @@ mod tests {
     #[test]
     fn conservative_database_spawns_on_credentials() {
         let spawner = SpecialistSpawner::new(AggressionLevel::Conservative);
-        // Discovered DB credentials are actionable on their own, regardless of
-        // engine classification.
+        // Discovered DB credentials are actionable on their own (you can connect
+        // and enumerate) - regardless of engine classification. Only the SQLi
+        // trigger needs an identified engine for takeover.
         let ctx = make_database_context(DatabaseIndicators {
+            credentials_found: true,
+            ..Default::default()
+        });
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::DATABASE, &ctx),
+            SpawnDecision::Spawn
+        );
+
+        // Even with an explicitly *unidentified* engine present, credentials
+        // alone must still spawn. This pins that credentials bypass the
+        // has_identified_engine() requirement - a regression to
+        // `credentials_found && has_identified_engine()` would be caught here
+        // but not by the empty-engines case above (|| short-circuits).
+        let ctx = make_database_context(DatabaseIndicators {
+            engines: vec![DbEngine::Unknown],
             credentials_found: true,
             ..Default::default()
         });

--- a/crates/core/src/specialist_spawner.rs
+++ b/crates/core/src/specialist_spawner.rs
@@ -7,13 +7,37 @@
 use crate::aggression::{AggressionLevel, OverridePolicy, SpawnPolicy};
 use crate::error::{Error, Result};
 use crate::matrix::{AgentInfo, ChatClient, CreateAgentInput};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::path::PathBuf;
 
 /// Domain-specific specialist types available for spawning.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "kebab-case")]
+///
+/// Specialists fall into two spawn-decision families:
+/// - [`ThresholdSpecialist`] are gated by the recon endpoint-count threshold.
+/// - [`IndicatorSpecialist`] are gated by their own attack-surface indicators
+///   (e.g. the Cloud specialist on [`CloudIndicators`]).
+///
+/// Modelling this split at the type level keeps [`SpecialistSpawner::should_spawn`]
+/// dispatch exhaustive - there is no "threshold for an indicator-driven
+/// specialist" case to handle with a panic.
+///
+/// The external serde representation is intentionally a *flat* kebab-case string
+/// (`"web-app"`, `"cloud"`, ...). That string is the LLM's JSON contract for the
+/// `spawn_specialist` tool, so [`Serialize`]/[`Deserialize`] are hand-written to
+/// delegate to the private flat [`SpecialistTypeWire`] enum rather than exposing
+/// the nested structure.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SpecialistType {
+    /// Endpoint-count-driven specialist.
+    ThresholdBased(ThresholdSpecialist),
+    /// Indicator-driven specialist.
+    IndicatorBased(IndicatorSpecialist),
+}
+
+/// Specialists whose spawn decision is driven by the recon endpoint-count
+/// threshold (and concern hints).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ThresholdSpecialist {
     /// Web application security specialist (SQLi, XSS, SSRF, SSTI, XXE, etc.)
     WebApp,
     /// API security specialist (GraphQL, JWT, OAuth, REST vulnerabilities)
@@ -22,20 +46,108 @@ pub enum SpecialistType {
     Binary,
     /// AI/LLM security specialist (prompt injection, RAG poisoning, etc.)
     AiSecurity,
+}
+
+/// Specialists whose spawn decision is driven by their own attack-surface
+/// indicators rather than the endpoint-count threshold.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum IndicatorSpecialist {
     /// Cloud security specialist (IAM, instance-metadata abuse, storage
     /// exposure, serverless, container/K8s escapes). See pick#151.
     Cloud,
+    /// Database security specialist (DBMS config, authn/authz,
+    /// injection-to-takeover, exposure, NoSQL, cloud-managed DBs). See pick#161.
+    Database,
+}
+
+/// Flat wire representation of [`SpecialistType`] - the single source of truth
+/// for the kebab-case strings exchanged with the LLM. Keeping this as a plain
+/// derived enum preserves serde's actionable `unknown variant ... expected one
+/// of ...` error on bad input (which the Red Team agent uses to self-correct).
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum SpecialistTypeWire {
+    WebApp,
+    Api,
+    Binary,
+    AiSecurity,
+    Cloud,
+    Database,
+}
+
+impl From<SpecialistType> for SpecialistTypeWire {
+    fn from(value: SpecialistType) -> Self {
+        match value {
+            SpecialistType::ThresholdBased(ThresholdSpecialist::WebApp) => Self::WebApp,
+            SpecialistType::ThresholdBased(ThresholdSpecialist::Api) => Self::Api,
+            SpecialistType::ThresholdBased(ThresholdSpecialist::Binary) => Self::Binary,
+            SpecialistType::ThresholdBased(ThresholdSpecialist::AiSecurity) => Self::AiSecurity,
+            SpecialistType::IndicatorBased(IndicatorSpecialist::Cloud) => Self::Cloud,
+            SpecialistType::IndicatorBased(IndicatorSpecialist::Database) => Self::Database,
+        }
+    }
+}
+
+impl From<SpecialistTypeWire> for SpecialistType {
+    fn from(value: SpecialistTypeWire) -> Self {
+        match value {
+            SpecialistTypeWire::WebApp => Self::WEB_APP,
+            SpecialistTypeWire::Api => Self::API,
+            SpecialistTypeWire::Binary => Self::BINARY,
+            SpecialistTypeWire::AiSecurity => Self::AI_SECURITY,
+            SpecialistTypeWire::Cloud => Self::CLOUD,
+            SpecialistTypeWire::Database => Self::DATABASE,
+        }
+    }
+}
+
+impl Serialize for SpecialistType {
+    fn serialize<S: Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+        SpecialistTypeWire::from(*self).serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for SpecialistType {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> std::result::Result<Self, D::Error> {
+        SpecialistTypeWire::deserialize(deserializer).map(SpecialistType::from)
+    }
+}
+
+impl From<ThresholdSpecialist> for SpecialistType {
+    fn from(value: ThresholdSpecialist) -> Self {
+        Self::ThresholdBased(value)
+    }
+}
+
+impl From<IndicatorSpecialist> for SpecialistType {
+    fn from(value: IndicatorSpecialist) -> Self {
+        Self::IndicatorBased(value)
+    }
 }
 
 impl SpecialistType {
+    /// Web application security specialist.
+    pub const WEB_APP: Self = Self::ThresholdBased(ThresholdSpecialist::WebApp);
+    /// API security specialist.
+    pub const API: Self = Self::ThresholdBased(ThresholdSpecialist::Api);
+    /// Binary exploitation specialist.
+    pub const BINARY: Self = Self::ThresholdBased(ThresholdSpecialist::Binary);
+    /// AI/LLM security specialist.
+    pub const AI_SECURITY: Self = Self::ThresholdBased(ThresholdSpecialist::AiSecurity);
+    /// Cloud security specialist.
+    pub const CLOUD: Self = Self::IndicatorBased(IndicatorSpecialist::Cloud);
+    /// Database security specialist.
+    pub const DATABASE: Self = Self::IndicatorBased(IndicatorSpecialist::Database);
+
     /// Get the system prompt file path for this specialist.
     pub fn prompt_file(&self) -> PathBuf {
         let filename = match self {
-            Self::WebApp => "web-app-specialist.md",
-            Self::Api => "api-specialist.md",
-            Self::Binary => "binary-specialist.md",
-            Self::AiSecurity => "ai-security-specialist.md",
-            Self::Cloud => "cloud-specialist.md",
+            Self::ThresholdBased(ThresholdSpecialist::WebApp) => "web-app-specialist.md",
+            Self::ThresholdBased(ThresholdSpecialist::Api) => "api-specialist.md",
+            Self::ThresholdBased(ThresholdSpecialist::Binary) => "binary-specialist.md",
+            Self::ThresholdBased(ThresholdSpecialist::AiSecurity) => "ai-security-specialist.md",
+            Self::IndicatorBased(IndicatorSpecialist::Cloud) => "cloud-specialist.md",
+            Self::IndicatorBased(IndicatorSpecialist::Database) => "database-specialist.md",
         };
         PathBuf::from("skills/claude-red/specialists").join(filename)
     }
@@ -43,22 +155,26 @@ impl SpecialistType {
     /// Get the specialist agent name suffix.
     pub fn agent_suffix(&self) -> &'static str {
         match self {
-            Self::WebApp => "web-app",
-            Self::Api => "api",
-            Self::Binary => "binary",
-            Self::AiSecurity => "ai-security",
-            Self::Cloud => "cloud",
+            Self::ThresholdBased(ThresholdSpecialist::WebApp) => "web-app",
+            Self::ThresholdBased(ThresholdSpecialist::Api) => "api",
+            Self::ThresholdBased(ThresholdSpecialist::Binary) => "binary",
+            Self::ThresholdBased(ThresholdSpecialist::AiSecurity) => "ai-security",
+            Self::IndicatorBased(IndicatorSpecialist::Cloud) => "cloud",
+            Self::IndicatorBased(IndicatorSpecialist::Database) => "database",
         }
     }
 
     /// Get human-readable display name.
     pub fn display_name(&self) -> &'static str {
         match self {
-            Self::WebApp => "Web Application Security Specialist",
-            Self::Api => "API Security Specialist",
-            Self::Binary => "Binary Exploitation Specialist",
-            Self::AiSecurity => "AI/LLM Security Specialist",
-            Self::Cloud => "Cloud Security Specialist",
+            Self::ThresholdBased(ThresholdSpecialist::WebApp) => {
+                "Web Application Security Specialist"
+            }
+            Self::ThresholdBased(ThresholdSpecialist::Api) => "API Security Specialist",
+            Self::ThresholdBased(ThresholdSpecialist::Binary) => "Binary Exploitation Specialist",
+            Self::ThresholdBased(ThresholdSpecialist::AiSecurity) => "AI/LLM Security Specialist",
+            Self::IndicatorBased(IndicatorSpecialist::Cloud) => "Cloud Security Specialist",
+            Self::IndicatorBased(IndicatorSpecialist::Database) => "Database Security Specialist",
         }
     }
 }
@@ -125,6 +241,94 @@ impl CloudIndicators {
     }
 }
 
+/// Database engine fingerprinted during reconnaissance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DbEngine {
+    /// PostgreSQL.
+    Postgres,
+    /// MySQL / MariaDB.
+    #[serde(rename = "mysql")]
+    MySql,
+    /// Microsoft SQL Server.
+    #[serde(rename = "mssql")]
+    MsSql,
+    /// Oracle Database.
+    Oracle,
+    /// MongoDB.
+    #[serde(rename = "mongodb")]
+    MongoDb,
+    /// Redis.
+    Redis,
+    /// Elasticsearch.
+    Elasticsearch,
+    /// Memcached.
+    Memcached,
+    /// A database service was detected but the engine could not be classified.
+    Unknown,
+}
+
+impl DbEngine {
+    /// Whether the engine was classified to a specific product. `Unknown` is
+    /// not: engine-specific techniques (default ports, auth model, privesc
+    /// vectors) need a known engine to act on. Analogue of
+    /// [`CloudProvider::is_classified`].
+    pub fn is_identified(self) -> bool {
+        !matches!(self, Self::Unknown)
+    }
+}
+
+/// Database-specific attack-surface signals used to decide whether to spawn the
+/// Database specialist (pick#161).
+///
+/// Like [`CloudIndicators`], the Database specialist is indicator-driven rather
+/// than endpoint-count-driven: a single exposed Mongo/Redis instance or a
+/// confirmed SQLi behind an identified engine is a stronger signal than dozens
+/// of ordinary HTTP endpoints. These indicators are populated during recon and
+/// evaluated by [`SpecialistSpawner::should_spawn`].
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DatabaseIndicators {
+    /// DBMS engine(s) fingerprinted during recon.
+    #[serde(default)]
+    pub engines: Vec<DbEngine>,
+
+    /// A database service is directly network-reachable (exposed port).
+    #[serde(default)]
+    pub direct_exposure: bool,
+
+    /// SQLi confirmed at the app layer, enabling the SQLi -> DB takeover chain.
+    #[serde(default)]
+    pub sqli_available: bool,
+
+    /// Credentials for a database account were discovered.
+    #[serde(default)]
+    pub credentials_found: bool,
+
+    /// The database is a cloud-managed instance (RDS/Aurora/Azure SQL/Cloud
+    /// SQL); coordinate with the Cloud specialist (pick#151) for account-level
+    /// posture.
+    #[serde(default)]
+    pub cloud_managed: bool,
+}
+
+impl DatabaseIndicators {
+    /// Whether any database signal at all is present.
+    pub fn has_any(&self) -> bool {
+        !self.engines.is_empty()
+            || self.direct_exposure
+            || self.sqli_available
+            || self.credentials_found
+            || self.cloud_managed
+    }
+
+    /// Whether at least one fingerprinted engine was classified to a specific
+    /// product (i.e. not `Unknown`). The `Vec` analogue of
+    /// `provider.is_some_and(|p| p.is_classified())` on the Cloud side.
+    pub fn has_identified_engine(&self) -> bool {
+        self.engines.iter().any(|e| e.is_identified())
+    }
+}
+
 impl std::fmt::Display for SpecialistType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.display_name())
@@ -166,6 +370,12 @@ pub struct AttackSurface {
     /// serialized before the Cloud specialist existed still deserialize.
     #[serde(default)]
     pub cloud_indicators: CloudIndicators,
+
+    /// Database-specific attack-surface signals (pick#161). Defaulted so
+    /// contexts serialized before the Database specialist existed still
+    /// deserialize.
+    #[serde(default)]
+    pub database_indicators: DatabaseIndicators,
 }
 
 /// Spawn decision returned by policy evaluation.
@@ -199,27 +409,34 @@ impl SpecialistSpawner {
     }
 
     /// Evaluate whether to spawn a specialist given target characteristics.
+    ///
+    /// Dispatch is exhaustive over the two spawn families: threshold-driven
+    /// specialists go through [`Self::should_spawn_threshold`], indicator-driven
+    /// ones through [`Self::should_spawn_indicator`]. Modelling the split in the
+    /// type ([`SpecialistType`]) is what removes the old "threshold for an
+    /// indicator-driven specialist" arm that previously needed `unreachable!`.
     pub fn should_spawn(
         &self,
         specialist: SpecialistType,
         context: &SpecialistContext,
     ) -> SpawnDecision {
-        // The Cloud specialist is driven by cloud indicators rather than the
-        // endpoint-count threshold used by the web-facing specialists.
-        if specialist == SpecialistType::Cloud {
-            return self.should_spawn_cloud(&context.attack_surface.cloud_indicators);
+        match specialist {
+            SpecialistType::ThresholdBased(t) => self.should_spawn_threshold(t, context),
+            SpecialistType::IndicatorBased(i) => self.should_spawn_indicator(i, context),
         }
+    }
 
+    /// Spawn decision for endpoint-count-driven specialists.
+    fn should_spawn_threshold(
+        &self,
+        specialist: ThresholdSpecialist,
+        context: &SpecialistContext,
+    ) -> SpawnDecision {
         let threshold = match specialist {
-            SpecialistType::WebApp => self.policy.web_app_threshold,
-            SpecialistType::Api => self.policy.api_threshold,
-            SpecialistType::Binary => 1, // Always spawn for binaries (rare targets)
-            SpecialistType::AiSecurity => 1, // Always spawn for AI/LLM (rare targets)
-            SpecialistType::Cloud => {
-                unreachable!(
-                    "Cloud uses cloud_indicators, not endpoint_count; early-returned above"
-                )
-            }
+            ThresholdSpecialist::WebApp => self.policy.web_app_threshold,
+            ThresholdSpecialist::Api => self.policy.api_threshold,
+            ThresholdSpecialist::Binary => 1, // Always spawn for binaries (rare targets)
+            ThresholdSpecialist::AiSecurity => 1, // Always spawn for AI/LLM (rare targets)
         };
 
         let meets_threshold = context.attack_surface.endpoint_count >= threshold;
@@ -230,6 +447,22 @@ impl SpecialistSpawner {
             SpawnDecision::Spawn
         } else {
             SpawnDecision::Skip
+        }
+    }
+
+    /// Spawn decision for indicator-driven specialists.
+    fn should_spawn_indicator(
+        &self,
+        specialist: IndicatorSpecialist,
+        context: &SpecialistContext,
+    ) -> SpawnDecision {
+        match specialist {
+            IndicatorSpecialist::Cloud => {
+                self.should_spawn_cloud(&context.attack_surface.cloud_indicators)
+            }
+            IndicatorSpecialist::Database => {
+                self.should_spawn_database(&context.attack_surface.database_indicators)
+            }
         }
     }
 
@@ -270,6 +503,51 @@ impl SpecialistSpawner {
                 aggression = ?self.aggression,
                 "Cloud specialist skipped: no cloud indicators present. If the target \
                  is cloud-hosted, recon may not have populated indicators."
+            );
+        }
+
+        if spawn {
+            SpawnDecision::Spawn
+        } else {
+            SpawnDecision::Skip
+        }
+    }
+
+    /// Database specialist spawn decision, scaled by aggression level.
+    ///
+    /// Mirrors the pick#161 spec:
+    /// - Conservative: credentials found, OR confirmed SQLi + an *identified*
+    ///   engine (engine-specific takeover needs a known DBMS). Note this differs
+    ///   from the Cloud specialist's Balanced rule: here an unidentified engine
+    ///   never satisfies a conservative trigger.
+    /// - Balanced: an identified engine AND some actionable surface (direct
+    ///   exposure, SQLi, or credentials). Unlike Cloud's Balanced (which allows
+    ///   an `Unknown` provider with surface), the Database specialist requires a
+    ///   classified engine here - engine-native assessment is not actionable
+    ///   without knowing the engine.
+    /// - Aggressive: any single database indicator.
+    /// - Maximum: always spawn.
+    fn should_spawn_database(&self, ind: &DatabaseIndicators) -> SpawnDecision {
+        let spawn = match self.aggression {
+            AggressionLevel::Conservative => {
+                ind.credentials_found || (ind.sqli_available && ind.has_identified_engine())
+            }
+            AggressionLevel::Balanced => {
+                ind.has_identified_engine()
+                    && (ind.direct_exposure || ind.sqli_available || ind.credentials_found)
+            }
+            AggressionLevel::Aggressive => ind.has_any(),
+            AggressionLevel::Maximum => true,
+        };
+
+        // Operator visibility: distinguish a genuine "not a database target"
+        // skip from a recon step that failed to populate indicators (mirrors the
+        // Cloud specialist's skip-path logging).
+        if !spawn && !ind.has_any() {
+            tracing::debug!(
+                aggression = ?self.aggression,
+                "Database specialist skipped: no database indicators present. If the \
+                 target exposes a database, recon may not have populated indicators."
             );
         }
 
@@ -379,6 +657,7 @@ mod tests {
                 auth_mechanisms: vec![],
                 entry_points: vec![],
                 cloud_indicators: CloudIndicators::default(),
+                database_indicators: DatabaseIndicators::default(),
             },
         }
     }
@@ -399,6 +678,28 @@ mod tests {
                 auth_mechanisms: vec![],
                 entry_points: vec![],
                 cloud_indicators: indicators,
+                database_indicators: DatabaseIndicators::default(),
+            },
+        }
+    }
+
+    /// Build a context whose only meaningful signal is its database indicators.
+    ///
+    /// `endpoint_count` is deliberately 0 to prove the Database specialist spawns
+    /// on database indicators rather than on the endpoint-count threshold used by
+    /// the WebApp/API specialists.
+    fn make_database_context(indicators: DatabaseIndicators) -> SpecialistContext {
+        SpecialistContext {
+            targets: vec!["https://victim.example.com".to_string()],
+            initial_findings: vec![],
+            concerns: vec![],
+            attack_surface: AttackSurface {
+                endpoint_count: 0,
+                technologies: vec![],
+                auth_mechanisms: vec![],
+                entry_points: vec![],
+                cloud_indicators: CloudIndicators::default(),
+                database_indicators: indicators,
             },
         }
     }
@@ -410,14 +711,14 @@ mod tests {
 
         // Below threshold (50) - skip
         assert_eq!(
-            spawner.should_spawn(SpecialistType::WebApp, &context),
+            spawner.should_spawn(SpecialistType::WEB_APP, &context),
             SpawnDecision::Skip
         );
 
         // At threshold - spawn
         let context = make_context(50, vec![]);
         assert_eq!(
-            spawner.should_spawn(SpecialistType::WebApp, &context),
+            spawner.should_spawn(SpecialistType::WEB_APP, &context),
             SpawnDecision::Spawn
         );
     }
@@ -429,14 +730,14 @@ mod tests {
         // Below threshold (20) but no hints - skip
         let context = make_context(10, vec![]);
         assert_eq!(
-            spawner.should_spawn(SpecialistType::WebApp, &context),
+            spawner.should_spawn(SpecialistType::WEB_APP, &context),
             SpawnDecision::Skip
         );
 
         // Below threshold but has hints - spawn
         let context = make_context(10, vec!["SQLi suspected"]);
         assert_eq!(
-            spawner.should_spawn(SpecialistType::WebApp, &context),
+            spawner.should_spawn(SpecialistType::WEB_APP, &context),
             SpawnDecision::Spawn
         );
     }
@@ -448,7 +749,7 @@ mod tests {
 
         // Threshold is 5 - spawn
         assert_eq!(
-            spawner.should_spawn(SpecialistType::WebApp, &context),
+            spawner.should_spawn(SpecialistType::WEB_APP, &context),
             SpawnDecision::Spawn
         );
     }
@@ -460,7 +761,7 @@ mod tests {
 
         // Threshold is 1 - always spawn
         assert_eq!(
-            spawner.should_spawn(SpecialistType::WebApp, &context),
+            spawner.should_spawn(SpecialistType::WEB_APP, &context),
             SpawnDecision::Spawn
         );
     }
@@ -472,11 +773,11 @@ mod tests {
 
         // Binary and AI specialists always spawn (rare targets)
         assert_eq!(
-            spawner.should_spawn(SpecialistType::Binary, &context),
+            spawner.should_spawn(SpecialistType::BINARY, &context),
             SpawnDecision::Spawn
         );
         assert_eq!(
-            spawner.should_spawn(SpecialistType::AiSecurity, &context),
+            spawner.should_spawn(SpecialistType::AI_SECURITY, &context),
             SpawnDecision::Spawn
         );
     }
@@ -503,20 +804,61 @@ mod tests {
     #[test]
     fn specialist_prompt_paths() {
         assert_eq!(
-            SpecialistType::WebApp.prompt_file(),
+            SpecialistType::WEB_APP.prompt_file(),
             PathBuf::from("skills/claude-red/specialists/web-app-specialist.md")
         );
         assert_eq!(
-            SpecialistType::Api.prompt_file(),
+            SpecialistType::API.prompt_file(),
             PathBuf::from("skills/claude-red/specialists/api-specialist.md")
         );
         assert_eq!(
-            SpecialistType::Binary.prompt_file(),
+            SpecialistType::BINARY.prompt_file(),
             PathBuf::from("skills/claude-red/specialists/binary-specialist.md")
         );
         assert_eq!(
-            SpecialistType::AiSecurity.prompt_file(),
+            SpecialistType::AI_SECURITY.prompt_file(),
             PathBuf::from("skills/claude-red/specialists/ai-security-specialist.md")
+        );
+    }
+
+    #[test]
+    fn specialist_type_serializes_flat_kebab() {
+        // The external serde form MUST stay flat kebab-case strings - this is the
+        // LLM's JSON contract for the spawn_specialist tool. The refactor to
+        // ThresholdBased | IndicatorBased must not change the wire shape.
+        let cases = [
+            (SpecialistType::WEB_APP, "\"web-app\""),
+            (SpecialistType::API, "\"api\""),
+            (SpecialistType::BINARY, "\"binary\""),
+            (SpecialistType::AI_SECURITY, "\"ai-security\""),
+            (SpecialistType::CLOUD, "\"cloud\""),
+        ];
+        for (variant, expected) in cases {
+            assert_eq!(serde_json::to_string(&variant).unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn specialist_type_deserializes_flat_kebab() {
+        // Round-trips back from the flat strings.
+        assert_eq!(
+            serde_json::from_str::<SpecialistType>("\"web-app\"").unwrap(),
+            SpecialistType::WEB_APP
+        );
+        assert_eq!(
+            serde_json::from_str::<SpecialistType>("\"cloud\"").unwrap(),
+            SpecialistType::CLOUD
+        );
+
+        // An unknown variant must produce serde's actionable "expected one of"
+        // error (which the Red Team agent uses to self-correct). This guards
+        // against an accidental regression to #[serde(untagged)], whose generic
+        // "did not match any variant" message would lose that signal.
+        let err = serde_json::from_str::<SpecialistType>("\"webapp\"").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("expected one of"),
+            "expected an enumerated-variant error, got: {msg}"
         );
     }
 
@@ -538,11 +880,12 @@ mod tests {
         const MIN_PROMPT_BYTES: u64 = 1024;
 
         for specialist in [
-            SpecialistType::WebApp,
-            SpecialistType::Api,
-            SpecialistType::Binary,
-            SpecialistType::AiSecurity,
-            SpecialistType::Cloud,
+            SpecialistType::WEB_APP,
+            SpecialistType::API,
+            SpecialistType::BINARY,
+            SpecialistType::AI_SECURITY,
+            SpecialistType::CLOUD,
+            SpecialistType::DATABASE,
         ] {
             let path = repo_root.join(specialist.prompt_file());
             let metadata = std::fs::metadata(&path).unwrap_or_else(|e| {
@@ -569,12 +912,12 @@ mod tests {
     #[test]
     fn cloud_specialist_metadata() {
         assert_eq!(
-            SpecialistType::Cloud.prompt_file(),
+            SpecialistType::CLOUD.prompt_file(),
             PathBuf::from("skills/claude-red/specialists/cloud-specialist.md")
         );
-        assert_eq!(SpecialistType::Cloud.agent_suffix(), "cloud");
+        assert_eq!(SpecialistType::CLOUD.agent_suffix(), "cloud");
         assert_eq!(
-            SpecialistType::Cloud.display_name(),
+            SpecialistType::CLOUD.display_name(),
             "Cloud Security Specialist"
         );
     }
@@ -625,7 +968,7 @@ mod tests {
             ..Default::default()
         });
         assert_eq!(
-            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            spawner.should_spawn(SpecialistType::CLOUD, &ctx),
             SpawnDecision::Spawn
         );
 
@@ -636,7 +979,7 @@ mod tests {
             ..Default::default()
         });
         assert_eq!(
-            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            spawner.should_spawn(SpecialistType::CLOUD, &ctx),
             SpawnDecision::Spawn
         );
     }
@@ -651,14 +994,14 @@ mod tests {
             ..Default::default()
         });
         assert_eq!(
-            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            spawner.should_spawn(SpecialistType::CLOUD, &ctx),
             SpawnDecision::Skip
         );
 
         // No cloud indicators at all -> skip.
         let ctx = make_cloud_context(CloudIndicators::default());
         assert_eq!(
-            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            spawner.should_spawn(SpecialistType::CLOUD, &ctx),
             SpawnDecision::Skip
         );
     }
@@ -675,7 +1018,7 @@ mod tests {
             ..Default::default()
         });
         assert_eq!(
-            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            spawner.should_spawn(SpecialistType::CLOUD, &ctx),
             SpawnDecision::Skip
         );
 
@@ -685,7 +1028,7 @@ mod tests {
             ..Default::default()
         });
         assert_eq!(
-            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            spawner.should_spawn(SpecialistType::CLOUD, &ctx),
             SpawnDecision::Skip
         );
     }
@@ -706,7 +1049,7 @@ mod tests {
             ..Default::default()
         });
         assert_eq!(
-            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            spawner.should_spawn(SpecialistType::CLOUD, &ctx),
             SpawnDecision::Skip
         );
 
@@ -718,7 +1061,7 @@ mod tests {
             ..Default::default()
         });
         assert_eq!(
-            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            spawner.should_spawn(SpecialistType::CLOUD, &ctx),
             SpawnDecision::Spawn
         );
     }
@@ -738,7 +1081,7 @@ mod tests {
                 ..Default::default()
             });
             assert_eq!(
-                spawner.should_spawn(SpecialistType::Cloud, &ctx),
+                spawner.should_spawn(SpecialistType::CLOUD, &ctx),
                 SpawnDecision::Spawn,
                 "SSRF + {:?} should spawn at Conservative",
                 provider
@@ -759,7 +1102,7 @@ mod tests {
             credentials_found: true,
         });
         assert_eq!(
-            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            spawner.should_spawn(SpecialistType::CLOUD, &ctx),
             SpawnDecision::Skip
         );
     }
@@ -787,7 +1130,7 @@ mod tests {
         ] {
             let ctx = make_cloud_context(ind);
             assert_eq!(
-                spawner.should_spawn(SpecialistType::Cloud, &ctx),
+                spawner.should_spawn(SpecialistType::CLOUD, &ctx),
                 SpawnDecision::Spawn
             );
         }
@@ -805,7 +1148,7 @@ mod tests {
         });
         assert_eq!(ctx.attack_surface.endpoint_count, 0);
         assert_eq!(
-            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            spawner.should_spawn(SpecialistType::CLOUD, &ctx),
             SpawnDecision::Spawn
         );
     }
@@ -821,7 +1164,7 @@ mod tests {
             ..Default::default()
         });
         assert_eq!(
-            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            spawner.should_spawn(SpecialistType::CLOUD, &ctx),
             SpawnDecision::Spawn
         );
 
@@ -831,7 +1174,7 @@ mod tests {
             ..Default::default()
         });
         assert_eq!(
-            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            spawner.should_spawn(SpecialistType::CLOUD, &ctx),
             SpawnDecision::Skip
         );
     }
@@ -853,7 +1196,7 @@ mod tests {
             ..Default::default()
         });
         assert_eq!(
-            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            spawner.should_spawn(SpecialistType::CLOUD, &ctx),
             SpawnDecision::Spawn
         );
 
@@ -867,7 +1210,7 @@ mod tests {
             ..Default::default()
         });
         assert_eq!(
-            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            spawner.should_spawn(SpecialistType::CLOUD, &ctx),
             SpawnDecision::Spawn
         );
 
@@ -877,7 +1220,7 @@ mod tests {
             ..Default::default()
         });
         assert_eq!(
-            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            spawner.should_spawn(SpecialistType::CLOUD, &ctx),
             SpawnDecision::Skip
         );
     }
@@ -892,14 +1235,14 @@ mod tests {
             ..Default::default()
         });
         assert_eq!(
-            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            spawner.should_spawn(SpecialistType::CLOUD, &ctx),
             SpawnDecision::Spawn
         );
 
         // But still skip when there is genuinely no cloud signal.
         let ctx = make_cloud_context(CloudIndicators::default());
         assert_eq!(
-            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            spawner.should_spawn(SpecialistType::CLOUD, &ctx),
             SpawnDecision::Skip
         );
     }
@@ -911,7 +1254,7 @@ mod tests {
         // At maximum aggression the Cloud specialist spawns even with no signal.
         let ctx = make_cloud_context(CloudIndicators::default());
         assert_eq!(
-            spawner.should_spawn(SpecialistType::Cloud, &ctx),
+            spawner.should_spawn(SpecialistType::CLOUD, &ctx),
             SpawnDecision::Spawn
         );
     }
@@ -930,5 +1273,317 @@ mod tests {
             serde_json::from_str(json).expect("legacy AttackSurface must deserialize");
         assert_eq!(surface.endpoint_count, 5);
         assert!(!surface.cloud_indicators.has_any());
+    }
+
+    // --- Database specialist (pick#161) ------------------------------------
+
+    #[test]
+    fn database_specialist_metadata() {
+        assert_eq!(
+            SpecialistType::DATABASE.prompt_file(),
+            PathBuf::from("skills/claude-red/specialists/database-specialist.md")
+        );
+        assert_eq!(SpecialistType::DATABASE.agent_suffix(), "database");
+        assert_eq!(
+            SpecialistType::DATABASE.display_name(),
+            "Database Security Specialist"
+        );
+    }
+
+    #[test]
+    fn db_engine_is_identified() {
+        // Every classified engine is identified; only Unknown is not. A direct
+        // test fails immediately on a `matches!` typo rather than only via a
+        // downstream spawn-decision assertion (mirrors cloud_provider_is_classified).
+        for engine in [
+            DbEngine::Postgres,
+            DbEngine::MySql,
+            DbEngine::MsSql,
+            DbEngine::Oracle,
+            DbEngine::MongoDb,
+            DbEngine::Redis,
+            DbEngine::Elasticsearch,
+            DbEngine::Memcached,
+        ] {
+            assert!(engine.is_identified(), "{engine:?} should be identified");
+        }
+        assert!(!DbEngine::Unknown.is_identified());
+    }
+
+    #[test]
+    fn db_engine_serializes_to_operator_vocabulary() {
+        // Pin the wire strings operators/the LLM use - in particular the
+        // explicit renames that override the kebab default (my-sql/ms-sql/mongo-db).
+        assert_eq!(
+            serde_json::to_string(&DbEngine::Postgres).unwrap(),
+            "\"postgres\""
+        );
+        assert_eq!(
+            serde_json::to_string(&DbEngine::MySql).unwrap(),
+            "\"mysql\""
+        );
+        assert_eq!(
+            serde_json::to_string(&DbEngine::MsSql).unwrap(),
+            "\"mssql\""
+        );
+        assert_eq!(
+            serde_json::to_string(&DbEngine::MongoDb).unwrap(),
+            "\"mongodb\""
+        );
+        assert_eq!(
+            serde_json::from_str::<DbEngine>("\"mysql\"").unwrap(),
+            DbEngine::MySql
+        );
+    }
+
+    #[test]
+    fn database_indicators_default_is_empty() {
+        assert!(!DatabaseIndicators::default().has_any());
+        assert!(!DatabaseIndicators::default().has_identified_engine());
+    }
+
+    #[test]
+    fn database_indicators_has_any_detects_signal() {
+        // Each field alone is a signal.
+        assert!(DatabaseIndicators {
+            engines: vec![DbEngine::Unknown],
+            ..Default::default()
+        }
+        .has_any());
+        assert!(DatabaseIndicators {
+            direct_exposure: true,
+            ..Default::default()
+        }
+        .has_any());
+        assert!(DatabaseIndicators {
+            cloud_managed: true,
+            ..Default::default()
+        }
+        .has_any());
+    }
+
+    #[test]
+    fn database_indicators_has_identified_engine() {
+        // Empty and all-Unknown do NOT count as identified; any classified
+        // engine in the list does. This is the Vec analogue of
+        // provider.is_some_and(|p| p.is_classified()) on the Cloud side.
+        assert!(!DatabaseIndicators::default().has_identified_engine());
+        assert!(!DatabaseIndicators {
+            engines: vec![DbEngine::Unknown],
+            ..Default::default()
+        }
+        .has_identified_engine());
+        assert!(DatabaseIndicators {
+            engines: vec![DbEngine::Postgres],
+            ..Default::default()
+        }
+        .has_identified_engine());
+        assert!(DatabaseIndicators {
+            engines: vec![DbEngine::Unknown, DbEngine::MySql],
+            ..Default::default()
+        }
+        .has_identified_engine());
+    }
+
+    #[test]
+    fn conservative_database_spawns_on_credentials() {
+        let spawner = SpecialistSpawner::new(AggressionLevel::Conservative);
+        // Discovered DB credentials are actionable on their own, regardless of
+        // engine classification.
+        let ctx = make_database_context(DatabaseIndicators {
+            credentials_found: true,
+            ..Default::default()
+        });
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::DATABASE, &ctx),
+            SpawnDecision::Spawn
+        );
+    }
+
+    #[test]
+    fn conservative_database_spawns_on_sqli_with_identified_engine() {
+        let spawner = SpecialistSpawner::new(AggressionLevel::Conservative);
+        // Confirmed SQLi + an identified engine is the takeover-chain trigger.
+        let ctx = make_database_context(DatabaseIndicators {
+            engines: vec![DbEngine::Postgres],
+            sqli_available: true,
+            ..Default::default()
+        });
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::DATABASE, &ctx),
+            SpawnDecision::Spawn
+        );
+    }
+
+    #[test]
+    fn conservative_database_skips_sqli_with_unknown_engine() {
+        // The conservative takeover trigger needs an *identified* engine -
+        // engine-specific privesc/file-read is not actionable against an
+        // unclassified engine. SQLi + only Unknown must skip. This is the
+        // Database analogue of conservative_cloud_skips_unknown_provider_ssrf
+        // and pins the has_identified_engine() predicate.
+        let spawner = SpecialistSpawner::new(AggressionLevel::Conservative);
+        let ctx = make_database_context(DatabaseIndicators {
+            engines: vec![DbEngine::Unknown],
+            sqli_available: true,
+            ..Default::default()
+        });
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::DATABASE, &ctx),
+            SpawnDecision::Skip
+        );
+    }
+
+    #[test]
+    fn conservative_database_skips_weak_signal() {
+        let spawner = SpecialistSpawner::new(AggressionLevel::Conservative);
+        // Bare direct exposure is not enough at the conservative level.
+        let ctx = make_database_context(DatabaseIndicators {
+            direct_exposure: true,
+            ..Default::default()
+        });
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::DATABASE, &ctx),
+            SpawnDecision::Skip
+        );
+        // No indicators at all -> skip.
+        let ctx = make_database_context(DatabaseIndicators::default());
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::DATABASE, &ctx),
+            SpawnDecision::Skip
+        );
+    }
+
+    #[test]
+    fn balanced_database_spawns_on_identified_engine_plus_surface() {
+        let spawner = SpecialistSpawner::new(AggressionLevel::Balanced);
+        // Identified engine + any actionable surface (direct exposure here).
+        let ctx = make_database_context(DatabaseIndicators {
+            engines: vec![DbEngine::MySql],
+            direct_exposure: true,
+            ..Default::default()
+        });
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::DATABASE, &ctx),
+            SpawnDecision::Spawn
+        );
+    }
+
+    #[test]
+    fn balanced_database_skips_unknown_engine_with_surface() {
+        // Database DIFFERS from Cloud here: the Cloud specialist's Balanced rule
+        // allows an `Unknown` provider with surface, but the Database
+        // specialist's Balanced rule requires an *identified* engine - engine-
+        // native assessment is not actionable without knowing the engine. An
+        // unidentified engine + surface must skip. Pins that divergence so a
+        // future copy-paste from the Cloud arm cannot loosen it.
+        let spawner = SpecialistSpawner::new(AggressionLevel::Balanced);
+        let ctx = make_database_context(DatabaseIndicators {
+            engines: vec![DbEngine::Unknown],
+            direct_exposure: true,
+            sqli_available: true,
+            ..Default::default()
+        });
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::DATABASE, &ctx),
+            SpawnDecision::Skip
+        );
+    }
+
+    #[test]
+    fn balanced_database_skips_engine_without_surface() {
+        let spawner = SpecialistSpawner::new(AggressionLevel::Balanced);
+        // An identified engine with no actionable surface signal -> skip.
+        let ctx = make_database_context(DatabaseIndicators {
+            engines: vec![DbEngine::Postgres],
+            ..Default::default()
+        });
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::DATABASE, &ctx),
+            SpawnDecision::Skip
+        );
+    }
+
+    #[test]
+    fn aggressive_database_spawns_on_each_indicator_in_isolation() {
+        // Aggressive spawns on any single indicator, including a lone Unknown
+        // engine - has_any() must check every field.
+        let spawner = SpecialistSpawner::new(AggressionLevel::Aggressive);
+        for ind in [
+            DatabaseIndicators {
+                engines: vec![DbEngine::Unknown],
+                ..Default::default()
+            },
+            DatabaseIndicators {
+                direct_exposure: true,
+                ..Default::default()
+            },
+            DatabaseIndicators {
+                sqli_available: true,
+                ..Default::default()
+            },
+            DatabaseIndicators {
+                credentials_found: true,
+                ..Default::default()
+            },
+            DatabaseIndicators {
+                cloud_managed: true,
+                ..Default::default()
+            },
+        ] {
+            let ctx = make_database_context(ind);
+            assert_eq!(
+                spawner.should_spawn(SpecialistType::DATABASE, &ctx),
+                SpawnDecision::Spawn
+            );
+        }
+        // But still skip when there is genuinely no database signal.
+        let ctx = make_database_context(DatabaseIndicators::default());
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::DATABASE, &ctx),
+            SpawnDecision::Skip
+        );
+    }
+
+    #[test]
+    fn maximum_database_always_spawns() {
+        let spawner = SpecialistSpawner::new(AggressionLevel::Maximum);
+        let ctx = make_database_context(DatabaseIndicators::default());
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::DATABASE, &ctx),
+            SpawnDecision::Spawn
+        );
+    }
+
+    #[test]
+    fn database_spawn_is_independent_of_endpoint_count() {
+        // make_database_context sets endpoint_count = 0; a spawn on a database
+        // signal proves Database does not fall through to endpoint-threshold logic.
+        let spawner = SpecialistSpawner::new(AggressionLevel::Aggressive);
+        let ctx = make_database_context(DatabaseIndicators {
+            engines: vec![DbEngine::Redis],
+            direct_exposure: true,
+            ..Default::default()
+        });
+        assert_eq!(ctx.attack_surface.endpoint_count, 0);
+        assert_eq!(
+            spawner.should_spawn(SpecialistType::DATABASE, &ctx),
+            SpawnDecision::Spawn
+        );
+    }
+
+    #[test]
+    fn attack_surface_deserializes_without_database_field() {
+        // Backward compatibility: contexts serialized before pick#161 have no
+        // `database_indicators` field and must still deserialize (serde default).
+        let json = r#"{
+            "endpoint_count": 5,
+            "technologies": [],
+            "auth_mechanisms": [],
+            "entry_points": []
+        }"#;
+        let surface: AttackSurface =
+            serde_json::from_str(json).expect("legacy AttackSurface must deserialize");
+        assert!(!surface.database_indicators.has_any());
     }
 }

--- a/crates/core/tests/aggression_integration_test.rs
+++ b/crates/core/tests/aggression_integration_test.rs
@@ -21,6 +21,7 @@ fn create_context(endpoint_count: usize) -> SpecialistContext {
             auth_mechanisms: vec![],
             entry_points: vec![],
             cloud_indicators: Default::default(),
+            database_indicators: Default::default(),
         },
     }
 }
@@ -37,6 +38,7 @@ fn create_context_with_hints(endpoint_count: usize) -> SpecialistContext {
             auth_mechanisms: vec!["Cookie-based".to_string()],
             entry_points: vec!["/login".to_string(), "/search".to_string()],
             cloud_indicators: Default::default(),
+            database_indicators: Default::default(),
         },
     }
 }
@@ -47,7 +49,7 @@ fn test_conservative_skips_small_targets() {
 
     // Conservative requires 50+ endpoints for web-app
     let small_context = create_context(20);
-    let decision = spawner.should_spawn(SpecialistType::WebApp, &small_context);
+    let decision = spawner.should_spawn(SpecialistType::WEB_APP, &small_context);
     assert_eq!(
         decision,
         SpawnDecision::Skip,
@@ -56,7 +58,7 @@ fn test_conservative_skips_small_targets() {
 
     // Should spawn for 50+ endpoints
     let large_context = create_context(50);
-    let decision = spawner.should_spawn(SpecialistType::WebApp, &large_context);
+    let decision = spawner.should_spawn(SpecialistType::WEB_APP, &large_context);
     assert_eq!(
         decision,
         SpawnDecision::Spawn,
@@ -70,7 +72,7 @@ fn test_conservative_ignores_hints() {
 
     // Conservative does NOT spawn on hints alone (spawn_on_hints=false)
     let context_with_hints = create_context_with_hints(20);
-    let decision = spawner.should_spawn(SpecialistType::WebApp, &context_with_hints);
+    let decision = spawner.should_spawn(SpecialistType::WEB_APP, &context_with_hints);
     assert_eq!(
         decision,
         SpawnDecision::Skip,
@@ -84,7 +86,7 @@ fn test_balanced_spawns_on_moderate_targets() {
 
     // Balanced requires 20+ endpoints for web-app
     let small_context = create_context(10);
-    let decision = spawner.should_spawn(SpecialistType::WebApp, &small_context);
+    let decision = spawner.should_spawn(SpecialistType::WEB_APP, &small_context);
     assert_eq!(
         decision,
         SpawnDecision::Skip,
@@ -93,7 +95,7 @@ fn test_balanced_spawns_on_moderate_targets() {
 
     // Should spawn for 20+ endpoints
     let moderate_context = create_context(20);
-    let decision = spawner.should_spawn(SpecialistType::WebApp, &moderate_context);
+    let decision = spawner.should_spawn(SpecialistType::WEB_APP, &moderate_context);
     assert_eq!(
         decision,
         SpawnDecision::Spawn,
@@ -107,7 +109,7 @@ fn test_balanced_spawns_on_hints() {
 
     // Balanced DOES spawn on hints (spawn_on_hints=true)
     let context_with_hints = create_context_with_hints(10);
-    let decision = spawner.should_spawn(SpecialistType::WebApp, &context_with_hints);
+    let decision = spawner.should_spawn(SpecialistType::WEB_APP, &context_with_hints);
     assert_eq!(
         decision,
         SpawnDecision::Spawn,
@@ -121,7 +123,7 @@ fn test_aggressive_spawns_liberally() {
 
     // Aggressive requires only 5+ endpoints for web-app
     let tiny_context = create_context(3);
-    let decision = spawner.should_spawn(SpecialistType::WebApp, &tiny_context);
+    let decision = spawner.should_spawn(SpecialistType::WEB_APP, &tiny_context);
     assert_eq!(
         decision,
         SpawnDecision::Skip,
@@ -130,7 +132,7 @@ fn test_aggressive_spawns_liberally() {
 
     // Should spawn for 5+ endpoints
     let small_context = create_context(5);
-    let decision = spawner.should_spawn(SpecialistType::WebApp, &small_context);
+    let decision = spawner.should_spawn(SpecialistType::WEB_APP, &small_context);
     assert_eq!(
         decision,
         SpawnDecision::Spawn,
@@ -139,7 +141,7 @@ fn test_aggressive_spawns_liberally() {
 
     // Should definitely spawn with hints
     let context_with_hints = create_context_with_hints(3);
-    let decision = spawner.should_spawn(SpecialistType::WebApp, &context_with_hints);
+    let decision = spawner.should_spawn(SpecialistType::WEB_APP, &context_with_hints);
     assert_eq!(
         decision,
         SpawnDecision::Spawn,
@@ -153,7 +155,7 @@ fn test_maximum_spawns_everything() {
 
     // Maximum spawns for ANY target (threshold = 1)
     let minimal_context = create_context(1);
-    let decision = spawner.should_spawn(SpecialistType::WebApp, &minimal_context);
+    let decision = spawner.should_spawn(SpecialistType::WEB_APP, &minimal_context);
     assert_eq!(
         decision,
         SpawnDecision::Spawn,
@@ -162,7 +164,7 @@ fn test_maximum_spawns_everything() {
 
     // Even with zero endpoints, should spawn on hints
     let hints_only = create_context_with_hints(0);
-    let decision = spawner.should_spawn(SpecialistType::WebApp, &hints_only);
+    let decision = spawner.should_spawn(SpecialistType::WEB_APP, &hints_only);
     assert_eq!(
         decision,
         SpawnDecision::Spawn,
@@ -177,25 +179,25 @@ fn test_api_specialist_thresholds() {
     // Conservative: 30+ for API (vs 50+ for web-app)
     let conservative = SpecialistSpawner::new(AggressionLevel::Conservative);
     let context_25 = create_context(25);
-    let decision = conservative.should_spawn(SpecialistType::Api, &context_25);
+    let decision = conservative.should_spawn(SpecialistType::API, &context_25);
     assert_eq!(decision, SpawnDecision::Skip);
     let context_30 = create_context(30);
-    let decision = conservative.should_spawn(SpecialistType::Api, &context_30);
+    let decision = conservative.should_spawn(SpecialistType::API, &context_30);
     assert_eq!(decision, SpawnDecision::Spawn);
 
     // Balanced: 15+ for API (vs 20+ for web-app)
     let balanced = SpecialistSpawner::new(AggressionLevel::Balanced);
     let context_10 = create_context(10);
-    let decision = balanced.should_spawn(SpecialistType::Api, &context_10);
+    let decision = balanced.should_spawn(SpecialistType::API, &context_10);
     assert_eq!(decision, SpawnDecision::Skip);
     let context_15 = create_context(15);
-    let decision = balanced.should_spawn(SpecialistType::Api, &context_15);
+    let decision = balanced.should_spawn(SpecialistType::API, &context_15);
     assert_eq!(decision, SpawnDecision::Spawn);
 
     // Aggressive: 5+ for API (same as web-app)
     let aggressive = SpecialistSpawner::new(AggressionLevel::Aggressive);
     let context_5 = create_context(5);
-    let decision = aggressive.should_spawn(SpecialistType::Api, &context_5);
+    let decision = aggressive.should_spawn(SpecialistType::API, &context_5);
     assert_eq!(decision, SpawnDecision::Spawn);
 }
 
@@ -207,14 +209,14 @@ fn test_binary_and_ai_always_spawn() {
     let conservative = SpecialistSpawner::new(AggressionLevel::Conservative);
     let minimal_context = create_context(1);
 
-    let binary_decision = conservative.should_spawn(SpecialistType::Binary, &minimal_context);
+    let binary_decision = conservative.should_spawn(SpecialistType::BINARY, &minimal_context);
     assert_eq!(
         binary_decision,
         SpawnDecision::Spawn,
         "Binary specialist should always spawn when needed"
     );
 
-    let ai_decision = conservative.should_spawn(SpecialistType::AiSecurity, &minimal_context);
+    let ai_decision = conservative.should_spawn(SpecialistType::AI_SECURITY, &minimal_context);
     assert_eq!(
         ai_decision,
         SpawnDecision::Spawn,

--- a/crates/tools/src/spawn_specialist.rs
+++ b/crates/tools/src/spawn_specialist.rs
@@ -9,8 +9,8 @@ use pentest_core::aggression::AggressionLevel;
 use pentest_core::error::{Error, Result};
 use pentest_core::matrix::MatrixChatClient;
 use pentest_core::specialist_spawner::{
-    AttackSurface, CloudIndicators, SpawnDecision, SpecialistContext, SpecialistSpawner,
-    SpecialistType,
+    AttackSurface, CloudIndicators, DatabaseIndicators, SpawnDecision, SpecialistContext,
+    SpecialistSpawner, SpecialistType,
 };
 use pentest_core::tools::{execute_timed, PentestTool, Platform, ToolContext, ToolResult};
 use serde::{Deserialize, Serialize};
@@ -52,6 +52,11 @@ pub struct SpawnSpecialistInput {
     /// Team agent can omit it for non-cloud specialist spawns.
     #[serde(default)]
     pub cloud_indicators: CloudIndicators,
+
+    /// Database-specific attack-surface signals (pick#161). Defaulted so the
+    /// Red Team agent can omit it for non-database specialist spawns.
+    #[serde(default)]
+    pub database_indicators: DatabaseIndicators,
 
     /// Justification for spawning (required when overriding policy).
     #[serde(default)]
@@ -104,7 +109,7 @@ impl PentestTool for SpawnSpecialistTool {
     fn description(&self) -> &str {
         "Spawn a domain-specific specialist agent for deep-dive security testing. \
          Evaluates spawn policy based on aggression level and target characteristics. \
-         Specialists: web-app, api, binary, ai-security, cloud."
+         Specialists: web-app, api, binary, ai-security, cloud, database."
     }
 
     fn supported_platforms(&self) -> Vec<Platform> {
@@ -179,6 +184,7 @@ async fn spawn_specialist_impl(
             auth_mechanisms: input.auth_mechanisms,
             entry_points: input.entry_points,
             cloud_indicators: input.cloud_indicators,
+            database_indicators: input.database_indicators,
         },
     };
 
@@ -307,22 +313,23 @@ mod tests {
             auth_mechanisms: vec![],
             entry_points: vec![],
             cloud_indicators: Default::default(),
+            database_indicators: Default::default(),
             justification: None,
         }
     }
 
     #[test]
     fn spawn_specialist_input_serialization() {
-        let input = make_input(SpecialistType::WebApp, 20);
+        let input = make_input(SpecialistType::WEB_APP, 20);
         let json = serde_json::to_string(&input).unwrap();
         let deserialized: SpawnSpecialistInput = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized.specialist_type, SpecialistType::WebApp);
+        assert_eq!(deserialized.specialist_type, SpecialistType::WEB_APP);
         assert_eq!(deserialized.endpoint_count, 20);
     }
 
     #[test]
     fn cloud_specialist_input_roundtrips_indicators() {
-        let mut input = make_input(SpecialistType::Cloud, 0);
+        let mut input = make_input(SpecialistType::CLOUD, 0);
         input.cloud_indicators = CloudIndicators {
             provider: Some(CloudProvider::Aws),
             ssrf_available: true,
@@ -330,12 +337,31 @@ mod tests {
         };
         let json = serde_json::to_string(&input).unwrap();
         let deserialized: SpawnSpecialistInput = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized.specialist_type, SpecialistType::Cloud);
+        assert_eq!(deserialized.specialist_type, SpecialistType::CLOUD);
         assert_eq!(
             deserialized.cloud_indicators.provider,
             Some(CloudProvider::Aws)
         );
         assert!(deserialized.cloud_indicators.ssrf_available);
+    }
+
+    #[test]
+    fn database_specialist_input_roundtrips_indicators() {
+        use pentest_core::specialist_spawner::{DatabaseIndicators, DbEngine};
+        let mut input = make_input(SpecialistType::DATABASE, 0);
+        input.database_indicators = DatabaseIndicators {
+            engines: vec![DbEngine::Postgres],
+            sqli_available: true,
+            ..Default::default()
+        };
+        let json = serde_json::to_string(&input).unwrap();
+        let deserialized: SpawnSpecialistInput = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.specialist_type, SpecialistType::DATABASE);
+        assert_eq!(
+            deserialized.database_indicators.engines,
+            vec![DbEngine::Postgres]
+        );
+        assert!(deserialized.database_indicators.sqli_available);
     }
 
     #[test]
@@ -347,7 +373,7 @@ mod tests {
             "endpoint_count": 10
         }"#;
         let input: SpawnSpecialistInput = serde_json::from_str(json).unwrap();
-        assert_eq!(input.specialist_type, SpecialistType::WebApp);
+        assert_eq!(input.specialist_type, SpecialistType::WEB_APP);
         assert!(!input.cloud_indicators.has_any());
     }
 

--- a/crates/ui/src/components/chat_panel/constants.rs
+++ b/crates/ui/src/components/chat_panel/constants.rs
@@ -200,6 +200,7 @@ You operate as the orchestrator Red Team agent. When you encounter deep, complex
 - **binary-specialist**: Crashes detected, binaries requiring reverse engineering, exploit development
 - **ai-security-specialist**: LLM chatbots, code generation interfaces, RAG systems, any AI service
 - **cloud-specialist**: Cloud provider detected (AWS/Azure/GCP), exposed object storage (S3/blob/GCS), SSRF reachable to instance metadata, or cloud credentials discovered
+- **database-specialist**: Direct database exposure (open 5432/3306/1433/27017/6379/9200), SQLi confirmed against an identified engine (takeover handoff), database credentials discovered, or a cloud-managed database (RDS/Cloud SQL/Cosmos) in scope
 
 **Spawning Process:**
 
@@ -227,6 +228,7 @@ Each specialist has comprehensive domain-specific knowledge and testing methodol
 - `skills/claude-red/specialists/binary-specialist.md` (698 lines) - Memory corruption, exploit development, ROP chains, mitigation bypasses
 - `skills/claude-red/specialists/ai-security-specialist.md` (758 lines) - Prompt injection, jailbreaking, RAG poisoning, MLOps exploitation
 - `skills/claude-red/specialists/cloud-specialist.md` (251 lines) - IAM/identity, instance-metadata credential chains, object-storage exposure, serverless, container/Kubernetes escapes
+- `skills/claude-red/specialists/database-specialist.md` (235 lines) - DBMS authn/authz, default/weak creds, SQLi-to-takeover chain, in-DB privesc, exposed NoSQL, cloud-managed DBs
 
 Load the appropriate specialist prompt when spawning via `MatrixClient::create_agent()`.
 

--- a/skills/claude-red/specialists/database-specialist.md
+++ b/skills/claude-red/specialists/database-specialist.md
@@ -1,0 +1,235 @@
+# Database Security Specialist
+
+You are the **Database Security Specialist** for the Strike48 pentest pipeline.
+You are spawned by a Red Team agent when a database is a first-class attack
+surface: a directly reachable DB service, a confirmed SQL injection that can be
+driven into the database tier, discovered database credentials, or a
+cloud-managed database in scope. You assess the database's own security posture
+and complete the injection-to-takeover chain that the web/API specialists stop
+short of.
+
+You are not the Red Team. You are not the web app or API specialist. You go deep
+on one surface: the database engine, its authentication and authorization, its
+configuration and exposure, and the data it holds.
+
+## Scope and identity
+
+Your domain is everything specific to the database tier - the engine, its access
+model, and its native attack surface. That includes:
+
+- **Relational engines** (highest value). PostgreSQL, MySQL/MariaDB, Microsoft
+  SQL Server, Oracle: default/weak/reused credentials, anonymous access,
+  authentication misconfiguration (`trust` auth, permissive `host all all`
+  rules), over-privileged accounts and `PUBLIC` grants, role-hierarchy abuse,
+  and in-DB privilege escalation (MSSQL `xp_cmdshell`, PostgreSQL
+  `COPY ... PROGRAM` / `pg_read_file` / untrusted-language UDFs, MySQL `INTO
+  OUTFILE` / UDF, Oracle `DBMS_*` packages).
+- **NoSQL and cache** (the classic open instances). MongoDB, Redis,
+  Elasticsearch, Memcached: unauthenticated/exposed instances, NoSQL operator
+  and JavaScript injection, Redis RCE vectors (config rewrite, module load -
+  flagged, not auto-fired), Elasticsearch open-index data exposure.
+- **Cloud-managed databases.** RDS/Aurora, Azure SQL, Cloud SQL: public
+  accessibility and security-group exposure, IAM-based DB-auth misconfiguration,
+  snapshot/backup exposure. The cloud *account* posture belongs to the Cloud
+  specialist; you own the *database-native* assessment and coordinate via the
+  evidence graph.
+- **The SQLi -> DB takeover chain.** When a web/API specialist confirms SQLi,
+  you take the handoff and go past the web tier: fingerprint the DBMS, enumerate
+  the current user and privileges, escalate in-DB where authorized, and (where
+  authorized) demonstrate file read / command execution.
+
+Your domain is **not**:
+
+- The application logic in front of the database - finding SQLi in the app's own
+  code is `web-app-specialist` / `api-specialist`. The boundary: if the bug is in
+  the application (the injectable parameter), they own discovery; once injection
+  is confirmed, the database-tier exploitation (engine fingerprint, privilege
+  enumeration, takeover) is yours.
+- Cloud account configuration (IAM, security groups, snapshots at the account
+  level) - that is `cloud-specialist`. Coordinate on cloud-managed databases via
+  shared evidence nodes.
+- Host-level post-exploitation once you break out of the database - hand the
+  resulting shell/credentials back for the next stage.
+
+If a web/API specialist confirms SQLi, you are frequently spawned to take the
+handoff: SQLi is the entry point to the database-takeover chain (see Phase 3).
+Coordinate via shared evidence nodes.
+
+## Authorization preflight
+
+Before any tool dispatch, verify these from your `SpecialistContext`:
+
+1. **Database instance in scope.** Every host, port, and database/instance name
+   you touch must be authorized. A reachable database is not an in-scope
+   database. When ambiguous, refuse and emit `scope_violation`.
+2. **Read vs. write permission.** This is the critical control for databases:
+   queries can destroy data by accident. The default posture is
+   **read-only / enumerate-only**. No `INSERT`/`UPDATE`/`DELETE`/`DROP`/
+   `TRUNCATE`/`ALTER` and no schema or configuration mutation without an explicit
+   per-action authorization marker in `concerns` (e.g. `"allow_destructive"`),
+   surfaced through the Engagement Gateway. Read `concerns` for `"read_only"`,
+   `"no_modification"`, `"no_destructive"`.
+3. **Data minimization.** Sensitive-data discovery proves exposure with a sampled
+   row count and masked values - never a full table dump. Exfiltrating data is
+   governed by scope, not implied by read access.
+4. **Cost and load awareness.** Heavy scans, large `JOIN`s, or full-table reads
+   against a production or cloud-managed database can degrade service or incur
+   cost. Sample; never run load-generating queries speculatively.
+5. **Credential provenance.** Credentials provided for the engagement, or
+   obtained mid-engagement (from a config file, a leaked key, an injection), are
+   in scope to *use* only against the authorized instances.
+
+If any check fails, emit one explanatory evidence node and return control.
+
+## Workflow
+
+You operate in five phases. The Validator will flag work that skips Phase 1 -
+engine and exposure identification is a prerequisite for everything downstream.
+
+### Phase 1: Engine and exposure identification
+
+You cannot test a database you have not identified.
+
+- Fingerprint the engine and version from service banners, default ports
+  (Postgres `5432`, MySQL `3306`, MSSQL `1433`, Oracle `1521`, MongoDB `27017`,
+  Redis `6379`, Elasticsearch `9200`, Memcached `11211`), and protocol probes
+  (`nmap` `*-info` / `ms-sql-*` / `mysql-*` / `mongodb-*` / `redis-info` NSE).
+- Determine reachability: is the database directly network-reachable, or only
+  via an application (SQLi handoff)? Note whether it is a cloud-managed instance.
+- Note whether a SQLi finding has been handed to you (enables Phase 3) and
+  whether any database credentials have already been discovered.
+
+Output: `service:database` nodes per distinct instance, with `metadata.engine`
+and the detected version/exposure.
+
+### Phase 2: Authentication and direct exposure
+
+The open database is the most common, highest-signal database finding.
+
+- Test for unauthenticated/anonymous access (the classic open Mongo/Redis/ES).
+  Quote the response that proves it.
+- Test default, weak, and reused credentials against the engine (engine-aware,
+  rate-limited).
+- Check authentication configuration where reachable: Postgres `pg_hba.conf`
+  `trust` rules, MySQL anonymous accounts, MSSQL mixed-mode and `sa`, Redis
+  `requirepass` absence.
+
+### Phase 3: SQLi -> DB takeover (key capability)
+
+This is the headline database attack and the reason you are often spawned off a
+SQLi handoff. The web/API specialist stops at the injection; you complete the
+chain.
+
+- Fingerprint the DBMS and version behind the injection.
+- Enumerate the current DB user, its privileges, and reachable schemas - confirm,
+  do not assume.
+- Identify engine-specific privilege-escalation and takeover primitives:
+  MSSQL `xp_cmdshell` / linked servers, PostgreSQL `COPY ... PROGRAM` /
+  `pg_read_file` / untrusted-language functions, MySQL `INTO OUTFILE` / UDF,
+  Oracle `DBMS_*` / Java stored procedures.
+- Where authorized, demonstrate file read / command execution to the depth proof
+  requires - and no further.
+
+### Phase 4: Privilege and data enumeration
+
+Once you have any authenticated context (provided, default-cred, or via
+injection):
+
+- Enumerate roles, grants, and the privilege hierarchy. Identify over-privileged
+  accounts and `PUBLIC`/`AllUsers`-equivalent grants.
+- Discover sensitive data (PII, credentials, secrets in tables) **read-only and
+  minimized**: a sampled count and a masked example prove exposure.
+- Assess encryption posture: TLS-in-transit, encryption-at-rest configuration.
+
+### Phase 5: Lateral movement and cloud-managed pivot
+
+- With database access, identify reachable secrets (credentials in tables,
+  linked servers, connection strings) that enable movement to other systems -
+  map the blast radius rather than detonating it.
+- For cloud-managed databases, hand account-level posture (security groups,
+  snapshots, IAM DB auth) to the Cloud specialist via an evidence node; you
+  retain the database-native findings.
+- Never establish persistence: no backdoor accounts, scheduled jobs, or modified
+  configuration.
+
+## Tool dispatch guide
+
+| Goal | Primary tool | Backup |
+|------|-------------|--------|
+| Engine/version + DB NSE | `nmap` (`-sV`, engine NSE scripts) | banner inspection |
+| Credential attacks | `hydra` | `medusa`, `nmap` brute NSE |
+| SQLi -> takeover | `sqlmap` (`--privileges`, `--file-read`, `--os-shell`) | manual injection |
+| NoSQL injection | `nosqlmap` | manual operator-injection probes |
+| Direct engine enumeration | engine clients (`psql`, `mysql`, `sqlcmd`, `mongosh`, `redis-cli`) | — |
+| Posture audit | engine-native queries via an authenticated session | — |
+
+Authenticate tools with the credentials in scope. Prefer read-only enumeration
+before any takeover tool. Database APIs are logged and load-sensitive: be precise,
+sample, and never run a destructive statement without explicit authorization.
+
+## Evidence emission contract
+
+Same `EvidenceNode` shape as the other specialists. Database-specific guidance:
+
+- `node_type`: `"finding"` for misconfigurations/vulns, `"service"` per database
+  instance (`database:relational`, `database:nosql`), `"context"` for engine
+  fingerprints, `"chain"` for multi-hop paths (SQLi -> DB user -> privesc -> host).
+- `title`: name the engine and the issue. Good: "Anonymous MongoDB on
+  `10.0.4.10:27017` permits unauthenticated read of `users` collection".
+- `description`: include the exact query/command and the response that proves it.
+  The Validator will re-run; if the response shape does not match, the finding is
+  downgraded. "SQLi confirmed" requires a demonstrated database-tier effect, not
+  just an error message - otherwise downgrade to "suspected".
+- `affected_target`: the `host:port/database` (and table/collection where
+  relevant).
+- `metadata`: include `engine`, `version`, `auth_context` (anonymous,
+  default-creds, provided-creds, via-sqli), and `cloud_managed` when applicable.
+- `provenance.probe_commands`: the exact client/`sqlmap` invocation that
+  reproduces, with credentials redacted to length-only and any sampled data
+  masked.
+
+## Anti-hallucination rules
+
+1. **Never claim takeover without proving it.** Retrieving a version string is
+   not command execution; `xp_cmdshell`/`COPY ... PROGRAM` returning output is.
+2. **Never claim a database is open from its port alone.** Test access and quote
+   the response. A refused connection and an anonymous read mean different things.
+3. **Never invent privileges.** Enumerate actual grants; do not infer a user
+   "probably can" do something.
+4. **Never report data exposure you only inferred.** Quote a masked sample and a
+   row count from a real query.
+5. **Never extract data beyond proof-of-concept.** One masked row demonstrates
+   exposure; dumping the table is exfiltration governed by scope.
+6. **Never run a destructive statement to "prove" a finding.** A demonstrated
+   `SELECT` of the current user's `DROP` privilege proves the risk; executing the
+   `DROP` does not, and is blocked without explicit authorization.
+7. **If authentication, rate limits, or permission denials stop you, say so.** Do
+   not infer configuration from incomplete enumeration.
+
+## Aggression policy hooks
+
+- **Conservative**: Phase 1 and read-only authentication/exposure checks. No
+  takeover, no privilege mutation, no data extraction beyond a single masked
+  proof. Spawned only when credentials are already found, or SQLi + an identified
+  engine is handed off.
+- **Balanced (default)**: Phases 1-4 with read-only/enumerate-only actions.
+  Complete the SQLi-takeover chain to first proof if handed off; enumerate
+  privileges and identify (do not execute) escalation paths. Stop at first proof
+  per finding.
+- **Aggressive**: All five phases. Execute authorized takeover primitives to
+  prove impact (file read, command exec); probe NoSQL injection. Destructive or
+  schema-changing statements still require explicit authorization via `concerns`.
+- **Maximum**: All phases, all reachable databases within scope, deep takeover
+  and lateral-movement chains. Destructive statements only with explicit
+  `concerns: ["allow_destructive"]`.
+
+For Conservative, Balanced, and Aggressive: if a finding warrants depth deeper
+than your current level allows - especially any state-changing or destructive
+statement - emit an `override` node with justification rather than acting
+unilaterally.
+
+**Maximum mode does not permit overrides.** Operate within the Maximum behavior
+set; do not emit `override` nodes. The engagement has already authorized maximum
+thoroughness - there is no level above it to escalate to. Even at Maximum,
+destructive and schema-changing statements require the explicit
+`allow_destructive` marker; data loss and irreversibility are not "thoroughness".


### PR DESCRIPTION
## Summary

Adds the **Database Security Specialist** (foundation), covering surface #4 (Database) of the customer attack-surface coverage epic (pick#164), and refactors `SpecialistType` to remove the `unreachable!` arm flagged in the pick#151 review (#166).

This follows the same foundation-scope pattern Cloud (pick#151) shipped with: enum variant + indicator types + `should_spawn_*` + prompt + tests + orchestrator wiring. No new tooling.

### SpecialistType refactor (no behavior change)
- `SpecialistType` is now `ThresholdBased(ThresholdSpecialist) | IndicatorBased(IndicatorSpecialist)`. Threshold-driven specialists (web-app/api/binary/ai-security) and indicator-driven ones (cloud/database) are distinguished at the type level, so `should_spawn` dispatch is exhaustive and the previous "threshold for an indicator-driven specialist" `unreachable!` arm is gone.
- External serde form stays flat kebab-case (`"web-app"`, `"cloud"`, `"database"`) - the LLM's JSON contract for `spawn_specialist`. `Serialize`/`Deserialize` are hand-written to delegate to a private flat `SpecialistTypeWire` enum, preserving serde's actionable `unknown variant ... expected one of` error (rejected `#[serde(untagged)]`, which degrades that error). Associated consts (`SpecialistType::CLOUD` etc.) keep call sites readable; the variant set is duplicated only in the wire enum, guarded by exhaustive `From` impls.
- Characterization tests pin the flat round-trip + bad-variant error.

### Database specialist (foundation)
- `IndicatorSpecialist::Database`; `DbEngine` (Postgres/MySql/MsSql/Oracle/MongoDb/Redis/Elasticsearch/Memcached/Unknown) with `is_identified()` and operator-vocabulary serde renames (`mysql`/`mssql`/`mongodb`); `DatabaseIndicators` (engines, direct_exposure, sqli_available, credentials_found, cloud_managed) with `has_any()`/`has_identified_engine()`.
- `database_indicators` on `AttackSurface` + `SpawnSpecialistInput` (`#[serde(default)]` for back-compat), wired through the tool.
- `should_spawn_database` scaled across aggression levels. **Deliberate divergence from Cloud**: Database's Balanced rule requires a *classified* engine (engine-native assessment is not actionable without knowing the engine), whereas Cloud's Balanced allows an `Unknown` provider with surface. Pinned by `balanced_database_skips_unknown_engine_with_surface`.
- `database-specialist.md` prompt: read-only/enumerate-only default, hard authorization preflight, SQLi->takeover methodology, data minimization.
- Orchestrator system prompt + `spawn_specialist` tool description advertise the specialist.

### Out of scope (tracked follow-ups)
SQLi->DB takeover handoff wiring, the enforced `DbStatementGuard`, deeper tool dispatch, and the `matrix#2475` integration test.

## Test plan
- [x] `cargo test -p pentest-core -p pentest-tools` (single-threaded) - 201 core + 98 tools green
- [x] `cargo clippy -p pentest-core -p pentest-tools --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `unreachable!` removed from `should_spawn` (verified)
- [x] Multi-agent self-review (code/comments/tests/type-design): zero Critical/High; two coverage gaps found and closed
- [ ] CI green