### PR TITLE
fix(evidence): wire tool findings into the report via the Validator round-trip (#172, #174)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,29 @@
+# cargo-audit configuration
+#
+# Ignored advisories are transitive dependencies we cannot currently patch
+# because the vulnerable crate version is pinned by an upstream dependency's
+# own version requirement (no compatible patched release is reachable).
+#
+# Each entry MUST document:
+#   - what pulls the vulnerable crate in
+#   - why we cannot upgrade yet
+#   - the condition under which the ignore should be removed
+#
+# Review this list whenever dependencies change. Remove entries as soon as an
+# upstream release makes the patched version reachable.
+
+[advisories]
+ignore = [
+    # quick-xml <0.41.0 — memory-exhaustion / quadratic-runtime DoS in NsReader.
+    # Pulled transitively (and only in XML parse paths we do not drive with
+    # untrusted network input) via:
+    #   - screenshots 0.8.10 -> wayland-scanner/xcb/display-info (quick-xml 0.28/0.30)
+    #   - syntect 5.3.0 -> plist (quick-xml 0.38)
+    #   - winit 0.30 -> wayland-scanner 0.31 (quick-xml 0.39)
+    # All four callers pin quick-xml to caret ranges (^0.28, ^0.30, ^0.38,
+    # ^0.39) that cannot resolve to the patched >=0.41.0. Remove these once
+    # screenshots, syntect, and winit/wayland-scanner ship releases that bump
+    # quick-xml past 0.41.0.
+    "RUSTSEC-2026-0194", # quadratic runtime checking start tags for duplicate attrs
+    "RUSTSEC-2026-0195", # unbounded namespace-declaration allocation
+]

--- a/.env.example
+++ b/.env.example
@@ -1,31 +1,27 @@
-# Dioxus Connector Environment Configuration
+# Pick Connector Environment Configuration
 # Copy this file to .env and customize for your environment
 
 # ============ Strike48 Backend Configuration ============
 
-# Strike48 WebSocket/gRPC host
-STRIKE48_HOST=ws://localhost:3030
+# Strike48 WebSocket/gRPC endpoint (required)
+STRIKE48_HOST=ws://localhost:4000
 
-# Strike48 tenant/realm
-STRIKE48_TENANT=non-prod
+# Tenant/realm identifier (required)
+STRIKE48_TENANT=019f2439-fc7f-740c-9b4f-14d7a82d8fbe
 
-# Matrix API URL (for chat functionality)
-MATRIX_API_URL=http://localhost:3030
-
-# Matrix tenant ID
-MATRIX_TENANT_ID=non-prod
+# Strike48 HTTP API (for OTT registration and authentication)
+STRIKE48_API_URL=http://localhost:4000/
 
 # ============ Optional Configuration ============
 
 # Connector instance ID (auto-generated if not set)
-# STRIKE48_INSTANCE_ID=my-connector-01
+# STRIKE48_INSTANCE_ID=pick-connector-01
 
-# Authentication token (if using JWT instead of OTT)
-# STRIKE48_TOKEN=your_jwt_token_here
+# Authentication token (JWT - obtained after OTT registration, persisted automatically)
+# STRIKE48_TOKEN=
 
 # TLS configuration
-# STRIKE48_TLS=true
-# MATRIX_TLS_INSECURE=false
+# STRIKE48_TLS=false
 
 # ============ Logging Configuration ============
 
@@ -37,13 +33,8 @@ RUST_LOG=debug
 
 # ============ Advanced Configuration ============
 
-# StrikeHub IPC socket (when launched by StrikeHub)
-# STRIKEHUB_SOCKET=/run/strikehub/connector.sock
+# Disable sandbox for testing (tools execute directly)
+# DISABLE_SANDBOX=true
 
 # Workspace directory (defaults to ~/.local/share/pentest-workspace)
 # WORKSPACE_PATH=/custom/workspace/path
-
-# ============ Development Shortcuts ============
-
-# For local development with self-signed certificates
-# MATRIX_TLS_INSECURE=true

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ android-jniLibs
 # Mise
 .mise.local.toml
 .direnv/
+__pycache__/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -169,10 +169,25 @@ pub struct EvidenceNode {
 - Non-blocking push operations
 - Near-full detection (80% threshold)
 
-> Known gap (pick#172): tool findings pushed to this buffer are not yet drained
-> into the report evidence graph in production, and there is no automatic flush to
-> Strike48 (the Matrix client carries no evidence wire types). The buffer-to-report
-> bridge is unbuilt; reports are currently populated only via direct test injection.
+Tool findings flow tool -> `PENDING_EVIDENCE` -> report evidence graph ->
+Validator adjudication -> report gate:
+
+1. Tools push findings into the process-global `PENDING_EVIDENCE` buffer
+   (`pentest_tools::evidence_producer`).
+2. After every tool run the connector drains that buffer into the report
+   evidence graph via `pentest_ui::session::drain_tool_evidence_into_graph`
+   (`begin_scan` clears the graph so scans do not bleed together).
+3. The operator's "Validate Findings" action seeds the Validator Agent with the
+   pending nodes; its verdicts are parsed and applied
+   (`session::apply_validator_verdicts`), transitioning each node to a terminal
+   state.
+4. "Generate Report" calls `gate_for_report`, which refuses while any node is
+   still `Pending` and otherwise hands the confirmed findings to the Report
+   Agent.
+
+Evidence is not synced to Strike48 — the Matrix client carries no evidence wire
+types; the graph is process-local to the connector. This bridge is the fix for
+pick#172 / pick#174.
 
 ---
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -42,8 +42,10 @@ pub mod prelude {
         EvidenceFile, Finding, SessionExport, SessionMetadata, Severity, ToolExecution,
     };
     pub use crate::orchestrator::{
-        build_report_agent_seed_message, gate_for_report, EngagementInfo, GateError,
-        ManifestCounts, ManifestFinding, SeverityCounts, ValidatedFindingsManifest,
+        build_pending_evidence_manifest, build_report_agent_seed_message,
+        build_validator_seed_message, gate_for_report, parse_validator_verdicts, EngagementInfo,
+        GateError, ManifestCounts, ManifestFinding, PendingEvidenceManifest, SeverityCounts,
+        ValidatedFindingsManifest, Verdict, VerdictDecision, VerdictParseError,
     };
     pub use crate::provenance::{redact, ProbeCommand, Provenance, RAW_RESPONSE_MAX_BYTES};
     pub use crate::seed::{

--- a/crates/core/src/orchestrator.rs
+++ b/crates/core/src/orchestrator.rs
@@ -269,6 +269,158 @@ pub fn build_report_agent_seed_message(manifest: &ValidatedFindingsManifest) -> 
     )
 }
 
+/// The payload the Validator Agent expects: every still-`Pending` node in the
+/// graph, wrapped with engagement context.
+///
+/// Shape is pinned by the Validator system prompt's "Input Contract"
+/// (`pending_evidence_manifest`). It reuses [`ManifestFinding`] because that is
+/// already the flattened, `current_severity`-exposed view the prompt documents.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PendingEvidenceManifest {
+    pub engagement: EngagementInfo,
+    /// The nodes awaiting a verdict. Only `Pending` nodes are included — the
+    /// Validator never re-adjudicates a node it already ruled on.
+    pub nodes: Vec<ManifestFinding>,
+}
+
+/// Build the [`PendingEvidenceManifest`] from the current evidence graph.
+///
+/// Filters to `Pending` nodes only. An empty result is valid and expected when
+/// there is nothing to validate; the Validator prompt handles that case.
+pub fn build_pending_evidence_manifest(
+    nodes: &[EvidenceNode],
+    engagement: EngagementInfo,
+) -> PendingEvidenceManifest {
+    let nodes = nodes
+        .iter()
+        .filter(|n| n.validation_status == ValidationStatus::Pending)
+        .map(ManifestFinding::from_node)
+        .collect();
+    PendingEvidenceManifest { engagement, nodes }
+}
+
+/// Render a pending-evidence manifest as the seed message the UI sends to the
+/// Validator Agent. Symmetric to [`build_report_agent_seed_message`]: the
+/// Validator's system prompt pins the JSON shape, so we hand it over verbatim
+/// inside a fenced block with a short instruction.
+pub fn build_validator_seed_message(manifest: &PendingEvidenceManifest) -> String {
+    // Same infallibility contract as the report seed: every field serializes,
+    // so a failure means a newly added field broke the contract. Fall back to
+    // an empty manifest rather than panicking the connector.
+    let json = serde_json::to_string_pretty(manifest).unwrap_or_else(|e| {
+        tracing::error!(
+            error = %e,
+            "BUG: PendingEvidenceManifest serialization failed — a newly added \
+             field violates the infallibility contract. Falling back to an empty \
+             manifest so the Validator still receives something it can parse."
+        );
+        "{}".to_string()
+    });
+    format!(
+        "The engagement's evidence collection is complete. Below is the \
+         `pending_evidence_manifest`. Adjudicate every node and emit your \
+         verdicts per your system prompt.\n\n```json\n{json}\n```"
+    )
+}
+
+/// A single adjudication decision emitted by the Validator Agent.
+///
+/// Mirrors the `decision` column of the Validator prompt's verdict taxonomy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum VerdictDecision {
+    /// Evidence sufficient and severity correct — publish at `current_severity`.
+    Confirmed,
+    /// Evidence sufficient but severity wrong — publish at the revised value.
+    Revised,
+    /// Claim not supported by evidence — keep for audit, exclude from report.
+    FalsePositive,
+    /// Useful context but not a finding — report appendix, not the table.
+    InfoOnly,
+}
+
+/// One entry in the Validator Agent's output.
+///
+/// Shape is pinned by the Validator prompt's "Output Format" section. `severity`
+/// is optional because the prompt only requires it for `confirmed` and
+/// `revised`; for `false_positive` / `info_only` it is ignored.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Verdict {
+    pub node_id: String,
+    pub decision: VerdictDecision,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub severity: Option<Severity>,
+    pub rationale: String,
+    #[serde(default)]
+    pub confidence: f32,
+}
+
+/// The full JSON object the Validator Agent emits.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+struct VerdictEnvelope {
+    verdicts: Vec<Verdict>,
+    // `summary` is advisory (counts the agent computed for its own sanity). We
+    // deliberately do not deserialize it — the counts are re-derived from the
+    // verdicts at writeback time, so trusting the agent's arithmetic would only
+    // add a failure mode.
+}
+
+/// Reasons [`parse_validator_verdicts`] can reject a Validator reply.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum VerdictParseError {
+    /// No fenced ```` ```json ```` block was found in the reply. The Validator
+    /// prompt requires exactly one, so its absence means the agent went
+    /// off-script — fail loudly rather than silently publishing nothing.
+    #[error("no fenced ```json block found in validator reply")]
+    NoJsonBlock,
+    /// A JSON block was found but did not deserialize into the verdict schema.
+    #[error("validator verdict JSON is malformed: {0}")]
+    MalformedJson(String),
+    /// A `revised` verdict omitted the required `severity`. Revising to an
+    /// unknown severity is meaningless, so we reject the whole batch to force a
+    /// regenerate rather than guess.
+    #[error("verdict for node '{0}' is 'revised' but has no severity")]
+    RevisedWithoutSeverity(String),
+}
+
+/// Extract the first fenced ```` ```json ```` block from a string.
+///
+/// The Validator (like the Report Agent) is instructed to emit exactly one
+/// fenced JSON block, optionally surrounded by prose. We take the first block
+/// so leading prose cannot smuggle a second, contradictory block past us.
+fn extract_json_block(reply: &str) -> Option<&str> {
+    let after_fence = reply.find("```json").map(|i| i + "```json".len())?;
+    let rest = &reply[after_fence..];
+    // Skip the newline that conventionally follows the fence marker.
+    let body_start = rest.find('\n').map(|i| i + 1).unwrap_or(0);
+    let body = &rest[body_start..];
+    let end = body.find("```")?;
+    Some(body[..end].trim())
+}
+
+/// Parse a Validator Agent reply into a list of [`Verdict`]s.
+///
+/// Extracts the fenced JSON block, deserializes it, and validates the
+/// per-decision invariants the writeback step relies on. Returns an error
+/// (never a silent empty list) when the reply is unparseable — the caller must
+/// surface that to the operator instead of generating a report from nothing.
+///
+/// An empty `verdicts` array is a *valid* success: it is exactly what the
+/// Validator emits for an empty manifest.
+pub fn parse_validator_verdicts(reply: &str) -> Result<Vec<Verdict>, VerdictParseError> {
+    let json = extract_json_block(reply).ok_or(VerdictParseError::NoJsonBlock)?;
+    let envelope: VerdictEnvelope =
+        serde_json::from_str(json).map_err(|e| VerdictParseError::MalformedJson(e.to_string()))?;
+
+    for v in &envelope.verdicts {
+        if v.decision == VerdictDecision::Revised && v.severity.is_none() {
+            return Err(VerdictParseError::RevisedWithoutSeverity(v.node_id.clone()));
+        }
+    }
+
+    Ok(envelope.verdicts)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -508,5 +660,109 @@ mod tests {
         let json = &msg[start..end];
         let back: ValidatedFindingsManifest = serde_json::from_str(json).unwrap();
         assert_eq!(back, manifest);
+    }
+
+    // --- Validator seed + verdict parsing (pick#174 seams 2 & 3) ---
+
+    #[test]
+    fn pending_manifest_includes_only_pending_nodes() {
+        let nodes = [
+            pending("p1"),
+            confirmed_finding("c1", Severity::High),
+            pending("p2"),
+            info_only("i1"),
+        ];
+        let manifest = build_pending_evidence_manifest(&nodes, engagement());
+        let ids: Vec<&str> = manifest.nodes.iter().map(|n| n.id.as_str()).collect();
+        assert_eq!(ids, vec!["p1", "p2"]);
+    }
+
+    #[test]
+    fn validator_seed_embeds_pending_manifest_as_fenced_json() {
+        let manifest = build_pending_evidence_manifest(&[pending("p1")], engagement());
+        let msg = build_validator_seed_message(&manifest);
+        assert!(msg.contains("pending_evidence_manifest"));
+        assert!(msg.contains("```json"));
+        assert!(msg.contains("\"p1\""));
+        assert!(msg.trim_end().ends_with("```"));
+    }
+
+    #[test]
+    fn validator_seed_round_trips_through_json() {
+        let manifest =
+            build_pending_evidence_manifest(&[pending("p1"), pending("p2")], engagement());
+        let msg = build_validator_seed_message(&manifest);
+        let start = msg.find("```json\n").unwrap() + "```json\n".len();
+        let end = msg.rfind("\n```").unwrap();
+        let json = &msg[start..end];
+        let back: PendingEvidenceManifest = serde_json::from_str(json).unwrap();
+        assert_eq!(back, manifest);
+    }
+
+    #[test]
+    fn parses_well_formed_verdicts_with_surrounding_prose() {
+        let reply = "Here is my adjudication.\n\n```json\n{\n  \"verdicts\": [\n    \
+             {\"node_id\": \"n1\", \"decision\": \"confirmed\", \"severity\": \"high\", \
+             \"rationale\": \"reproduced\", \"confidence\": 0.9},\n    \
+             {\"node_id\": \"n2\", \"decision\": \"false_positive\", \"rationale\": \
+             \"static 404\", \"confidence\": 0.8}\n  ],\n  \"summary\": {\"reviewed\": 2}\n}\n```\n\
+             Done.";
+        let verdicts = parse_validator_verdicts(reply).expect("well-formed reply should parse");
+        assert_eq!(verdicts.len(), 2);
+        assert_eq!(verdicts[0].node_id, "n1");
+        assert_eq!(verdicts[0].decision, VerdictDecision::Confirmed);
+        assert_eq!(verdicts[0].severity, Some(Severity::High));
+        assert_eq!(verdicts[1].decision, VerdictDecision::FalsePositive);
+        // severity omitted for a false positive is fine.
+        assert_eq!(verdicts[1].severity, None);
+    }
+
+    #[test]
+    fn parses_empty_verdicts_for_empty_manifest() {
+        let reply = "No pending evidence to validate.\n\n```json\n\
+             {\"verdicts\": [], \"summary\": {\"reviewed\": 0}}\n```";
+        let verdicts = parse_validator_verdicts(reply).expect("empty verdicts is valid");
+        assert!(verdicts.is_empty());
+    }
+
+    #[test]
+    fn rejects_reply_with_no_json_block() {
+        let reply = "I could not find any evidence worth adjudicating, sorry.";
+        assert_eq!(
+            parse_validator_verdicts(reply),
+            Err(VerdictParseError::NoJsonBlock)
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_json_block() {
+        let reply = "```json\n{ this is not valid json }\n```";
+        match parse_validator_verdicts(reply) {
+            Err(VerdictParseError::MalformedJson(_)) => {}
+            other => panic!("expected MalformedJson, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn rejects_revised_verdict_without_severity() {
+        let reply = "```json\n{\"verdicts\": [{\"node_id\": \"n1\", \
+             \"decision\": \"revised\", \"rationale\": \"sev is wrong\", \
+             \"confidence\": 0.7}]}\n```";
+        assert_eq!(
+            parse_validator_verdicts(reply),
+            Err(VerdictParseError::RevisedWithoutSeverity("n1".to_string()))
+        );
+    }
+
+    #[test]
+    fn takes_only_the_first_json_block() {
+        // A hostile or confused reply could contain two blocks. We take the
+        // first so a trailing block cannot override the leading verdict set.
+        let reply = "```json\n{\"verdicts\": [{\"node_id\": \"n1\", \
+             \"decision\": \"confirmed\", \"severity\": \"low\", \"rationale\": \"ok\", \
+             \"confidence\": 0.9}]}\n```\nand also\n```json\n{\"verdicts\": []}\n```";
+        let verdicts = parse_validator_verdicts(reply).unwrap();
+        assert_eq!(verdicts.len(), 1);
+        assert_eq!(verdicts[0].node_id, "n1");
     }
 }

--- a/crates/core/src/orchestrator.rs
+++ b/crates/core/src/orchestrator.rs
@@ -303,24 +303,22 @@ pub fn build_pending_evidence_manifest(
 /// Validator Agent. Symmetric to [`build_report_agent_seed_message`]: the
 /// Validator's system prompt pins the JSON shape, so we hand it over verbatim
 /// inside a fenced block with a short instruction.
-pub fn build_validator_seed_message(manifest: &PendingEvidenceManifest) -> String {
-    // Same infallibility contract as the report seed: every field serializes,
-    // so a failure means a newly added field broke the contract. Fall back to
-    // an empty manifest rather than panicking the connector.
-    let json = serde_json::to_string_pretty(manifest).unwrap_or_else(|e| {
-        tracing::error!(
-            error = %e,
-            "BUG: PendingEvidenceManifest serialization failed — a newly added \
-             field violates the infallibility contract. Falling back to an empty \
-             manifest so the Validator still receives something it can parse."
-        );
-        "{}".to_string()
-    });
-    format!(
+///
+/// # Errors
+/// Returns `Err` if serialization fails. This should never happen with the
+/// current `PendingEvidenceManifest` structure (all fields are `Serialize`),
+/// but if a newly added field breaks the contract, we surface the error rather
+/// than silently sending an empty manifest to the Validator.
+pub fn build_validator_seed_message(
+    manifest: &PendingEvidenceManifest,
+) -> Result<String, String> {
+    let json = serde_json::to_string_pretty(manifest)
+        .map_err(|e| format!("Failed to serialize pending evidence manifest: {e}"))?;
+    Ok(format!(
         "The engagement's evidence collection is complete. Below is the \
          `pending_evidence_manifest`. Adjudicate every node and emit your \
          verdicts per your system prompt.\n\n```json\n{json}\n```"
-    )
+    ))
 }
 
 /// A single adjudication decision emitted by the Validator Agent.

--- a/crates/core/src/orchestrator.rs
+++ b/crates/core/src/orchestrator.rs
@@ -309,9 +309,7 @@ pub fn build_pending_evidence_manifest(
 /// current `PendingEvidenceManifest` structure (all fields are `Serialize`),
 /// but if a newly added field breaks the contract, we surface the error rather
 /// than silently sending an empty manifest to the Validator.
-pub fn build_validator_seed_message(
-    manifest: &PendingEvidenceManifest,
-) -> Result<String, String> {
+pub fn build_validator_seed_message(manifest: &PendingEvidenceManifest) -> Result<String, String> {
     let json = serde_json::to_string_pretty(manifest)
         .map_err(|e| format!("Failed to serialize pending evidence manifest: {e}"))?;
     Ok(format!(

--- a/crates/core/src/orchestrator.rs
+++ b/crates/core/src/orchestrator.rs
@@ -678,7 +678,7 @@ mod tests {
     #[test]
     fn validator_seed_embeds_pending_manifest_as_fenced_json() {
         let manifest = build_pending_evidence_manifest(&[pending("p1")], engagement());
-        let msg = build_validator_seed_message(&manifest);
+        let msg = build_validator_seed_message(&manifest).expect("serialization should succeed");
         assert!(msg.contains("pending_evidence_manifest"));
         assert!(msg.contains("```json"));
         assert!(msg.contains("\"p1\""));
@@ -689,7 +689,7 @@ mod tests {
     fn validator_seed_round_trips_through_json() {
         let manifest =
             build_pending_evidence_manifest(&[pending("p1"), pending("p2")], engagement());
-        let msg = build_validator_seed_message(&manifest);
+        let msg = build_validator_seed_message(&manifest).expect("serialization should succeed");
         let start = msg.find("```json\n").unwrap() + "```json\n".len();
         let end = msg.rfind("\n```").unwrap();
         let json = &msg[start..end];

--- a/crates/tools/src/evidence_producer.rs
+++ b/crates/tools/src/evidence_producer.rs
@@ -33,11 +33,11 @@ const MAX_EVIDENCE_NODES: usize = 10_000;
 
 /// Global pending evidence buffer.
 ///
-/// Tools push evidence here via [`push_evidence`]. The buffer is intended to be
-/// drained by [`drain_pending_evidence`] and forwarded into the report evidence
-/// graph (`pentest_ui::session`), but that drain-and-forward step is NOT wired in
-/// production today: `drain_pending_evidence` has no non-test callers, so nodes
-/// pushed here do not currently reach the report. See pick#172.
+/// Tools push evidence here via [`push_evidence`]. The connector drains it after
+/// every tool run via [`drain_pending_evidence`] and forwards each node into the
+/// report evidence graph (`pentest_ui::session::drain_tool_evidence_into_graph`),
+/// where the Validator round-trip adjudicates it before the report gate can
+/// publish it. This buffer-to-graph bridge is the fix for pick#172.
 ///
 /// # Thread Safety
 /// Protected by `RwLock` for concurrent access. Multiple tools can
@@ -50,9 +50,8 @@ static PENDING_EVIDENCE: LazyLock<RwLock<Vec<EvidenceNode>>> =
 /// Push an evidence node to the global evidence buffer.
 ///
 /// This function is called by tools after producing findings. The evidence is
-/// stored in a global buffer. NOTE: nothing drains this buffer into the report
-/// graph in production yet (see [`PENDING_EVIDENCE`] and pick#172), so a pushed
-/// node is currently not surfaced in the generated report.
+/// stored in [`PENDING_EVIDENCE`], which the connector drains into the report
+/// graph after each tool run (see that static's docs and pick#172).
 ///
 /// # Capacity
 /// The buffer has a maximum capacity of [`MAX_EVIDENCE_NODES`]. If the
@@ -480,13 +479,13 @@ mod tests {
     //
     // Run: cargo test --package pentest-tools --lib evidence_producer::tests -- --test-threads=1
 
-    /// Test that evidence flows through the push → drain cycle.
+    /// Test that evidence survives the push → drain cycle on a single shared
+    /// static (the tools-side buffer). This covers only the `pentest-tools`
+    /// half: that a pushed node is retrievable by a later drain.
     ///
-    /// This test verifies the fix for the dual-static bug where push and drain
-    /// used separate static variables, causing evidence to never reach the UI.
-    ///
-    /// CRITICAL: This is THE test that proves the dual-static bug is fixed.
-    /// If this test passes, evidence flows from tools → UI.
+    /// It does NOT prove the node reaches the report — that end-to-end flow
+    /// (tool -> buffer -> report graph -> validator -> gate) is covered by the
+    /// `evidence_pipeline` integration test in `crates/ui/tests/`. See pick#172.
     #[test]
     fn evidence_flows_through_buffer() {
         // Create test evidence nodes with unique IDs

--- a/crates/tools/src/evidence_producer.rs
+++ b/crates/tools/src/evidence_producer.rs
@@ -112,6 +112,16 @@ pub fn push_evidence(node: EvidenceNode) -> Result<(), BufferFullError> {
 /// each call will receive a portion of the evidence (non-deterministic split).
 /// The UI should call this from a single thread for predictable behavior.
 ///
+/// # Lock Ordering Safety
+/// **CRITICAL:** This function MUST NOT hold the `PENDING_EVIDENCE` lock after
+/// returning. The UI layer's `drain_tool_evidence_into_graph` depends on this
+/// property to avoid deadlock - it acquires `EVIDENCE_GRAPH` after calling this
+/// function. See `pentest_ui::session::EVIDENCE_GRAPH` documentation for the
+/// complete lock ordering contract (PENDING_EVIDENCE first, EVIDENCE_GRAPH second).
+///
+/// The current implementation correctly releases the lock before returning via
+/// `std::mem::take`, which only holds the write lock for the duration of the swap.
+///
 /// # Returns
 /// All accumulated evidence nodes since the last drain. Empty vector if
 /// no evidence has been produced.

--- a/crates/ui/src/components/chat_panel/agent_selector.rs
+++ b/crates/ui/src/components/chat_panel/agent_selector.rs
@@ -9,7 +9,7 @@ use pentest_core::matrix::{AgentInfo, ConversationInfo};
 
 use super::constants::SUGGESTED_ACTIONS;
 use super::render::format_relative_time;
-use crate::components::icons::{ChevronDown, FileText, History, Plus};
+use crate::components::icons::{ChevronDown, FileText, History, Plus, Shield};
 
 /// Props for [`ChatHeader`].
 #[derive(Props, Clone, PartialEq)]
@@ -30,6 +30,9 @@ pub struct ChatHeaderProps {
     pub on_new_chat: EventHandler<()>,
     /// Called when the user clicks the history icon to toggle the history dropdown.
     pub on_toggle_history: EventHandler<()>,
+    /// Called when the user clicks "Validate Findings" — hands the pending
+    /// evidence graph to the Validator Agent before report generation.
+    pub on_validate_findings: EventHandler<()>,
     /// Called when the user clicks "Generate Report" — asks the orchestrator
     /// to gate the evidence graph and hand off to the Report Agent.
     pub on_generate_report: EventHandler<()>,
@@ -80,6 +83,18 @@ pub fn ChatHeader(props: ChatHeaderProps) -> Element {
                         }
                     }
                 } else {
+                    // Validate Findings: hands the pending evidence graph to
+                    // the Validator Agent sibling. Run before Generate Report.
+                    button {
+                        class: "chat-header-btn",
+                        title: "Validate Findings",
+                        onclick: {
+                            let vf = props.on_validate_findings;
+                            move |_| vf.call(())
+                        },
+                        Shield { size: 16 }
+                    }
+
                     // Generate Report: hands the validated evidence graph to
                     // the Report Agent sibling.
                     button {
@@ -188,6 +203,7 @@ pub struct ChatHeaderCtx {
     pub on_agent_select: EventHandler<String>,
     pub on_new_chat: EventHandler<()>,
     pub on_toggle_history: EventHandler<()>,
+    pub on_validate_findings: EventHandler<()>,
     pub on_generate_report: EventHandler<()>,
 }
 
@@ -229,6 +245,15 @@ pub fn ChatHeaderActions(ctx: ChatHeaderCtx) -> Element {
                 }
             }
         } else {
+            // Validate Findings: hands the pending evidence graph to the
+            // Validator Agent sibling. Run before Generate Report.
+            button {
+                class: "chat-header-btn",
+                title: "Validate Findings",
+                onclick: move |_| ctx.on_validate_findings.call(()),
+                Shield { size: 16 }
+            }
+
             // Generate Report: hands the validated evidence graph to
             // the Report Agent sibling.
             button {

--- a/crates/ui/src/components/chat_panel/constants.rs
+++ b/crates/ui/src/components/chat_panel/constants.rs
@@ -585,7 +585,7 @@ CORRECT: | Success Rate | &gt; 90% |
 
 **When the operator says "generate the report" / "write the report" / "save the report":**
 
-Do not do it yourself. Respond with something like: "The Report Agent handles final report rendering once validation is done — use the 'Generate Report' action to kick it off." Then stop.
+Do not do it yourself. The pipeline is two steps: first the operator clicks the 'Validate Findings' action so the Validator adjudicates each finding, then the 'Generate Report' action hands the confirmed findings to the Report Agent. Respond with something like: "Findings get adjudicated by the Validator first — use the 'Validate Findings' action, then 'Generate Report' to render it." Then stop.
 "#;
 
 /// Suffix appended to the connector name to produce the Report Agent name.

--- a/crates/ui/src/components/chat_panel/mod.rs
+++ b/crates/ui/src/components/chat_panel/mod.rs
@@ -81,11 +81,24 @@ fn apply_validator_reply(
 
     let report = crate::session::apply_validator_verdicts(&verdicts);
 
+    // Surface unmatched verdict IDs - these indicate the Validator hallucinated
+    // or mistyped node IDs that don't exist in the evidence graph.
     if !report.unmatched_verdict_ids.is_empty() {
         tracing::warn!(
             unmatched = report.unmatched_verdict_ids.len(),
             "validator emitted verdicts for node ids not in the graph"
         );
+        error_msg.set(Some(format!(
+            "Warning: Validator issued verdicts for {} non-existent node ID(s). \
+             This indicates the Validator hallucinated IDs. Validated {}/{} findings; \
+             {} still pending. Ask the Validator to re-emit verdicts using only the \
+             node IDs from the manifest, or validate again.",
+            report.unmatched_verdict_ids.len(),
+            report.applied,
+            pending_count,
+            report.still_pending_ids.len()
+        )));
+        return;
     }
 
     if report.is_fully_adjudicated() {
@@ -878,7 +891,16 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
             agent_thinking.set(false);
             agent_status_text.set(String::new());
 
-            let seed = pentest_core::orchestrator::build_validator_seed_message(&manifest);
+            let seed = match pentest_core::orchestrator::build_validator_seed_message(&manifest) {
+                Ok(s) => s,
+                Err(e) => {
+                    error_msg.set(Some(format!(
+                        "Cannot validate findings: {e}. This indicates a bug in evidence \
+                         serialization. Please report this error."
+                    )));
+                    return;
+                }
+            };
             let client = make_client();
             is_sending.set(true);
 
@@ -894,7 +916,9 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
                     }
                     Err(e) => {
                         error_msg.set(Some(format!(
-                            "Failed to create validation conversation: {e}"
+                            "Failed to create validation conversation with Validator Agent '{}': {}. \
+                             Check that Strike48 backend is accessible.",
+                            validator_agent.name, e
                         )));
                         is_sending.set(false);
                         return;

--- a/crates/ui/src/components/chat_panel/mod.rs
+++ b/crates/ui/src/components/chat_panel/mod.rs
@@ -32,6 +32,75 @@ use polling::{poll_and_update, ChatNoticeKind};
 pub use render::format_relative_time;
 use render::{CHART_PROCESSOR_JS, UTILS_JS};
 
+/// Parse the Validator Agent's latest reply and apply its verdicts to the
+/// evidence graph.
+///
+/// Called after the validation conversation finishes polling. Finds the newest
+/// non-USER message, extracts the fenced verdict JSON, and hands it to
+/// [`crate::session::apply_validator_verdicts`]. The outcome is surfaced through
+/// `error_msg` so the operator never silently proceeds:
+///
+/// * unparseable reply -> error (the Validator went off-script);
+/// * verdicts applied but nodes still pending -> warning that Generate Report
+///   will refuse until they are adjudicated;
+/// * everything adjudicated -> `error_msg` is cleared.
+///
+/// Kept as a free function (rather than a closure) so the glue stays readable
+/// and does not capture the component's signal soup. The behaviour it composes
+/// is covered by the `parse_validator_verdicts` tests in `pentest-core` and the
+/// `apply_validator_verdicts` tests in `crate::session`.
+fn apply_validator_reply(
+    messages: &[ChatMessage],
+    pending_count: usize,
+    error_msg: &mut Signal<Option<String>>,
+) {
+    let Some(reply) = messages
+        .iter()
+        .rev()
+        .find(|m| m.sender_type != "USER" && !m.text.is_empty())
+    else {
+        error_msg.set(Some(
+            "The Validator produced no reply. Try validating again, or check the \
+             conversation for an error."
+                .to_string(),
+        ));
+        return;
+    };
+
+    let verdicts = match pentest_core::orchestrator::parse_validator_verdicts(&reply.text) {
+        Ok(v) => v,
+        Err(e) => {
+            error_msg.set(Some(format!(
+                "Could not read the Validator's verdicts ({e}). The report gate will refuse \
+                 until every finding is adjudicated — ask the Validator to re-emit its JSON \
+                 verdict block, or validate again."
+            )));
+            return;
+        }
+    };
+
+    let report = crate::session::apply_validator_verdicts(&verdicts);
+
+    if !report.unmatched_verdict_ids.is_empty() {
+        tracing::warn!(
+            unmatched = report.unmatched_verdict_ids.len(),
+            "validator emitted verdicts for node ids not in the graph"
+        );
+    }
+
+    if report.is_fully_adjudicated() {
+        // All clear — Generate Report will now succeed.
+        error_msg.set(None);
+    } else {
+        let still = report.still_pending_ids.len();
+        error_msg.set(Some(format!(
+            "Validated {} of {} finding(s); {} still pending. Generate Report will refuse \
+             until the Validator adjudicates the rest.",
+            report.applied, pending_count, still
+        )));
+    }
+}
+
 /// Props for the ChatPanel component.
 #[derive(Props, Clone, PartialEq)]
 pub struct ChatPanelProps {
@@ -739,6 +808,146 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
         }
     });
 
+    // Handler: validate findings.
+    //
+    // The Validator round-trip that sits between evidence collection and
+    // report generation (pick#174 seams 2 & 3). Without it every node stays
+    // `Pending` and `gate_for_report` refuses, so this must run before
+    // Generate Report on any real engagement.
+    //
+    // 1. Snapshot the graph and build the `pending_evidence_manifest`. If there
+    //    are no pending nodes, tell the operator and bail — nothing to do.
+    // 2. Resolve the Validator sibling (`{connector_name}-validator`) and switch
+    //    to it in a fresh conversation, seeding the pending manifest.
+    // 3. Poll until it finishes, then parse the verdicts out of its reply and
+    //    apply them to the graph. Surface how many were applied / left pending
+    //    so the operator knows whether Generate Report will succeed.
+    let on_validate_findings = EventHandler::new({
+        let make_client = make_client.clone();
+        move |_: ()| {
+            let snapshot = crate::session::evidence_snapshot();
+            let engagement = pentest_core::orchestrator::EngagementInfo::new(
+                crate::session::get_connector_name(),
+                chrono::Utc::now(),
+            );
+            let manifest =
+                pentest_core::orchestrator::build_pending_evidence_manifest(&snapshot, engagement);
+            if manifest.nodes.is_empty() {
+                error_msg.set(Some(
+                    "No pending findings to validate. Run tools to collect evidence first, \
+                     or the Validator has already adjudicated everything."
+                        .to_string(),
+                ));
+                return;
+            }
+            let pending_count = manifest.nodes.len();
+
+            // Resolve the Validator sibling. Same deterministic-name lookup as
+            // the Report handoff below.
+            let connector_name = crate::session::get_connector_name();
+            let validator_name = format!("{}{}", connector_name, VALIDATOR_AGENT_SUFFIX);
+            let validator_agent = agents
+                .peek()
+                .iter()
+                .find(|a| a.name == validator_name)
+                .cloned();
+            let Some(validator_agent) = validator_agent else {
+                error_msg.set(Some(format!(
+                    "Validator Agent '{validator_name}' is not registered. Reload the page \
+                     so the chat panel can create it."
+                )));
+                return;
+            };
+
+            // Save current conversation under the previously selected agent
+            // before switching the panel to the Validator.
+            if let Some(old_agent) = selected_agent.peek().as_ref() {
+                if let Some(cid) = conversation_id.peek().clone() {
+                    agent_conversations
+                        .write()
+                        .insert(old_agent.id.clone(), cid);
+                }
+            }
+
+            selected_agent.set(Some(validator_agent.clone()));
+            conversation_id.set(None);
+            messages.set(Vec::new());
+            show_history.set(false);
+            error_msg.set(None);
+            chat_notice.set(None);
+            agent_thinking.set(false);
+            agent_status_text.set(String::new());
+
+            let seed = pentest_core::orchestrator::build_validator_seed_message(&manifest);
+            let client = make_client();
+            is_sending.set(true);
+
+            spawn(async move {
+                let conv_title = format!("Validation for {}", manifest.engagement.target);
+                let conv_id = match client.create_conversation(Some(&conv_title)).await {
+                    Ok(id) => {
+                        conversation_id.set(Some(id.clone()));
+                        agent_conversations
+                            .write()
+                            .insert(validator_agent.id.clone(), id.clone());
+                        id
+                    }
+                    Err(e) => {
+                        error_msg.set(Some(format!(
+                            "Failed to create validation conversation: {e}"
+                        )));
+                        is_sending.set(false);
+                        return;
+                    }
+                };
+
+                let user_msg = ChatMessage {
+                    id: format!("local-{}", messages.peek().len()),
+                    sender_type: "USER".to_string(),
+                    sender_name: "Orchestrator".to_string(),
+                    text: seed.clone(),
+                    parts: vec![pentest_core::matrix::MessagePart::Text(seed.clone())],
+                };
+                messages.write().push(user_msg);
+                user_scrolled_up.set(false);
+
+                match client
+                    .send_message(&conv_id, &validator_agent.id, &seed)
+                    .await
+                {
+                    Ok(_) => {
+                        agent_thinking.set(true);
+                        agent_status_text.set("Validating findings...".to_string());
+                        is_sending.set(false);
+                        poll_and_update(
+                            client,
+                            conv_id,
+                            conversation_id,
+                            messages,
+                            agent_thinking,
+                            agent_status_text,
+                            error_msg,
+                            chat_notice,
+                        )
+                        .await;
+
+                        // Polling has ended. Parse the Validator's latest reply
+                        // and apply its verdicts to the evidence graph. The
+                        // verdict block is machine-parseable per the Validator
+                        // system prompt; a reply we cannot parse is surfaced so
+                        // the operator does not silently proceed to an empty or
+                        // stuck report.
+                        apply_validator_reply(&messages.peek(), pending_count, &mut error_msg);
+                    }
+                    Err(e) => {
+                        error_msg.set(Some(format!("Failed to send validation seed: {e}")));
+                        is_sending.set(false);
+                    }
+                }
+            });
+        }
+    });
+
     // Handler: generate final report.
     //
     // 1. Snapshot the evidence graph and ask the orchestrator gate to build
@@ -936,6 +1145,7 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
                 on_agent_select,
                 on_new_chat,
                 on_toggle_history,
+                on_validate_findings,
                 on_generate_report,
             };
             // Only write if the data actually changed (avoids unnecessary parent re-renders).
@@ -1074,6 +1284,7 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
                     on_agent_select: on_agent_select,
                     on_new_chat: on_new_chat,
                     on_toggle_history: on_toggle_history,
+                    on_validate_findings: on_validate_findings,
                     on_generate_report: on_generate_report,
                     show_history: show_history,
                     is_full: is_full,

--- a/crates/ui/src/liveview_connector/tools.rs
+++ b/crates/ui/src/liveview_connector/tools.rs
@@ -238,6 +238,32 @@ pub(crate) async fn handle_execute_impl(req: proto::ExecuteRequest, params: Exec
         let result = match tools.execute(tool_name, params, &ctx).await {
             Ok(result) => {
                 let duration_ms = start.elapsed().as_millis() as u64;
+
+                // A successful `begin_scan` marks the start of a fresh
+                // engagement. Clear any evidence left over from a previous scan
+                // so it cannot bleed into this report (pick#172). `begin_scan`
+                // itself produces no findings, so nothing is lost by clearing
+                // here rather than draining first.
+                if tool_name == "begin_scan" && result.success {
+                    crate::session::clear_evidence();
+                    tracing::debug!("begin_scan: cleared evidence graph for new engagement");
+                }
+
+                // Bridge tool-produced evidence into the report graph (pick#172).
+                // Tools push findings into the process-global PENDING_EVIDENCE
+                // buffer as a side effect of execution; if we don't drain them
+                // here they never reach `gate_for_report` and the report comes
+                // out empty. This is the single production drain point shared by
+                // both the headless and desktop connectors.
+                let forwarded = crate::session::drain_tool_evidence_into_graph();
+                if forwarded > 0 {
+                    tracing::debug!(
+                        tool = tool_name,
+                        forwarded,
+                        "forwarded tool evidence into report graph"
+                    );
+                }
+
                 emit_event(
                     &event_tx,
                     ConnectorEvent::ToolCompleted {

--- a/crates/ui/src/session.rs
+++ b/crates/ui/src/session.rs
@@ -203,6 +203,102 @@ pub fn clear_evidence() {
         .clear();
 }
 
+/// Outcome of applying a batch of Validator verdicts to the evidence graph.
+///
+/// The UI surfaces these counts so the operator can tell whether every node was
+/// adjudicated before generating the report. Unmatched ids and still-pending
+/// nodes are the two ways the round-trip can fail; both are reported explicitly
+/// rather than swallowed (pick#184 fail-closed spirit).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct VerdictApplyReport {
+    /// Number of verdicts that matched a node and transitioned it.
+    pub applied: usize,
+    /// Verdict `node_id`s that matched no node in the graph. A non-empty list
+    /// means the Validator invented or mistyped an id — a correctness problem.
+    pub unmatched_verdict_ids: Vec<String>,
+    /// Node ids still `Pending` after the batch (the Validator returned no
+    /// verdict for them). `gate_for_report` will refuse while any remain.
+    pub still_pending_ids: Vec<String>,
+}
+
+impl VerdictApplyReport {
+    /// Whether every node in the graph now has a terminal verdict. When true,
+    /// `gate_for_report` will accept the graph.
+    pub fn is_fully_adjudicated(&self) -> bool {
+        self.still_pending_ids.is_empty()
+    }
+}
+
+/// Apply a batch of Validator verdicts to the evidence graph in place.
+///
+/// Each verdict is matched to a node by `node_id` and drives the node through
+/// its lifecycle transition (`apply_validator_decision` / `reject_as_false_
+/// positive` / `mark_info_only`). This is the production writeback pick#174
+/// (seam 3) identified as test-only.
+///
+/// A `revised`/`confirmed` verdict without a severity falls back to the node's
+/// current severity, which `apply_validator_decision` treats as a confirmation.
+/// The parser (`parse_validator_verdicts`) already rejects `revised` without a
+/// severity, so that fallback only applies to `confirmed`.
+///
+/// Returns a [`VerdictApplyReport`] describing what matched and what is still
+/// outstanding. Nothing is dropped silently.
+pub fn apply_validator_verdicts(
+    verdicts: &[pentest_core::orchestrator::Verdict],
+) -> VerdictApplyReport {
+    use pentest_core::orchestrator::VerdictDecision;
+
+    let mut graph = EVIDENCE_GRAPH
+        .write()
+        .unwrap_or_else(|e| recover_poisoned(e, "EVIDENCE_GRAPH"));
+
+    let mut report = VerdictApplyReport::default();
+
+    for verdict in verdicts {
+        match graph.iter_mut().find(|n| n.id == verdict.node_id) {
+            Some(node) => {
+                match verdict.decision {
+                    VerdictDecision::Confirmed | VerdictDecision::Revised => {
+                        let severity = verdict.severity.unwrap_or_else(|| node.current_severity());
+                        node.apply_validator_decision(severity, verdict.rationale.clone());
+                    }
+                    VerdictDecision::FalsePositive => {
+                        node.reject_as_false_positive(verdict.rationale.clone());
+                    }
+                    VerdictDecision::InfoOnly => {
+                        node.mark_info_only(verdict.rationale.clone());
+                    }
+                }
+                report.applied += 1;
+            }
+            None => {
+                tracing::warn!(
+                    node_id = %verdict.node_id,
+                    "validator verdict references a node id not present in the evidence graph; \
+                     ignoring it"
+                );
+                report.unmatched_verdict_ids.push(verdict.node_id.clone());
+            }
+        }
+    }
+
+    report.still_pending_ids = graph
+        .iter()
+        .filter(|n| n.validation_status == pentest_core::evidence::ValidationStatus::Pending)
+        .map(|n| n.id.clone())
+        .collect();
+
+    if !report.still_pending_ids.is_empty() {
+        tracing::warn!(
+            pending = report.still_pending_ids.len(),
+            "evidence graph still has pending nodes after applying validator verdicts; \
+             the report gate will refuse until they are adjudicated"
+        );
+    }
+
+    report
+}
+
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
@@ -290,5 +386,121 @@ mod tests {
             !snapshot_contains(id),
             "clear_evidence must empty the report graph for a fresh engagement"
         );
+    }
+
+    // --- Verdict writeback (pick#174 seam 3) ---
+
+    use pentest_core::evidence::ValidationStatus;
+    use pentest_core::orchestrator::{Verdict, VerdictDecision};
+
+    fn verdict(node_id: &str, decision: VerdictDecision, severity: Option<Severity>) -> Verdict {
+        Verdict {
+            node_id: node_id.to_string(),
+            decision,
+            severity,
+            rationale: "test rationale".to_string(),
+            confidence: 0.9,
+        }
+    }
+
+    fn status_of(id: &str) -> Option<ValidationStatus> {
+        evidence_snapshot()
+            .into_iter()
+            .find(|n| n.id == id)
+            .map(|n| n.validation_status)
+    }
+
+    #[test]
+    fn writeback_applies_each_decision_type() {
+        let _guard = serial();
+        clear_evidence();
+        push_evidence(node("wb-confirmed"));
+        push_evidence(node("wb-revised"));
+        push_evidence(node("wb-fp"));
+        push_evidence(node("wb-info"));
+
+        let report = apply_validator_verdicts(&[
+            verdict(
+                "wb-confirmed",
+                VerdictDecision::Confirmed,
+                Some(Severity::Medium),
+            ),
+            verdict("wb-revised", VerdictDecision::Revised, Some(Severity::High)),
+            verdict("wb-fp", VerdictDecision::FalsePositive, None),
+            verdict("wb-info", VerdictDecision::InfoOnly, None),
+        ]);
+
+        assert_eq!(report.applied, 4);
+        assert!(report.unmatched_verdict_ids.is_empty());
+        assert!(report.still_pending_ids.is_empty());
+        assert!(report.is_fully_adjudicated());
+
+        assert_eq!(status_of("wb-confirmed"), Some(ValidationStatus::Confirmed));
+        assert_eq!(status_of("wb-revised"), Some(ValidationStatus::Revised));
+        assert_eq!(status_of("wb-fp"), Some(ValidationStatus::FalsePositive));
+        assert_eq!(status_of("wb-info"), Some(ValidationStatus::InfoOnly));
+    }
+
+    #[test]
+    fn writeback_reports_unmatched_verdict_ids() {
+        let _guard = serial();
+        clear_evidence();
+        push_evidence(node("wb-real"));
+
+        // node() starts at Medium; confirm at Medium so the status is a clean
+        // Confirmed (this test is about the unmatched id, not severity revision).
+        let report = apply_validator_verdicts(&[
+            verdict(
+                "wb-real",
+                VerdictDecision::Confirmed,
+                Some(Severity::Medium),
+            ),
+            verdict(
+                "wb-ghost",
+                VerdictDecision::Confirmed,
+                Some(Severity::Medium),
+            ),
+        ]);
+
+        assert_eq!(report.applied, 1);
+        assert_eq!(report.unmatched_verdict_ids, vec!["wb-ghost".to_string()]);
+        assert_eq!(status_of("wb-real"), Some(ValidationStatus::Confirmed));
+    }
+
+    #[test]
+    fn writeback_reports_nodes_left_pending() {
+        let _guard = serial();
+        clear_evidence();
+        push_evidence(node("wb-adjudicated"));
+        push_evidence(node("wb-forgotten"));
+
+        // The Validator only ruled on one of the two nodes.
+        let report = apply_validator_verdicts(&[verdict(
+            "wb-adjudicated",
+            VerdictDecision::Confirmed,
+            Some(Severity::Medium),
+        )]);
+
+        assert_eq!(report.applied, 1);
+        assert_eq!(report.still_pending_ids, vec!["wb-forgotten".to_string()]);
+        assert!(
+            !report.is_fully_adjudicated(),
+            "a forgotten pending node must block full adjudication"
+        );
+    }
+
+    #[test]
+    fn writeback_confirmed_without_severity_uses_current() {
+        let _guard = serial();
+        clear_evidence();
+        // node() starts at Medium.
+        push_evidence(node("wb-nosev"));
+
+        let report =
+            apply_validator_verdicts(&[verdict("wb-nosev", VerdictDecision::Confirmed, None)]);
+
+        assert_eq!(report.applied, 1);
+        // Confirmed at the same (current) severity stays Confirmed, not Revised.
+        assert_eq!(status_of("wb-nosev"), Some(ValidationStatus::Confirmed));
     }
 }

--- a/crates/ui/src/session.rs
+++ b/crates/ui/src/session.rs
@@ -46,6 +46,13 @@ static TOOL_REGISTRY: LazyLock<SharedToolRegistry> = LazyLock::new(|| Arc::new(R
 ///
 /// Kept as a flat `Vec` rather than an index because the orchestrator gate
 /// iterates the whole graph anyway, and the UI never looks up nodes by id.
+///
+/// LOCK ORDERING: the only place that touches two evidence locks is
+/// [`drain_tool_evidence_into_graph`], and it fully releases the tool-side
+/// `PENDING_EVIDENCE` lock (inside `drain_pending_evidence`) *before* it
+/// acquires this one — the locks are never held simultaneously, so there is no
+/// deadlock even under concurrent tool execution. Any future code that needs
+/// both must keep that order (PENDING_EVIDENCE first, EVIDENCE_GRAPH second).
 static EVIDENCE_GRAPH: LazyLock<RwLock<Vec<EvidenceNode>>> =
     LazyLock::new(|| RwLock::new(Vec::new()));
 

--- a/crates/ui/src/session.rs
+++ b/crates/ui/src/session.rs
@@ -37,11 +37,12 @@ static TOOL_REGISTRY: LazyLock<SharedToolRegistry> = LazyLock::new(|| Arc::new(R
 /// Process-wide evidence graph that the Generate Report action in the chat
 /// panel reads out (via [`evidence_snapshot`]) and gates into the report.
 ///
-/// INTENDED: tool wrappers / the Red Team agent populate this via
-/// [`push_evidence`]. ACTUAL: [`push_evidence`] has no callers, so this graph is
-/// never populated in production and the report is built from an empty set. Tool
-/// findings currently land in a separate, unbridged buffer
-/// (`pentest_tools::evidence_producer::PENDING_EVIDENCE`). See pick#172.
+/// Populated in production by [`drain_tool_evidence_into_graph`], which the
+/// connector calls after every tool execution to forward the tool-side buffer
+/// (`pentest_tools::evidence_producer::PENDING_EVIDENCE`) into this graph. The
+/// Validator round-trip then transitions each node's `validation_status` via
+/// [`apply_validator_verdicts`] before the report gate will publish it. This is
+/// the bridge that pick#172 identified as missing.
 ///
 /// Kept as a flat `Vec` rather than an index because the orchestrator gate
 /// iterates the whole graph anyway, and the UI never looks up nodes by id.
@@ -155,10 +156,9 @@ pub fn evidence_snapshot() -> Vec<EvidenceNode> {
 
 /// Append a node to the evidence graph.
 ///
-/// INTENDED to be called by tool wrappers after the Red Team Agent produces a
-/// finding and by the Validator Agent when it adjudicates one. It currently has
-/// NO callers, so the evidence graph is never populated in production. Wiring the
-/// tool buffer to this function is tracked in pick#172.
+/// Called by [`drain_tool_evidence_into_graph`] for each finding a tool
+/// produces. Prefer that drain helper at call sites; this is the low-level
+/// primitive it (and tests) build on.
 pub fn push_evidence(node: EvidenceNode) {
     EVIDENCE_GRAPH
         .write()
@@ -166,11 +166,129 @@ pub fn push_evidence(node: EvidenceNode) {
         .push(node);
 }
 
-/// Clear the evidence graph. Typically called at the start of a new
-/// engagement.
+/// Drain the tool-side evidence buffer into the report evidence graph.
+///
+/// This is the production bridge pick#172 identified as missing. Tools push
+/// findings into `pentest_tools::evidence_producer::PENDING_EVIDENCE` as a side
+/// effect of execution; that buffer is process-global and unbounded-until-cap,
+/// so it must be drained into the report graph or the findings never reach
+/// [`evidence_snapshot`] / `gate_for_report`.
+///
+/// The connector calls this after every tool run (see
+/// `liveview_connector::tools`). Draining the *whole* buffer each time is safe
+/// under the parallel-tool execution the connector allows: the `RwLock`
+/// serializes the take, so no node is lost or double-counted.
+///
+/// Returns the number of nodes forwarded, for logging and tests. A zero return
+/// is normal — most tool runs produce no evidence.
+pub fn drain_tool_evidence_into_graph() -> usize {
+    let drained = pentest_tools::evidence_producer::drain_pending_evidence();
+    let count = drained.len();
+    if count > 0 {
+        let mut graph = EVIDENCE_GRAPH
+            .write()
+            .unwrap_or_else(|e| recover_poisoned(e, "EVIDENCE_GRAPH"));
+        graph.extend(drained);
+    }
+    count
+}
+
+/// Clear the evidence graph. Called at the start of a new engagement
+/// (`begin_scan` completion) so findings from a prior scan do not bleed into
+/// the next report.
 pub fn clear_evidence() {
     EVIDENCE_GRAPH
         .write()
         .unwrap_or_else(|e| recover_poisoned(e, "EVIDENCE_GRAPH"))
         .clear();
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+    use pentest_core::export::Severity;
+    use std::sync::Mutex;
+
+    // EVIDENCE_GRAPH and PENDING_EVIDENCE are process-global statics. cargo runs
+    // tests in parallel threads, so a drain in one test can steal another's
+    // freshly-pushed node and `clear_evidence` can wipe the whole graph. These
+    // tests exercise exactly those shared buffers, so we serialize them behind a
+    // module-local lock and tag nodes with unique ids. (Poison is irrelevant —
+    // we only need mutual exclusion, so we recover the guard and continue.)
+    static SERIAL: Mutex<()> = Mutex::new(());
+
+    fn serial() -> std::sync::MutexGuard<'static, ()> {
+        SERIAL.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
+    fn node(id: &str) -> EvidenceNode {
+        EvidenceNode::new(
+            id,
+            "finding",
+            "Open port 22/tcp",
+            "SSH service detected",
+            "10.0.0.1",
+            Severity::Medium,
+            "initial rationale",
+        )
+    }
+
+    fn snapshot_contains(id: &str) -> bool {
+        evidence_snapshot().iter().any(|n| n.id == id)
+    }
+
+    #[test]
+    fn drain_forwards_tool_buffer_into_report_graph() {
+        let _guard = serial();
+        let id = "session-bridge-forward-1";
+        // A tool pushed a finding into the tool-side buffer...
+        pentest_tools::evidence_producer::push_evidence(node(id))
+            .expect("buffer should accept one node");
+        assert!(
+            !snapshot_contains(id),
+            "node must not reach the report graph until it is drained"
+        );
+
+        // ...the connector drains it into the report graph.
+        let forwarded = drain_tool_evidence_into_graph();
+
+        assert!(forwarded >= 1, "at least our node should be forwarded");
+        assert!(
+            snapshot_contains(id),
+            "drained node must appear in the report evidence snapshot"
+        );
+    }
+
+    #[test]
+    fn drain_with_empty_buffer_forwards_nothing_new() {
+        let _guard = serial();
+        // Ensure the tool buffer is empty for our purposes, then draining must
+        // not invent our node.
+        let id = "session-bridge-empty-1";
+        let _ = drain_tool_evidence_into_graph();
+        assert!(
+            !snapshot_contains(id),
+            "draining an empty buffer must not surface an unpushed node"
+        );
+    }
+
+    #[test]
+    fn clear_evidence_drops_forwarded_nodes() {
+        let _guard = serial();
+        let id = "session-bridge-clear-1";
+        pentest_tools::evidence_producer::push_evidence(node(id))
+            .expect("buffer should accept one node");
+        drain_tool_evidence_into_graph();
+        assert!(
+            snapshot_contains(id),
+            "node should be in the graph pre-clear"
+        );
+
+        clear_evidence();
+
+        assert!(
+            !snapshot_contains(id),
+            "clear_evidence must empty the report graph for a fresh engagement"
+        );
+    }
 }

--- a/crates/ui/src/session.rs
+++ b/crates/ui/src/session.rs
@@ -266,7 +266,8 @@ pub fn apply_validator_verdicts(
             Some(node) => {
                 match verdict.decision {
                     VerdictDecision::Confirmed | VerdictDecision::Revised => {
-                        let severity = verdict.severity.unwrap_or_else(|| node.current_severity());
+                        // Confirmed without explicit severity means "keep current severity"
+                        let severity = verdict.severity.unwrap_or(node.current_severity());
                         node.apply_validator_decision(severity, verdict.rationale.clone());
                     }
                     VerdictDecision::FalsePositive => {

--- a/crates/ui/tests/evidence_pipeline.rs
+++ b/crates/ui/tests/evidence_pipeline.rs
@@ -1,0 +1,128 @@
+//! End-to-end regression test for the evidence pipeline (pick#172, pick#174).
+//!
+//! This is the production-path test the issue explicitly asked for: prove that a
+//! real tool's finding travels all the way to the report gate. It exercises the
+//! seams that were unwired in production, without a network or a live agent:
+//!
+//! 1. A tool produces evidence and pushes it into `PENDING_EVIDENCE`
+//!    (here via the real `evidence_from_nmap` builder + `push_evidence`, the
+//!    same calls `nmap.rs` makes in production).
+//! 2. The connector's bridge drains that buffer into the report graph
+//!    (`session::drain_tool_evidence_into_graph`).
+//! 3. The report gate refuses while the drained node is still `Pending`
+//!    (`gate_for_report` -> `GateError::PendingNodes`) — proving evidence
+//!    actually reached the gate rather than silently vanishing.
+//! 4. A Validator verdict is parsed and applied
+//!    (`parse_validator_verdicts` -> `session::apply_validator_verdicts`).
+//! 5. The gate now accepts the graph and the finding appears in the manifest.
+//!
+//! Before pick#172/#174 were wired, step 3 would have seen an empty graph (the
+//! drained node never reached it), so the finding could never appear in a
+//! report. This test fails closed if any of those seams regress.
+
+use pentest_core::orchestrator::{
+    build_pending_evidence_manifest, gate_for_report, parse_validator_verdicts, EngagementInfo,
+    GateError,
+};
+use pentest_core::provenance::{ProbeCommand, Provenance};
+use pentest_tools::evidence_producer::{evidence_from_nmap, push_evidence};
+use pentest_ui::session;
+use serde_json::json;
+
+fn engagement() -> EngagementInfo {
+    EngagementInfo::new("10.0.0.0/24", chrono::Utc::now())
+}
+
+#[test]
+fn tool_finding_reaches_the_report_after_validation() {
+    // A fresh engagement starts by clearing the graph, exactly as the connector
+    // does on `begin_scan`.
+    session::clear_evidence();
+
+    // (1) A real tool produces evidence. This is the same `evidence_from_nmap`
+    // builder the production nmap wrapper uses, fed synthetic scan JSON so the
+    // test needs no network and is deterministic.
+    let nmap_json = json!({
+        "hosts": [{
+            "ip": "10.0.0.1",
+            "ports": [{
+                "port": 22,
+                "protocol": "tcp",
+                "state": "open",
+                "service": "ssh",
+                "version": "OpenSSH 8.9"
+            }]
+        }]
+    });
+    let provenance = Provenance::new(
+        "nmap",
+        "7.95",
+        ProbeCommand::from_exact("nmap -sV 10.0.0.1"),
+        "Nmap scan report for 10.0.0.1\n22/tcp open ssh OpenSSH 8.9",
+    );
+    let nodes = evidence_from_nmap(&nmap_json, "10.0.0.1", provenance);
+    assert_eq!(
+        nodes.len(),
+        1,
+        "one open port should yield one evidence node"
+    );
+    let node_id = nodes[0].id.clone();
+    for node in nodes {
+        push_evidence(node).expect("tool buffer should accept the finding");
+    }
+
+    // (2) The connector bridge drains the tool buffer into the report graph.
+    let forwarded = session::drain_tool_evidence_into_graph();
+    assert!(
+        forwarded >= 1,
+        "the finding should be forwarded to the graph"
+    );
+
+    // (3) The gate must SEE the node — and refuse because it is still Pending.
+    // This is the proof that evidence reached the gate (a pre-#172 empty graph
+    // would have returned an empty manifest here, not PendingNodes).
+    let snapshot = session::evidence_snapshot();
+    match gate_for_report(&snapshot, engagement()) {
+        Err(GateError::PendingNodes { pending_ids }) => {
+            assert!(
+                pending_ids.contains(&node_id),
+                "the drained nmap finding must be the pending node blocking the gate"
+            );
+        }
+        other => panic!("expected PendingNodes before validation, got {other:?}"),
+    }
+
+    // (4) The Validator adjudicates. Build the seed it would receive, then parse
+    // a representative verdict reply and apply it — the real parse+writeback
+    // path, not a hand-mutated node.
+    let pending_manifest = build_pending_evidence_manifest(&snapshot, engagement());
+    assert_eq!(pending_manifest.nodes.len(), 1);
+
+    let validator_reply = format!(
+        "Adjudicated the open SSH port.\n\n```json\n{{\
+         \"verdicts\": [{{\"node_id\": \"{node_id}\", \"decision\": \"confirmed\", \
+         \"severity\": \"medium\", \"rationale\": \"SSH reachable, default port\", \
+         \"confidence\": 0.9}}], \"summary\": {{\"reviewed\": 1}}}}\n```"
+    );
+    let verdicts = parse_validator_verdicts(&validator_reply).expect("verdict reply should parse");
+    let apply = session::apply_validator_verdicts(&verdicts);
+    assert_eq!(apply.applied, 1);
+    assert!(
+        apply.is_fully_adjudicated(),
+        "no nodes should remain pending after the verdict"
+    );
+
+    // (5) The gate now accepts the graph and the finding is in the manifest.
+    let snapshot = session::evidence_snapshot();
+    let manifest = gate_for_report(&snapshot, engagement())
+        .expect("gate should accept a fully-adjudicated graph");
+    assert_eq!(
+        manifest.findings.len(),
+        1,
+        "the confirmed nmap finding must appear in the report manifest"
+    );
+    assert_eq!(manifest.findings[0].id, node_id);
+
+    // Leave the shared graph clean for any other test in this binary.
+    session::clear_evidence();
+}

--- a/crates/ui/tests/evidence_pipeline.rs
+++ b/crates/ui/tests/evidence_pipeline.rs
@@ -27,14 +27,83 @@ use pentest_core::orchestrator::{
 use pentest_core::provenance::{ProbeCommand, Provenance};
 use pentest_tools::evidence_producer::{evidence_from_nmap, push_evidence};
 use pentest_ui::session;
-use serde_json::json;
+use serde_json::{json, Value};
+use std::sync::{Mutex, MutexGuard};
 
 fn engagement() -> EngagementInfo {
     EngagementInfo::new("10.0.0.0/24", chrono::Utc::now())
 }
 
+/// Every test in this binary touches the same process-global evidence state
+/// (`PENDING_EVIDENCE` in `pentest-tools`, `EVIDENCE_GRAPH` in `pentest-ui`).
+/// `cargo test` runs tests in one binary on parallel threads, so without a
+/// shared guard they would race on that global state and flake. Each test
+/// takes this lock for its whole body and clears the graph at both ends.
+static SERIAL: Mutex<()> = Mutex::new(());
+
+fn serial() -> MutexGuard<'static, ()> {
+    // Recover from a poisoned lock: a panic in one test must not wedge the rest.
+    SERIAL.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Build one nmap evidence node for a single open port and push it into the
+/// tool buffer, mirroring exactly what the production nmap wrapper does. Returns
+/// the generated node id so the caller can assert on it.
+fn push_nmap_finding(host_ip: &str, port: u16, service: &str, version: &str) -> String {
+    let nmap_json: Value = json!({
+        "hosts": [{
+            "ip": host_ip,
+            "ports": [{
+                "port": port,
+                "protocol": "tcp",
+                "state": "open",
+                "service": service,
+                "version": version
+            }]
+        }]
+    });
+    let provenance = Provenance::new(
+        "nmap",
+        "7.95",
+        ProbeCommand::from_exact(format!("nmap -sV {host_ip}")),
+        format!("Nmap scan report for {host_ip}\n{port}/tcp open {service} {version}"),
+    );
+    let nodes = evidence_from_nmap(&nmap_json, host_ip, provenance);
+    assert_eq!(
+        nodes.len(),
+        1,
+        "one open port should yield one evidence node"
+    );
+    let node_id = nodes[0].id.clone();
+    for node in nodes {
+        push_evidence(node).expect("tool buffer should accept the finding");
+    }
+    node_id
+}
+
+/// Format a Validator reply that confirms every supplied node id at `medium`.
+fn confirm_all(node_ids: &[String]) -> String {
+    let verdicts: Vec<String> = node_ids
+        .iter()
+        .map(|id| {
+            format!(
+                "{{\"node_id\": \"{id}\", \"decision\": \"confirmed\", \
+                 \"severity\": \"medium\", \"rationale\": \"reproduced\", \
+                 \"confidence\": 0.9}}"
+            )
+        })
+        .collect();
+    format!(
+        "Adjudicated every finding.\n\n```json\n{{\"verdicts\": [{}], \
+         \"summary\": {{\"reviewed\": {}}}}}\n```",
+        verdicts.join(", "),
+        node_ids.len()
+    )
+}
+
 #[test]
 fn tool_finding_reaches_the_report_after_validation() {
+    let _guard = serial();
     // A fresh engagement starts by clearing the graph, exactly as the connector
     // does on `begin_scan`.
     session::clear_evidence();
@@ -124,5 +193,137 @@ fn tool_finding_reaches_the_report_after_validation() {
     assert_eq!(manifest.findings[0].id, node_id);
 
     // Leave the shared graph clean for any other test in this binary.
+    session::clear_evidence();
+}
+
+/// Evidence from several tool runs must accumulate in the graph across
+/// successive drains, and every finding must survive to the report manifest
+/// after validation. This guards the "drain after each tool run" contract: a
+/// regression that dropped earlier evidence on a later drain would show up as a
+/// missing finding here.
+#[test]
+fn multiple_tools_drain_to_report_sequentially() {
+    let _guard = serial();
+    session::clear_evidence();
+
+    // (1) First tool run: nmap finds SSH. Drain immediately, as the connector
+    // does after each tool completes.
+    let ssh_id = push_nmap_finding("10.0.0.1", 22, "ssh", "OpenSSH 8.9");
+    let forwarded_first = session::drain_tool_evidence_into_graph();
+    assert_eq!(forwarded_first, 1, "first drain forwards exactly one node");
+
+    // (2) Second tool run: nmap finds HTTP on another host. Drain again — the
+    // earlier SSH node must still be in the graph.
+    let http_id = push_nmap_finding("10.0.0.2", 80, "http", "nginx 1.25");
+    let forwarded_second = session::drain_tool_evidence_into_graph();
+    assert_eq!(
+        forwarded_second, 1,
+        "second drain forwards exactly one node"
+    );
+
+    let snapshot = session::evidence_snapshot();
+    assert_eq!(
+        snapshot.len(),
+        2,
+        "both findings must accumulate in the graph across drains"
+    );
+
+    // (3) Validate both findings at once, then the gate must publish both.
+    let verdicts = parse_validator_verdicts(&confirm_all(&[ssh_id.clone(), http_id.clone()]))
+        .expect("verdict reply should parse");
+    let apply = session::apply_validator_verdicts(&verdicts);
+    assert_eq!(apply.applied, 2);
+    assert!(
+        apply.is_fully_adjudicated(),
+        "both nodes should be adjudicated"
+    );
+
+    let snapshot = session::evidence_snapshot();
+    let manifest =
+        gate_for_report(&snapshot, engagement()).expect("gate should accept both findings");
+    let ids: Vec<&String> = manifest.findings.iter().map(|f| &f.id).collect();
+    assert_eq!(manifest.findings.len(), 2, "both findings reach the report");
+    assert!(
+        ids.contains(&&ssh_id),
+        "SSH finding must be in the manifest"
+    );
+    assert!(
+        ids.contains(&&http_id),
+        "HTTP finding must be in the manifest"
+    );
+
+    session::clear_evidence();
+}
+
+/// The `drain_tool_evidence_into_graph` docs claim the drain is safe under
+/// concurrent tool execution: tools may be pushing into `PENDING_EVIDENCE`
+/// while the connector drains. This test demonstrates that property instead of
+/// merely asserting it — many producer threads push while a drainer thread runs
+/// concurrently, and afterwards every pushed node must be accounted for exactly
+/// once (none lost, none duplicated) across what the drainer forwarded plus
+/// whatever remains buffered for the final drain.
+#[test]
+fn drain_is_safe_under_concurrent_tool_execution() {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    let _guard = serial();
+    session::clear_evidence();
+
+    const PRODUCERS: usize = 8;
+    const PER_PRODUCER: usize = 25;
+    let total_pushed = PRODUCERS * PER_PRODUCER;
+
+    let stop = Arc::new(AtomicBool::new(false));
+
+    // Producer threads: each pushes PER_PRODUCER distinct nmap findings.
+    let mut producers = Vec::new();
+    for p in 0..PRODUCERS {
+        producers.push(std::thread::spawn(move || {
+            for i in 0..PER_PRODUCER {
+                // Unique host/port per push keeps node ids distinct and human-readable.
+                let host = format!("10.0.{p}.{i}");
+                push_nmap_finding(&host, 8000 + i as u16, "http", "nginx 1.25");
+            }
+        }));
+    }
+
+    // Drainer thread: repeatedly drains into the graph while producers run,
+    // accumulating a running count of everything it forwarded.
+    let drainer_stop = Arc::clone(&stop);
+    let drainer = std::thread::spawn(move || {
+        let mut drained = 0usize;
+        while !drainer_stop.load(Ordering::Relaxed) {
+            drained += session::drain_tool_evidence_into_graph();
+            std::thread::yield_now();
+        }
+        drained
+    });
+
+    for producer in producers {
+        producer.join().expect("producer thread should not panic");
+    }
+    // All producers are done; tell the drainer to finish its loop.
+    stop.store(true, Ordering::Relaxed);
+    let drained_during = drainer.join().expect("drainer thread should not panic");
+
+    // A final drain sweeps up anything pushed after the drainer's last pass.
+    let drained_after = session::drain_tool_evidence_into_graph();
+
+    // Every pushed node must be forwarded exactly once: nothing lost to a race,
+    // nothing double-counted.
+    assert_eq!(
+        drained_during + drained_after,
+        total_pushed,
+        "every pushed node must be forwarded exactly once across concurrent drains"
+    );
+    // And the graph must hold exactly those nodes.
+    let snapshot = session::evidence_snapshot();
+    assert_eq!(
+        snapshot.len(),
+        total_pushed,
+        "the graph must contain every forwarded node with no duplicates"
+    );
+
     session::clear_evidence();
 }

--- a/docs/BUILD_TROUBLESHOOTING.md
+++ b/docs/BUILD_TROUBLESHOOTING.md
@@ -1,0 +1,669 @@
+# Build Troubleshooting Guide
+
+Common build errors and their solutions when building Pick.
+
+---
+
+## Quick Diagnosis
+
+Run this command to identify your build issue:
+
+```bash
+cargo build --package pentest-headless 2>&1 | tee build-error.log
+```
+
+Then search this page for your error message.
+
+---
+
+## Table of Contents
+
+- [Rust Version Issues](#rust-version-issues)
+- [OpenSSL Errors](#openssl-errors)
+- [pkg-config Errors](#pkg-config-errors)
+- [protobuf / protoc Errors](#protobuf--protoc-errors)
+- [libpcap Errors](#libpcap-errors)
+- [Linker Errors](#linker-errors)
+- [Platform-Specific Issues](#platform-specific-issues)
+- [Clean Build](#clean-build)
+
+---
+
+## Rust Version Issues
+
+### Error: "package requires rustc 1.92 or newer"
+
+**Symptom:**
+```
+error: package `egui v0.XX.X` cannot be built because it requires rustc 1.92.0 or newer
+```
+
+**Cause:** Pick requires Rust 1.92+ due to egui dependency requirements.
+
+**Solution:**
+```bash
+# Update Rust
+rustup update stable
+
+# Verify version
+rustc --version
+# Should show: rustc 1.92.0 or higher
+```
+
+**If rustup update doesn't work:**
+```bash
+# Install latest stable explicitly
+rustup install stable
+rustup default stable
+```
+
+---
+
+### Error: "edition 2021 is unstable"
+
+**Symptom:**
+```
+error: edition 2021 is unstable and only available with -Z unstable-options
+```
+
+**Cause:** Using an old Rust version that doesn't support Edition 2021.
+
+**Solution:**
+```bash
+# Update to Rust 1.56+ (Edition 2021 minimum)
+rustup update stable
+```
+
+---
+
+## OpenSSL Errors
+
+### Error: "Could not find directory of OpenSSL installation"
+
+**Symptom:**
+```
+error: failed to run custom build command for `openssl-sys v0.X.XX`
+Could not find directory of OpenSSL installation
+```
+
+**Cause:** OpenSSL development headers not installed or not found.
+
+**Solution (Debian/Ubuntu):**
+```bash
+sudo apt update
+sudo apt install libssl-dev pkg-config
+```
+
+**Solution (Fedora/RHEL):**
+```bash
+sudo dnf install openssl-devel pkg-config
+```
+
+**Solution (macOS):**
+```bash
+brew install openssl@3
+
+# Set environment variable for build
+export OPENSSL_DIR=$(brew --prefix openssl@3)
+cargo build
+```
+
+**Solution (Arch Linux):**
+```bash
+sudo pacman -S openssl pkg-config
+```
+
+---
+
+### Error: "OpenSSL version mismatch"
+
+**Symptom:**
+```
+error: OpenSSL version 1.1.1 is not supported
+note: version 3.0 or later is required
+```
+
+**Cause:** System has old OpenSSL version.
+
+**Solution (Ubuntu 22.04+):**
+```bash
+sudo apt install libssl-dev
+# Should install OpenSSL 3.x
+```
+
+**Solution (Ubuntu 20.04 or older):**
+```bash
+# Upgrade to Ubuntu 22.04, or build OpenSSL from source
+# Or use vendored OpenSSL:
+cargo build --features vendored-openssl
+```
+
+---
+
+## pkg-config Errors
+
+### Error: "Could not run `pkg-config`"
+
+**Symptom:**
+```
+error: failed to run custom build command for `openssl-sys`
+pkg-config has not been configured to support cross-compilation
+```
+
+**Cause:** `pkg-config` not installed.
+
+**Solution (Debian/Ubuntu):**
+```bash
+sudo apt install pkg-config
+```
+
+**Solution (Fedora/RHEL):**
+```bash
+sudo dnf install pkgconf-pkg-config
+```
+
+**Solution (macOS):**
+```bash
+brew install pkg-config
+```
+
+**Solution (Arch Linux):**
+```bash
+sudo pacman -S pkgconf
+```
+
+---
+
+## protobuf / protoc Errors
+
+### Error: "Could not find `protoc` installation"
+
+**Symptom:**
+```
+error: failed to run custom build command for `prost-build`
+Could not find `protoc` installation
+```
+
+**Cause:** Protocol Buffers compiler (protoc) not installed.
+
+**Solution (Debian/Ubuntu):**
+```bash
+sudo apt install protobuf-compiler
+```
+
+**Solution (Fedora/RHEL):**
+```bash
+sudo dnf install protobuf-compiler
+```
+
+**Solution (macOS):**
+```bash
+brew install protobuf
+```
+
+**Solution (Arch Linux):**
+```bash
+sudo pacman -S protobuf
+```
+
+**Verify installation:**
+```bash
+protoc --version
+# Should show: libprotoc 3.x or higher
+```
+
+---
+
+### Error: "protoc version too old"
+
+**Symptom:**
+```
+error: protoc version 2.X is too old, need 3.0 or later
+```
+
+**Solution:**
+```bash
+# Debian/Ubuntu
+sudo apt update
+sudo apt install --reinstall protobuf-compiler
+
+# macOS
+brew upgrade protobuf
+
+# Verify
+protoc --version
+```
+
+---
+
+## libpcap Errors
+
+### Error: "Could not find library `pcap`"
+
+**Symptom:**
+```
+error: failed to run custom build command for `pcap-sys`
+Could not find library `pcap` required for `libpcap`
+```
+
+**Cause:** libpcap development headers not installed (required for packet capture features).
+
+**Solution (Debian/Ubuntu):**
+```bash
+sudo apt install libpcap-dev
+```
+
+**Solution (Fedora/RHEL):**
+```bash
+sudo dnf install libpcap-devel
+```
+
+**Solution (macOS):**
+```bash
+# Usually pre-installed, but if missing:
+brew install libpcap
+```
+
+**Solution (Arch Linux):**
+```bash
+sudo pacman -S libpcap
+```
+
+---
+
+## Linker Errors
+
+### Error: "linking with `cc` failed"
+
+**Symptom:**
+```
+error: linking with `cc` failed: exit status: 1
+ld: library not found for -lssl
+```
+
+**Cause:** Linker cannot find required libraries.
+
+**Solution:**
+
+1. **Install missing development packages:**
+```bash
+# Debian/Ubuntu
+sudo apt install build-essential libssl-dev libpcap-dev
+
+# Fedora/RHEL
+sudo dnf install gcc openssl-devel libpcap-devel
+
+# macOS
+xcode-select --install
+```
+
+2. **Set library path (macOS):**
+```bash
+export LIBRARY_PATH=$(brew --prefix)/lib
+export CPATH=$(brew --prefix)/include
+cargo build
+```
+
+---
+
+### Error: "cannot find -lpthread"
+
+**Symptom:**
+```
+error: linking with `cc` failed
+ld: cannot find -lpthread
+```
+
+**Cause:** Missing glibc development files.
+
+**Solution (Debian/Ubuntu):**
+```bash
+sudo apt install build-essential libc6-dev
+```
+
+**Solution (Fedora/RHEL):**
+```bash
+sudo dnf install glibc-devel
+```
+
+---
+
+## Platform-Specific Issues
+
+### Linux
+
+#### Error: "failed to load shared library"
+
+**Symptom:**
+```
+error while loading shared libraries: libssl.so.3: cannot open shared object file
+```
+
+**Solution:**
+```bash
+# Update library cache
+sudo ldconfig
+
+# Or install missing library
+sudo apt install libssl3  # Debian/Ubuntu
+sudo dnf install openssl-libs  # Fedora/RHEL
+```
+
+---
+
+### macOS
+
+#### Error: "xcrun: error: invalid active developer path"
+
+**Symptom:**
+```
+xcrun: error: invalid active developer path
+```
+
+**Solution:**
+```bash
+# Install Xcode command-line tools
+xcode-select --install
+
+# If already installed, reset path
+sudo xcode-select --reset
+```
+
+---
+
+#### Error: "ld: framework 'Security' not found"
+
+**Symptom:**
+```
+error: linking with `cc` failed
+ld: framework 'Security' not found
+```
+
+**Solution:**
+```bash
+# Install Xcode command-line tools
+xcode-select --install
+
+# Ensure Xcode is up to date
+softwareupdate --all --install --force
+```
+
+---
+
+### Windows (WSL)
+
+#### Error: "error: linker `cc` not found"
+
+**Symptom:**
+```
+error: linker `cc` not found
+```
+
+**Solution:**
+```bash
+# Install build tools in WSL
+sudo apt update
+sudo apt install build-essential
+```
+
+---
+
+#### Error: "could not find native TLS library"
+
+**Solution:**
+```bash
+# Install OpenSSL in WSL
+sudo apt install libssl-dev pkg-config
+```
+
+---
+
+### Android
+
+See [ANDROID_BUILD.md](ANDROID_BUILD.md) for Android-specific build issues.
+
+---
+
+## Clean Build
+
+If you encounter persistent build issues, try a clean build:
+
+```bash
+# Remove all build artifacts
+cargo clean
+
+# Remove Cargo.lock (regenerates dependencies)
+rm Cargo.lock
+
+# Clear Cargo registry cache (nuclear option)
+rm -rf ~/.cargo/registry/cache
+rm -rf ~/.cargo/git/checkouts
+
+# Rebuild
+cargo build --package pentest-headless
+```
+
+---
+
+## Dependency Issues
+
+### Error: "failed to download dependencies"
+
+**Symptom:**
+```
+error: failed to download `crate-name v1.0.0`
+```
+
+**Cause:** Network issues or corrupted cache.
+
+**Solution:**
+```bash
+# Update cargo index
+cargo update
+
+# If that fails, clear and re-fetch
+rm -rf ~/.cargo/registry/index
+cargo fetch
+```
+
+---
+
+### Error: "version conflict in dependencies"
+
+**Symptom:**
+```
+error: failed to select a version for `crate-name`
+```
+
+**Solution:**
+```bash
+# Update dependencies
+cargo update
+
+# If specific conflict, update Cargo.toml version constraints
+# Then:
+cargo clean
+cargo build
+```
+
+---
+
+## Incremental Compilation Issues
+
+### Error: "incremental compilation data is corrupt"
+
+**Symptom:**
+```
+error: internal compiler error: incremental compilation data is corrupt
+```
+
+**Solution:**
+```bash
+# Remove incremental compilation cache
+rm -rf target/debug/incremental
+rm -rf target/release/incremental
+
+# Rebuild
+cargo build
+```
+
+---
+
+## Out of Memory Errors
+
+### Error: "signal: 9, SIGKILL: kill"
+
+**Symptom:**
+```
+error: could not compile `crate-name`
+Caused by: signal: 9, SIGKILL: kill
+```
+
+**Cause:** Rust compiler ran out of memory (common on small VMs).
+
+**Solution:**
+
+1. **Reduce parallel compilation:**
+```bash
+# Build with fewer parallel jobs
+cargo build -j 2
+
+# Or set permanently
+export CARGO_BUILD_JOBS=2
+```
+
+2. **Increase swap:**
+```bash
+# Check current swap
+free -h
+
+# Add swap file (Ubuntu/Debian)
+sudo fallocate -l 4G /swapfile
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+```
+
+3. **Build in release mode (uses less memory):**
+```bash
+cargo build --release
+```
+
+---
+
+## Still Having Issues?
+
+### 1. Check Prerequisites
+
+Ensure all required dependencies are installed:
+
+```bash
+# Rust version
+rustc --version  # Should be 1.92.0+
+
+# Required tools
+pkg-config --version
+protoc --version
+openssl version
+```
+
+### 2. Enable Verbose Output
+
+```bash
+# See detailed error messages
+cargo build -vv 2>&1 | tee build-error.log
+```
+
+### 3. Search GitHub Issues
+
+Check existing issues: https://github.com/Strike48-public/pick/issues
+
+### 4. Ask for Help
+
+- **GitHub Discussions:** https://github.com/Strike48-public/pick/discussions
+- **Create an issue:** Include your `build-error.log` file
+- **Include:**
+  - OS and version (`uname -a`)
+  - Rust version (`rustc --version`)
+  - Full error output
+  - What you've already tried
+
+---
+
+## Common Environment Setup
+
+### Debian/Ubuntu (All Dependencies)
+
+```bash
+sudo apt update
+sudo apt install -y \
+    build-essential \
+    libssl-dev \
+    pkg-config \
+    protobuf-compiler \
+    libpcap-dev \
+    git \
+    curl
+
+# Install Rust if not present
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+
+# Update to latest stable
+rustup update stable
+```
+
+### Fedora/RHEL (All Dependencies)
+
+```bash
+sudo dnf install -y \
+    gcc \
+    openssl-devel \
+    pkgconf-pkg-config \
+    protobuf-compiler \
+    libpcap-devel \
+    git \
+    curl
+
+# Install Rust
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+```
+
+### macOS (All Dependencies)
+
+```bash
+# Install Homebrew if not present
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+# Install dependencies
+brew install openssl@3 protobuf libpcap pkg-config
+
+# Install Rust
+curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
+source "$HOME/.cargo/env"
+
+# Set environment for OpenSSL
+export OPENSSL_DIR=$(brew --prefix openssl@3)
+```
+
+### Arch Linux (All Dependencies)
+
+```bash
+sudo pacman -Syu
+sudo pacman -S --needed \
+    base-devel \
+    openssl \
+    pkgconf \
+    protobuf \
+    libpcap \
+    git \
+    rustup
+
+# Install stable Rust
+rustup default stable
+```
+
+---
+
+**Last updated:** 2026-05-28

--- a/docs/BWRAP_SUDO_EXPLAINED.md
+++ b/docs/BWRAP_SUDO_EXPLAINED.md
@@ -1,0 +1,307 @@
+# Why Pick Requires Sudo for WiFi Tools
+
+This document explains the technical requirements for WiFi penetration testing and why certain Pick features require root privileges.
+
+---
+
+## Quick Answer
+
+**WiFi penetration testing tools require direct hardware access to wireless adapters.** This includes:
+- Enabling monitor mode
+- Packet injection
+- Raw socket access
+- Changing MAC addresses
+- Controlling RF parameters
+
+These operations require kernel-level privileges that only root (sudo) can provide.
+
+---
+
+## What is Bubblewrap (bwrap)?
+
+**Bubblewrap** (`bwrap`) is a lightweight Linux sandboxing tool that creates isolated namespaces for running applications.
+
+**Pick can optionally use bwrap to:**
+- Isolate tool execution from the main process
+- Limit filesystem access
+- Restrict network capabilities
+- Provide defense-in-depth security
+
+**However:** Even with bwrap, WiFi tools still need elevated privileges because they require hardware access that cannot be namespaced.
+
+---
+
+## Why WiFi Tools Specifically Need Root
+
+### 1. Monitor Mode
+
+**What it is:** WiFi monitor mode allows the adapter to capture all wireless traffic, not just packets addressed to it.
+
+**Why root is required:**
+- Requires changing the adapter's operating mode via kernel drivers
+- Uses `nl80211` netlink interface (privileged)
+- Disables firmware-level filtering
+
+**Tools that need this:**
+- `wifi_scan`
+- `wifi_scan_detailed`
+- `autopwn_capture`
+- `aircrack-ng`
+- `airodump-ng`
+
+### 2. Packet Injection
+
+**What it is:** Sending raw 802.11 frames to the wireless medium.
+
+**Why root is required:**
+- Raw socket creation requires `CAP_NET_RAW` capability
+- Firmware must be instructed to transmit crafted frames
+- Timing and sequence control requires kernel access
+
+**Tools that need this:**
+- `autopwn_crack`
+- `aireplay-ng`
+- `mdk4`
+
+### 3. Interface Management
+
+**What it is:** Creating virtual interfaces, changing MAC addresses, setting channels.
+
+**Why root is required:**
+- `iw` commands require `CAP_NET_ADMIN` capability
+- `/dev/rfkill` access needs root
+- `/sys/class/net/` modifications are privileged
+
+**Operations:**
+- Creating `mon0` monitor interface
+- MAC address spoofing
+- Channel hopping
+- TX power adjustment
+
+### 4. Raw Socket Access
+
+**What it is:** Creating sockets that can send/receive raw Ethernet frames.
+
+**Why root is required:**
+- `socket(AF_PACKET, SOCK_RAW, ...)` requires `CAP_NET_RAW`
+- Bypasses normal network stack
+- Can forge source addresses
+
+---
+
+## Security Implications
+
+### Running Pick with Sudo
+
+**Risks:**
+- Pick process runs as root
+- Compromised tool execution could affect entire system
+- Malicious tools could escape sandbox
+
+**Mitigations:**
+- Pick only uses sudo for WiFi-specific operations
+- Desktop mode runs GUI as user, tools as root
+- Bubblewrap isolation (when available) limits blast radius
+
+### Alternative: Capabilities
+
+**Can we use Linux capabilities instead of sudo?**
+
+Partially. You can grant specific capabilities:
+
+```bash
+# Grant CAP_NET_RAW and CAP_NET_ADMIN to the binary
+sudo setcap cap_net_raw,cap_net_admin+eip /path/to/pentest-headless
+```
+
+**Limitations:**
+- Still requires initial sudo to set capabilities
+- Doesn't work for all WiFi operations
+- Some drivers require full root regardless
+- Capabilities don't persist across binary updates
+
+### Recommended Approach
+
+**For operators:**
+1. Run Pick headless mode with sudo only when using WiFi tools
+2. Use network scanning tools (port_scan, nmap) without sudo
+3. Isolate Pick instances to dedicated VMs/containers when possible
+
+**For development:**
+1. Test WiFi features in isolated environments
+2. Use `just run-headless-sudo` or `./run-pentest.sh headless` (includes sudo)
+3. Never run development builds as root unnecessarily
+
+---
+
+## Platform Differences
+
+### Linux
+
+**Full WiFi support:**
+- All monitor mode operations work
+- Packet injection supported (driver-dependent)
+- Bubblewrap available for isolation
+
+**Recommended:**
+```bash
+# Install bubblewrap
+sudo apt install bubblewrap
+
+# Pick will automatically use it when available
+./run-pentest.sh headless
+```
+
+### macOS
+
+**Limited WiFi support:**
+- Monitor mode supported via `airport` utility
+- Packet injection NOT supported on most hardware
+- No bubblewrap (use sandbox-exec instead)
+
+**Requires:**
+- Xcode command-line tools
+- May require disabling System Integrity Protection (SIP) for some tools
+
+### Android
+
+**Root required:**
+- Must have rooted device for monitor mode
+- Requires custom firmware on many chipsets
+- Pick's Android app detects root and warns if unavailable
+
+**See:** [ANDROID_BUILD.md](ANDROID_BUILD.md) for details
+
+### Windows (WSL)
+
+**Works via WSL2:**
+- Run Pick in WSL2 with Linux WiFi adapter passthrough
+- Or use external WiFi adapter in WSL
+- Native Windows support in development
+
+---
+
+## Alternatives to Running as Root
+
+### Option 1: Network Namespace Isolation
+
+Run Pick in a dedicated network namespace with only the WiFi adapter:
+
+```bash
+# Create network namespace
+sudo ip netns add pick-ns
+sudo ip netns exec pick-ns ./run-pentest.sh headless
+```
+
+**Benefits:**
+- Isolates network access
+- Limits blast radius of compromised tools
+
+### Option 2: Dedicated WiFi Adapter
+
+Use an external USB WiFi adapter for pentesting:
+
+**Benefits:**
+- Main internet connection stays active
+- Can pass adapter to VM/container
+- Physical isolation from production network
+
+**Recommended adapters:** See [README.md](../README.md#recommended-wifi-adapters)
+
+### Option 3: Remote Tool Execution
+
+Configure Pick to execute WiFi tools on a remote machine:
+
+**Benefits:**
+- Operator machine doesn't need sudo
+- Tools run in isolated environment
+- Can use dedicated pentesting hardware
+
+**Trade-offs:**
+- More complex setup
+- Network latency affects real-time tools
+
+---
+
+## Non-WiFi Tools (No Sudo Required)
+
+These Pick tools work **without sudo**:
+
+**Network Scanning:**
+- `port_scan` - TCP connect scanning
+- `arp_table` - Read ARP cache
+- `network_discover` - mDNS discovery
+- `ssdp_discover` - UPnP discovery
+
+**Web Testing:**
+- `web_vuln_scan` - HTTP vulnerability scanning
+- All external web tools (nikto, sqlmap, etc.)
+
+**System Information:**
+- `device_info` - System information gathering
+- `list_files` - File system enumeration
+- `read_file` - File reading (within permissions)
+
+**External Tools:**
+Most BlackArch tools work without root unless they specifically need raw sockets or hardware access.
+
+---
+
+## Frequently Asked Questions
+
+### Q: Can I run Pick without ever using sudo?
+
+**A:** Yes, if you only use non-WiFi tools. Network scanning, web testing, and credential testing work without sudo.
+
+### Q: Why doesn't Pick use setuid instead?
+
+**A:** Setuid binaries are security risks. Modern Linux recommends capabilities or explicit sudo instead.
+
+### Q: Can I audit what Pick does with root privileges?
+
+**A:** Yes. Pick is open source. Review:
+- `crates/platform/src/linux.rs` - Linux-specific operations
+- `crates/tools/src/wifi_scan.rs` - WiFi tool implementations
+- `crates/tools/src/external/aircrack.rs` - External tool wrappers
+
+### Q: Does Strike48 require sudo?
+
+**A:** No. Strike48 (the control plane) runs as a normal user. Only Pick connectors need sudo for WiFi operations.
+
+---
+
+## Security Best Practices
+
+1. **Principle of Least Privilege:**
+   - Only use sudo for operations that require it
+   - Run non-WiFi tasks without sudo
+
+2. **Audit Tool Execution:**
+   - Review logs in `~/tmp/pentest.log`
+   - Monitor tool behavior with `strace` if suspicious
+
+3. **Isolate Pentesting:**
+   - Use dedicated machines/VMs for pentesting
+   - Don't run Pick with sudo on production systems
+
+4. **Keep Pick Updated:**
+   - Security fixes may reduce privilege requirements
+   - Future versions may support capability-based execution
+
+5. **Report Security Issues:**
+   - Use [GitHub Security Advisories](https://github.com/Strike48-public/pick/security/advisories/new)
+   - See [SECURITY.md](../SECURITY.md) for full reporting process
+
+---
+
+## References
+
+- [Linux Capabilities Man Page](https://man7.org/linux/man-pages/man7/capabilities.7.html)
+- [Bubblewrap Documentation](https://github.com/containers/bubblewrap)
+- [nl80211 Interface](https://wireless.wiki.kernel.org/en/developers/documentation/nl80211)
+- [WiFi Monitor Mode](https://en.wikipedia.org/wiki/Monitor_mode)
+- [Aircrack-ng Suite](https://www.aircrack-ng.org/)
+
+---
+
+**Last updated:** 2026-05-28

--- a/run-pentest.sh
+++ b/run-pentest.sh
@@ -50,8 +50,7 @@ else
     # Set defaults
     export STRIKE48_HOST="${STRIKE48_HOST:-ws://localhost:3030}"
     export STRIKE48_TENANT="${STRIKE48_TENANT:-non-prod}"
-    export MATRIX_API_URL="${MATRIX_API_URL:-http://localhost:3030}"
-    export MATRIX_TENANT_ID="${MATRIX_TENANT_ID:-non-prod}"
+    export STRIKE48_API_URL="${STRIKE48_API_URL:-http://localhost:3030}"
     export RUST_LOG="${RUST_LOG:-debug}"
 fi
 
@@ -85,7 +84,7 @@ log_info "  App Type:     ${APP_TYPE}"
 log_info "  Mode:         ${MODE}"
 log_info "  Strike48:     ${STRIKE48_HOST}"
 log_info "  Tenant:       ${STRIKE48_TENANT}"
-log_info "  Matrix API:   ${MATRIX_API_URL}"
+log_info "  API URL:      ${STRIKE48_API_URL}"
 log_info "  Log Level:    ${RUST_LOG}"
 log_info "  Log File:     ${LOG_FILE}"
 log_info ""

--- a/run-pentest.sh
+++ b/run-pentest.sh
@@ -58,24 +58,26 @@ fi
 ORIGINAL_USER="${SUDO_USER:-$USER}"
 ORIGINAL_HOME=$(eval echo "~$ORIGINAL_USER")
 
-# Check if running as root (needed for WiFi hardware access)
-if [[ $EUID -ne 0 ]]; then
-    log_warn "Not running as root - WiFi hardware access will not work"
-    log_info "WiFi tools (autopwn, wifi_scan, airmon-ng) require root privileges"
+# Note: WiFi tools (airmon-ng, etc.) will prompt for sudo when needed
+# No need to run the entire script as root
+if [[ $EUID -eq 0 ]]; then
+    log_warn "Running as root - this is not recommended"
+    log_info "WiFi tools will request sudo when needed"
     log_info ""
-    log_info "Restarting with sudo..."
-    exec sudo -E "$0" "$@"
-fi
 
-log_success "Running as root - WiFi hardware access enabled"
+    # If running as root, ensure .pick directory is owned by the original user
+    if [[ -n "$SUDO_USER" ]]; then
+        PICK_DIR="${ORIGINAL_HOME}/.pick"
+        if [[ -d "$PICK_DIR" ]]; then
+            chown -R "${ORIGINAL_USER}:${ORIGINAL_USER}" "$PICK_DIR" 2>/dev/null || true
+        fi
 
-# Set up Rust environment from the original user
-if [[ -n "$SUDO_USER" ]]; then
-    # Running via sudo, use the calling user's Rust installation
-    export PATH="${ORIGINAL_HOME}/.cargo/bin:$PATH"
-    export CARGO_HOME="${ORIGINAL_HOME}/.cargo"
-    export RUSTUP_HOME="${ORIGINAL_HOME}/.rustup"
-    log_info "Using Rust from user: $ORIGINAL_USER"
+        # Set up Rust environment from the original user
+        export PATH="${ORIGINAL_HOME}/.cargo/bin:$PATH"
+        export CARGO_HOME="${ORIGINAL_HOME}/.cargo"
+        export RUSTUP_HOME="${ORIGINAL_HOME}/.rustup"
+        log_info "Using Rust from user: $ORIGINAL_USER"
+    fi
 fi
 
 # Display configuration


### PR DESCRIPTION
## Summary

Fixes pick#172 and closes seams 1-3 of the pick#174 epic: in a native production build, tool-produced evidence never reached the final report. Tools pushed findings into one process-global buffer (`PENDING_EVIDENCE`, in `pentest-tools`) while the Generate Report path read a different, never-populated one (`EVIDENCE_GRAPH`, in `pentest-ui`). Nothing bridged them, so `gate_for_report` always built an empty manifest. Real engagements produced findingless reports; only `inject_test_evidence` and direct-injection tests reached the report path, so CI and demos never caught it.

Fixing the bridge alone would have made things worse, not better (as the issue thread warned): every drained node lands as `Pending`, and there was no production Validator writeback to clear it, so the gate would refuse forever. This PR therefore wires the whole round-trip:

**tool -> `PENDING_EVIDENCE` -> `EVIDENCE_GRAPH` -> Validator adjudication -> `gate_for_report` -> Report Agent**

## Changes (phased commits)

1. **Evidence bridge** - `session::drain_tool_evidence_into_graph()`, called after every tool run in the connector's `handle_execute_impl` (the one tool path shared by headless and desktop). `clear_evidence()` on `begin_scan` success so scans don't bleed together.
2. **Validator seed + parser (core)** - `build_pending_evidence_manifest` / `build_validator_seed_message` (symmetric to the existing Report seed) and `parse_validator_verdicts`, which extracts the fenced JSON block and rejects malformed/absent blocks and `revised`-without-severity rather than failing open. Takes only the first block so a trailing one can't override it.
3. **Verdict writeback** - `session::apply_validator_verdicts` transitions each node by id and returns a `VerdictApplyReport` (applied / unmatched ids / still-pending). Nothing is dropped silently.
4. **UI wiring** - a "Validate Findings" header action (beside Generate Report) seeds the Validator, polls, then parses and applies verdicts, surfacing the outcome to the operator. Report generation stays blocked until every finding is adjudicated.
5. **Integration test + docs** - `crates/ui/tests/evidence_pipeline.rs` drives the real seam end to end (nmap evidence builder -> drain -> gate refuses while Pending -> verdict -> gate accepts -> finding in manifest). Corrected the `ARCHITECTURE.md` and code comments that asserted a flow which did not exist.

## Test plan

- [x] `cargo clippy --workspace --features pentest-platform/desktop-pcap -- -D warnings` clean
- [x] `cargo test --workspace --features pentest-platform/desktop-pcap` green (core 216, ui 46, tools 234, new integration test 1; 0 failures)
- [x] `cargo fmt --all --check` clean
- [x] New unit tests: parser (7), writeback (4), bridge (3); new end-to-end integration test (1)
- [ ] Live run: connect, run nmap against a target, Validate Findings, Generate Report, confirm the nmap finding appears (the runtime confirmation the issue asked whoever picks it up to do)

## Notes

- Evidence is process-local to the connector; it is not synced to Strike48 (the Matrix client carries no evidence wire types). Documented in ARCHITECTURE.md.
- Seam 4 (gate -> Report Agent) already worked; seam 5 (recon -> spawn handoff) is out of scope and stays on pick#174.
- Lock ordering (PENDING_EVIDENCE before EVIDENCE_GRAPH; never held simultaneously) is documented on the static to prevent future deadlocks.