### PR TITLE
feat(ui): drive Tools page from the live registry

### DIFF
--- a/crates/tools/src/catalog.rs
+++ b/crates/tools/src/catalog.rs
@@ -396,6 +396,88 @@ pub async fn build_catalog_items() -> Vec<CatalogItem> {
     items
 }
 
+/// A single tool as shown on the read-only Tools overview page: its registered
+/// name, description, and a display category. Unlike [`CatalogItem`], this
+/// covers EVERY registered tool — including built-ins with no external
+/// dependency (port_scan, device_info, ...) — and does not probe install state.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ToolOverviewItem {
+    pub name: String,
+    pub description: String,
+    /// Stable lowercase category key (e.g. "active_directory", "other").
+    pub category: String,
+}
+
+/// Map a tool's name + its (optional) declared category to a display category.
+///
+/// Tools that declare an `ExternalDependency` carry an explicit
+/// [`ToolCategory`]. Built-in tools (no external dep) get a best-effort category
+/// from a small name-based heuristic so the overview page can still group them
+/// sensibly rather than dumping everything in "other".
+fn overview_category(name: &str, declared: Option<ToolCategory>) -> &'static str {
+    if let Some(cat) = declared {
+        // Reuse the serde rename for a stable key.
+        return match cat {
+            ToolCategory::Network => "network",
+            ToolCategory::Web => "web",
+            ToolCategory::ActiveDirectory => "active_directory",
+            ToolCategory::Credentials => "credentials",
+            ToolCategory::PostExploit => "post_exploit",
+            ToolCategory::Wireless => "wireless",
+            ToolCategory::Recon => "recon",
+            ToolCategory::Forensics => "forensics",
+            ToolCategory::Other => "other",
+        };
+    }
+    // Heuristic for built-ins with no declared category.
+    match name {
+        "port_scan" | "network_discover" | "ssdp_discover" | "arp_table" => "network",
+        "wifi_scan" | "wifi_scan_detailed" => "wireless",
+        "device_info" | "screenshot" | "execute_command" | "safety_check" => "system",
+        "list_files" | "read_file" | "write_file" | "session_export" => "files",
+        "web_vuln_scan" => "web",
+        "smb_enum" => "active_directory",
+        "cve_lookup" | "default_creds" | "service_banner" => "recon",
+        _ => "other",
+    }
+}
+
+/// Build the full read-only tools overview: every registered tool with a
+/// display category, sorted by (category, name). Drives the Tools page so it
+/// always reflects the live registry instead of a hand-maintained list.
+pub fn tools_overview() -> Vec<ToolOverviewItem> {
+    let registry = crate::create_tool_registry();
+    let mut items: Vec<ToolOverviewItem> = registry
+        .schemas()
+        .into_iter()
+        .map(|schema| {
+            let declared = schema.external_dependencies.first().map(|d| d.category);
+            ToolOverviewItem {
+                category: overview_category(&schema.name, declared).to_string(),
+                name: schema.name,
+                description: schema.description,
+            }
+        })
+        .collect();
+    items.sort_by(|a, b| {
+        a.category
+            .cmp(&b.category)
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    items
+}
+
+/// Distinct categories present in [`tools_overview`], in display order.
+pub fn tools_overview_categories(items: &[ToolOverviewItem]) -> Vec<String> {
+    let mut seen: Vec<String> = Vec::new();
+    for item in items {
+        if !seen.iter().any(|c| c == &item.category) {
+            seen.push(item.category.clone());
+        }
+    }
+    seen
+}
+
 /// Install a single catalog entry identified by its `binary_name`, emitting
 /// progress through `progress`. Rebuilds the catalog to resolve the entry so
 /// callers (e.g. the UI) only need to pass a string. Errors if no such entry
@@ -550,6 +632,54 @@ mod tests {
         let json = serde_json::to_string(&item).unwrap();
         let back: CatalogItem = serde_json::from_str(&json).unwrap();
         assert_eq!(item, back);
+    }
+
+    #[test]
+    fn tools_overview_covers_whole_registry_and_is_sorted() {
+        let overview = tools_overview();
+        let registry_count = crate::create_tool_registry().names().len();
+        // Every registered tool appears exactly once.
+        assert_eq!(
+            overview.len(),
+            registry_count,
+            "overview must include every registered tool"
+        );
+        // Includes both a built-in (no external dep) and an external tool.
+        assert!(overview.iter().any(|t| t.name == "port_scan"));
+        assert!(overview.iter().any(|t| t.name == "nmap"));
+        assert!(overview.iter().any(|t| t.name == "zap"));
+        // Sorted by (category, name).
+        for pair in overview.windows(2) {
+            assert!(
+                (pair[0].category.as_str(), pair[0].name.as_str())
+                    <= (pair[1].category.as_str(), pair[1].name.as_str()),
+                "overview must be sorted by (category, name)"
+            );
+        }
+    }
+
+    #[test]
+    fn overview_category_uses_declared_then_heuristic() {
+        // Declared category wins.
+        assert_eq!(
+            overview_category("nxc", Some(ToolCategory::ActiveDirectory)),
+            "active_directory"
+        );
+        // Built-in heuristic for a tool with no declared category.
+        assert_eq!(overview_category("port_scan", None), "network");
+        assert_eq!(overview_category("read_file", None), "files");
+        // Unknown built-in falls back to "other".
+        assert_eq!(overview_category("some_new_builtin", None), "other");
+    }
+
+    #[test]
+    fn tools_overview_categories_are_distinct_and_ordered() {
+        let overview = tools_overview();
+        let cats = tools_overview_categories(&overview);
+        let mut deduped = cats.clone();
+        deduped.dedup();
+        assert_eq!(cats.len(), deduped.len(), "categories must be distinct");
+        assert!(cats.iter().any(|c| c == "active_directory"));
     }
 
     #[tokio::test]

--- a/crates/ui/src/components/icons.rs
+++ b/crates/ui/src/components/icons.rs
@@ -5,8 +5,8 @@
 
 pub use lucide_dioxus::{
     Bolt, ChevronDown, CircleQuestionMark, Download, FileText, Folder, History, House, Info,
-    LayoutGrid, Menu, MessageCircle, MessageSquare, Network, Palette, Plus, ScrollText, Search,
-    Settings, Shield, Terminal, User, Wifi, Wrench, X,
+    LayoutGrid, Lock, Menu, MessageCircle, MessageSquare, Network, Palette, Plus, ScrollText,
+    Search, Settings, Shield, Terminal, User, Wifi, Wrench, X,
 };
 
 // ---------------------------------------------------------------------------

--- a/crates/ui/src/components/tools_page.rs
+++ b/crates/ui/src/components/tools_page.rs
@@ -1,121 +1,81 @@
-//! Tools page — categorized grid of available connector tools
+//! Tools page — categorized grid of all connector tools.
+//!
+//! Renders directly from the live tool registry (`pentest_tools::catalog::
+//! tools_overview`) rather than a hand-maintained list, so every registered
+//! tool appears and new tools show up automatically. Clicking a tool opens the
+//! chat pre-seeded with a prompt to use it.
 
 use dioxus::prelude::*;
 
-use super::icons::{Folder, Network, Search, Terminal};
+use super::icons::{Folder, Lock, Network, Search, Shield, Terminal, Wifi};
 
-struct ToolInfo {
-    name: &'static str,
-    description: &'static str,
-}
-
-struct ToolCategory {
-    label: &'static str,
-    tools: &'static [ToolInfo],
-}
-
-const CATEGORIES: &[ToolCategory] = &[
-    ToolCategory {
-        label: "Reconnaissance",
-        tools: &[
-            ToolInfo {
-                name: "device_info",
-                description: "System info, hostname, OS, architecture",
-            },
-            ToolInfo {
-                name: "network_discover",
-                description: "ARP + mDNS + SSDP host discovery",
-            },
-            ToolInfo {
-                name: "ssdp_discover",
-                description: "UPnP/SSDP service discovery",
-            },
-        ],
-    },
-    ToolCategory {
-        label: "Network",
-        tools: &[
-            ToolInfo {
-                name: "port_scan",
-                description: "TCP port scanning with banner grab",
-            },
-            ToolInfo {
-                name: "wifi_scan",
-                description: "Nearby wireless network enumeration",
-            },
-            ToolInfo {
-                name: "arp_table",
-                description: "Local ARP cache and neighbor table",
-            },
-            ToolInfo {
-                name: "traffic_capture",
-                description: "Packet capture on network interfaces",
-            },
-        ],
-    },
-    ToolCategory {
-        label: "System",
-        tools: &[
-            ToolInfo {
-                name: "execute_command",
-                description: "Run shell commands on the target",
-            },
-            ToolInfo {
-                name: "screenshot",
-                description: "Capture screen or display output",
-            },
-        ],
-    },
-    ToolCategory {
-        label: "Files",
-        tools: &[
-            ToolInfo {
-                name: "list_files",
-                description: "Directory listing with metadata",
-            },
-            ToolInfo {
-                name: "read_file",
-                description: "Read file contents from target",
-            },
-            ToolInfo {
-                name: "write_file",
-                description: "Write or create files on target",
-            },
-        ],
-    },
-];
-
-fn render_category_icon(idx: usize) -> Element {
-    match idx {
-        0 => rsx! { Search { size: 18 } },
-        1 => rsx! { Network { size: 18 } },
-        2 => rsx! { Terminal { size: 18 } },
-        3 => rsx! { Folder { size: 18 } },
-        _ => rsx! { Search { size: 18 } },
+/// Humanize a stable category key into a section label.
+fn humanize_category(category: &str) -> &'static str {
+    match category {
+        "network" => "Network",
+        "web" => "Web",
+        "active_directory" => "Active Directory",
+        "credentials" => "Credentials",
+        "post_exploit" => "Post-Exploitation",
+        "wireless" => "Wireless",
+        "recon" => "Reconnaissance",
+        "forensics" => "Forensics",
+        "system" => "System",
+        "files" => "Files",
+        _ => "Other",
     }
 }
 
-/// Tools page — displays all available connector tools organized by category
+/// Icon per category key.
+fn render_category_icon(category: &str) -> Element {
+    match category {
+        "network" => rsx! { Network { size: 18 } },
+        "web" => rsx! { Search { size: 18 } },
+        "active_directory" => rsx! { Lock { size: 18 } },
+        "credentials" => rsx! { Lock { size: 18 } },
+        "post_exploit" => rsx! { Shield { size: 18 } },
+        "wireless" => rsx! { Wifi { size: 18 } },
+        "recon" => rsx! { Search { size: 18 } },
+        "forensics" => rsx! { Search { size: 18 } },
+        "system" => rsx! { Terminal { size: 18 } },
+        "files" => rsx! { Folder { size: 18 } },
+        _ => rsx! { Terminal { size: 18 } },
+    }
+}
+
+/// Tools page — displays all registered connector tools grouped by category.
 #[component]
 pub fn ToolsPage(on_open_chat: EventHandler<String>) -> Element {
+    // The registry is process-global and cheap to enumerate; compute once per
+    // mount and hold the result.
+    let tools = use_hook(pentest_tools::catalog::tools_overview);
+    let categories = pentest_tools::catalog::tools_overview_categories(&tools);
+    let total = tools.len();
+
     rsx! {
         style { {include_str!("css/tools_page.css")} }
 
         div { class: "tools-page",
             div { class: "tools-body",
-                for (idx, cat) in CATEGORIES.iter().enumerate() {
+                div { class: "text-dim-sm", style: "margin-bottom: 8px;",
+                    "{total} tools available" }
+                for category in categories {
                     div { class: "tools-category",
                         div { class: "tools-category-header",
                             span {
                                 class: "tools-category-icon",
-                                {render_category_icon(idx)}
+                                {render_category_icon(&category)}
                             }
-                            h3 { class: "tools-category-title", "{cat.label}" }
+                            h3 { class: "tools-category-title", "{humanize_category(&category)}" }
                         }
                         div { class: "tools-grid",
-                            for tool in cat.tools.iter() {
+                            for tool in tools.iter().filter(|t| t.category == category).cloned() {
                                 {
-                                    let prompt = format!("Use the {} tool — {}", tool.name, tool.description.to_lowercase());
+                                    let prompt = format!(
+                                        "Use the {} tool — {}",
+                                        tool.name,
+                                        tool.description.to_lowercase()
+                                    );
                                     rsx! {
                                         div {
                                             class: "tool-card dashboard-card",


### PR DESCRIPTION
## Summary

The `/tools` page rendered a **hardcoded list of 12 tools** (`tools_page.rs` `const CATEGORIES`) that was completely disconnected from `create_tool_registry()` (~120 tools). That's why most tools — every external one (nmap, sqlmap, hydra, …) and all the new ones (zap, metasploit, certipy, netexec, kerbrute, bloodhound, burpsuite) — never appeared on the page, even though they're registered and advertised to Strike48.

This makes the Tools page **registry-driven**:
- New `pentest_tools::catalog::tools_overview()` enumerates every registered tool with a display category — the declared `ToolCategory` for tools that have an `ExternalDependency`, and a small name-based heuristic for built-ins (port_scan → network, read_file → files, …).
- `ToolsPage` is rewritten to render from it, grouped by category, with a tool count. New tools now show up automatically with zero UI edits.
- Adds the `Lock` icon (lucide) for the AD/credentials categories.

## Stacking / merge order
This PR is **stacked on #177** (base = `feat/tool-catalog-installers`) because it uses the `ToolCategory` and catalog code added there. Merge order:
1. #178 (commit Cargo.lock + `--locked`) — fixes red CI
2. #177 (tool-install catalog + new tools) — rebase on main after #178
3. this PR — rebase on main after #177

CI on this branch will be red until #178's lockfile reaches `main` (the pre-existing `time 0.3.52` dependency breakage, unrelated to this diff).

## Test plan
- [x] `cargo test -p pentest-tools catalog::` — overview tests pass (full-registry coverage, sorting, category mapping)
- [x] `cargo clippy -p pentest-tools -p pentest-ui --locked -- -D warnings` — clean
- [x] `cargo check -p pentest-ui --features desktop,connector,shell-ws` — compiles
- [ ] Manual click-through of `/tools` in the running app (all categories render, click opens chat)