### PR TITLE
docs(evidence): correct comments asserting an unwired tool->report flow (pick#172)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -168,7 +168,11 @@ pub struct EvidenceNode {
 - Bounded buffer (configurable capacity)
 - Non-blocking push operations
 - Near-full detection (80% threshold)
-- Automatic flush to Strike48
+
+> Known gap (pick#172): tool findings pushed to this buffer are not yet drained
+> into the report evidence graph in production, and there is no automatic flush to
+> Strike48 (the Matrix client carries no evidence wire types). The buffer-to-report
+> bridge is unbuilt; reports are currently populated only via direct test injection.
 
 ---
 

--- a/crates/tools/src/evidence_producer.rs
+++ b/crates/tools/src/evidence_producer.rs
@@ -33,12 +33,15 @@ const MAX_EVIDENCE_NODES: usize = 10_000;
 
 /// Global pending evidence buffer.
 ///
-/// Tools push evidence here via [`push_evidence`], and the UI layer
-/// periodically drains it via [`drain_pending_evidence`].
+/// Tools push evidence here via [`push_evidence`]. The buffer is intended to be
+/// drained by [`drain_pending_evidence`] and forwarded into the report evidence
+/// graph (`pentest_ui::session`), but that drain-and-forward step is NOT wired in
+/// production today: `drain_pending_evidence` has no non-test callers, so nodes
+/// pushed here do not currently reach the report. See pick#172.
 ///
 /// # Thread Safety
 /// Protected by `RwLock` for concurrent access. Multiple tools can
-/// push evidence simultaneously, and the UI can drain without blocking
+/// push evidence simultaneously, and a drain can run without blocking
 /// tool execution (briefly blocks during the write lock acquisition).
 #[cfg(not(target_arch = "wasm32"))]
 static PENDING_EVIDENCE: LazyLock<RwLock<Vec<EvidenceNode>>> =
@@ -46,14 +49,15 @@ static PENDING_EVIDENCE: LazyLock<RwLock<Vec<EvidenceNode>>> =
 
 /// Push an evidence node to the global evidence buffer.
 ///
-/// This function is called by tools after producing findings. The evidence
-/// is stored in a global buffer that the UI layer periodically drains and
-/// adds to the evidence graph.
+/// This function is called by tools after producing findings. The evidence is
+/// stored in a global buffer. NOTE: nothing drains this buffer into the report
+/// graph in production yet (see [`PENDING_EVIDENCE`] and pick#172), so a pushed
+/// node is currently not surfaced in the generated report.
 ///
 /// # Capacity
 /// The buffer has a maximum capacity of [`MAX_EVIDENCE_NODES`]. If the
 /// buffer is full, this function logs a warning and drops the new evidence.
-/// The UI should drain evidence periodically to prevent overflow.
+/// A consumer should drain evidence periodically to prevent overflow.
 ///
 /// # Thread Safety
 /// This function is thread-safe and can be called from multiple tools

--- a/crates/ui/src/session.rs
+++ b/crates/ui/src/session.rs
@@ -34,8 +34,14 @@ static ACTION_REGISTRY: LazyLock<pentest_tools::registry::QuickActionRegistry> =
 type SharedToolRegistry = Arc<RwLock<Option<Arc<TokioRwLock<ToolRegistry>>>>>;
 static TOOL_REGISTRY: LazyLock<SharedToolRegistry> = LazyLock::new(|| Arc::new(RwLock::new(None)));
 
-/// Process-wide evidence graph. Tool wrappers / the Red Team agent push
-/// nodes in; the Generate Report action in the chat panel reads them out.
+/// Process-wide evidence graph that the Generate Report action in the chat
+/// panel reads out (via [`evidence_snapshot`]) and gates into the report.
+///
+/// INTENDED: tool wrappers / the Red Team agent populate this via
+/// [`push_evidence`]. ACTUAL: [`push_evidence`] has no callers, so this graph is
+/// never populated in production and the report is built from an empty set. Tool
+/// findings currently land in a separate, unbridged buffer
+/// (`pentest_tools::evidence_producer::PENDING_EVIDENCE`). See pick#172.
 ///
 /// Kept as a flat `Vec` rather than an index because the orchestrator gate
 /// iterates the whole graph anyway, and the UI never looks up nodes by id.
@@ -147,9 +153,12 @@ pub fn evidence_snapshot() -> Vec<EvidenceNode> {
         .clone()
 }
 
-/// Append a node to the evidence graph. Called by tool wrappers after the
-/// Red Team Agent produces a finding and by the Validator Agent when it
-/// adjudicates one.
+/// Append a node to the evidence graph.
+///
+/// INTENDED to be called by tool wrappers after the Red Team Agent produces a
+/// finding and by the Validator Agent when it adjudicates one. It currently has
+/// NO callers, so the evidence graph is never populated in production. Wiring the
+/// tool buffer to this function is tracked in pick#172.
 pub fn push_evidence(node: EvidenceNode) {
     EVIDENCE_GRAPH
         .write()


### PR DESCRIPTION
## Summary

Doc-only correction. The evidence-buffer comments, the session evidence-graph comments, and `ARCHITECTURE.md` described the tool-buffer to report-graph flow as if it were wired in production. It is not: `PENDING_EVIDENCE` (tools side) is drained only in tests, and `session::push_evidence` (the `EVIDENCE_GRAPH` writer) has zero callers, so tool-produced evidence does not reach the generated report in a native production build.

This PR rewrites the affected comments and the ARCHITECTURE "Evidence Buffer" section to state intended-vs-actual behavior and point at the tracking bug. **No code behavior changes.**

The underlying defect is filed separately as pick#172 (P0). This PR only stops the documentation from asserting a flow that does not exist (the same overclaim the comments currently make would mislead anyone auditing the pipeline).

## Changes

- `crates/tools/src/evidence_producer.rs` - buffer + `push_evidence` doc comments: note the drain-and-forward step is not wired (no non-test callers), so pushed nodes do not reach the report.
- `crates/ui/src/session.rs` - `EVIDENCE_GRAPH` + `push_evidence` doc comments: note `push_evidence` has no callers, so the graph is never populated in production.
- `ARCHITECTURE.md` - replace the "Automatic flush to Strike48" bullet with a "Known gap (pick#172)" note (the Matrix client carries no evidence wire types; there is no flush).

## Test plan

- [x] `cargo check -p pentest-tools` passes (doc edits do not break intra-doc links or compilation).
- [ ] CI green on the project toolchain (local rustc is older than the UI crates require; verified the only local build failure is pre-existing on clean `main` and unrelated to this change).
- [ ] No behavior change to verify - documentation only.

Refs: pick#172
