### PR TITLE
fix(chat): revert send path to native events for Windows/WebView2 (#189)

### DIFF
--- a/crates/ui/src/assets/utils.js
+++ b/crates/ui/src/assets/utils.js
@@ -117,66 +117,6 @@
     };
 
     /**
-     * Install document-level delegated listeners for the chat textarea:
-     *  - `input` events auto-resize the textarea between 40px and 200px,
-     *  - `keydown` Enter (no Shift) dispatches a send,
-     *  - `click` on a `.chat-send-btn` dispatches a send.
-     *
-     * `sendCallback` is invoked with the textarea text on each send trigger.
-     * It is wired to `dioxus.send` by Rust so submissions return over the
-     * eval channel instead of through dioxus's broken `convert_form_data`
-     * path (#130). The callback is overwritten on every call so a re-mounted
-     * ChatInput points the listeners at the new eval's `dioxus.send`.
-     *
-     * Idempotent for the listener install; the callback rebind is intentional.
-     */
-    window.installChatSendBridge = function(sendCallback) {
-        window.__chatSendDispatch = sendCallback;
-        if (window.__chatSendBridgeInstalled) return;
-        window.__chatSendBridgeInstalled = true;
-
-        function fireSend() {
-            var el = document.querySelector('.chat-textarea');
-            if (!el || el.disabled) return;
-            var text = el.value;
-            if (!text || !text.trim()) return;
-            if (typeof window.__chatSendDispatch === 'function') {
-                window.__chatSendDispatch(text);
-            }
-        }
-
-        // Auto-resize on every keystroke.
-        document.addEventListener('input', function(e) {
-            var t = e.target;
-            if (t && t.classList && t.classList.contains('chat-textarea')) {
-                t.style.height = 'auto';
-                t.style.height = Math.min(Math.max(t.scrollHeight, 40), 200) + 'px';
-            }
-        });
-
-        // Enter (no Shift) inside the chat textarea sends.
-        document.addEventListener('keydown', function(e) {
-            var t = e.target;
-            if (t && t.classList && t.classList.contains('chat-textarea')
-                && e.key === 'Enter' && !e.shiftKey) {
-                e.preventDefault();
-                fireSend();
-            }
-        });
-
-        // Send button click sends. preventDefault stops the native form-submit
-        // path (button is type="submit") so we don't trigger any dioxus
-        // onsubmit listener — there shouldn't be one, but be defensive.
-        document.addEventListener('click', function(e) {
-            var t = e.target;
-            if (t && t.classList && t.classList.contains('chat-send-btn')) {
-                e.preventDefault();
-                fireSend();
-            }
-        });
-    };
-
-    /**
      * Trigger chart post-processing (mermaid + echarts) on the next animation frame.
      * Calls window.__processChatCharts if it has been defined by chart_processor.js.
      */

--- a/crates/ui/src/components/chat_panel/input.rs
+++ b/crates/ui/src/components/chat_panel/input.rs
@@ -1,14 +1,13 @@
 //! Chat input area: auto-resizing textarea + Send button.
 //!
-//! All keystrokes, Enter-to-send, and Send-button clicks are handled by a
-//! delegated JavaScript listener (`installChatSendBridge` in utils.js). Sends
-//! are funneled back to Rust via a long-lived `document::eval` channel.
-//!
-//! This bypasses dioxus's `onsubmit` / `onkeydown` / `oninput` event path,
-//! which trips the `.unwrap()` in dioxus-liveview-0.7.x's `convert_form_data`
-//! and `convert_keyboard_data` once the conversation accumulates DOM state
-//! (#130). A pleasant side effect is that we no longer pay a WebSocket round
-//! trip per keystroke for auto-resize.
+//! Uses native Dioxus events (`oninput`, `onkeydown`, `onclick`) for the send
+//! path, matching KubeStudio's pattern. This deliberately reverts the JS-bridge
+//! rerouting from #132 while keeping the per-bubble `onmounted` removal in
+//! `messages.rs` — that removal is what actually fixed #130 (panic in
+//! `dioxus-liveview` 0.7.x `convert_mounted_data`). Sending through
+//! `document::eval`'s reverse channel (`dioxus.send`) doesn't deliver on
+//! Windows/WebView2 when Pick is hosted inside StrikeHub's iframe, which
+//! silently broke chat send on the Windows MSI (see issue #189).
 
 use dioxus::prelude::*;
 
@@ -26,9 +25,7 @@ pub struct ChatInputProps {
 /// Auto-resizing textarea + Send button with Enter-to-submit behaviour.
 ///
 /// The textarea grows from a minimum of 40px up to 200px as the user types.
-/// Plain Enter sends the message; Shift+Enter inserts a newline. Both auto-
-/// resize and send dispatch happen entirely on the client; the only Rust
-/// involvement is receiving the submitted text via the eval channel below.
+/// Plain Enter sends the message; Shift+Enter inserts a newline.
 #[component]
 pub fn ChatInput(props: ChatInputProps) -> Element {
     let is_sending = props.is_sending;
@@ -36,7 +33,9 @@ pub fn ChatInput(props: ChatInputProps) -> Element {
     let disabled = is_sending() || agent_thinking();
     let on_send = props.on_send;
 
-    // Re-focus the textarea when agent finishes (disabled → enabled)
+    let mut input_text = use_signal(String::new);
+
+    // Re-focus the textarea when agent finishes (disabled → enabled).
     use_effect(move || {
         if !disabled {
             spawn(async move {
@@ -48,39 +47,62 @@ pub fn ChatInput(props: ChatInputProps) -> Element {
         }
     });
 
-    // Long-lived JS↔Rust send bridge. The eval installs document-level
-    // delegated listeners (idempotent — see utils.js) and parks awaiting
-    // a never-resolved promise so `dioxus.send` stays callable. Each call
-    // from JS surfaces here as one `eval.recv()` result.
-    use_hook(|| {
+    // Auto-resize textarea client-side so we don't pay a WebSocket round trip
+    // per keystroke. Height clamped between 40px and 200px (matches CSS).
+    let on_input = move |evt: Event<FormData>| {
+        input_text.set(evt.value());
         spawn(async move {
-            let mut eval = document::eval(
-                r#"
-                // Wait for utils.js to define the bridge installer. utils.js
-                // is injected once by ChatPanel; if it hasn't run yet, this
-                // loop polls briefly until the function appears.
-                while (typeof window.installChatSendBridge !== 'function') {
-                    await new Promise(function(r) { setTimeout(r, 50); });
-                }
-                installChatSendBridge(function(text) { dioxus.send(text); });
-                // Park forever so the eval (and `dioxus.send`) stay alive.
-                await new Promise(function() {});
-                "#,
-            );
-            while let Ok(text) = eval.recv::<String>().await {
+            let _ = document::eval(
+                "var el=document.querySelector('.chat-textarea');\
+                 if(el){el.style.height='auto';\
+                 el.style.height=Math.min(Math.max(el.scrollHeight,40),200)+'px';}",
+            )
+            .await;
+        });
+    };
+
+    let on_keydown = move |evt: Event<KeyboardData>| {
+        if evt.key() == Key::Enter && !evt.modifiers().shift() {
+            evt.prevent_default();
+            let text = input_text.read().trim().to_string();
+            if !text.is_empty() {
+                input_text.set(String::new());
+                spawn(async move {
+                    let _ = document::eval(
+                        "var el=document.querySelector('.chat-textarea');\
+                         if(el){el.value='';el.style.height='40px';}",
+                    )
+                    .await;
+                });
                 on_send.call(text);
             }
-        });
-    });
+        }
+    };
+
+    let on_click = move |evt: Event<MouseData>| {
+        evt.prevent_default();
+        let text = input_text.read().trim().to_string();
+        if !text.is_empty() {
+            input_text.set(String::new());
+            spawn(async move {
+                let _ = document::eval(
+                    "var el=document.querySelector('.chat-textarea');\
+                     if(el){el.value='';el.style.height='40px';}",
+                )
+                .await;
+            });
+            on_send.call(text);
+        }
+    };
 
     rsx! {
         form {
             class: "chat-input-area chat-input-form",
-            // action="javascript:void(0)" is a defensive no-op in case the JS
-            // bridge listener somehow misses a submit (e.g. before utils.js
-            // has loaded). With no `onsubmit` handler the browser will not
-            // attempt navigation regardless.
+            // Neutralise the browser's native submit path. Sends are dispatched
+            // by onkeydown / onclick; leaving submit unbound would let Enter
+            // attempt an iframe navigation.
             action: "javascript:void(0)",
+            onsubmit: move |evt| { evt.prevent_default(); },
             textarea {
                 class: "chat-input chat-textarea",
                 name: "message",
@@ -88,11 +110,14 @@ pub fn ChatInput(props: ChatInputProps) -> Element {
                 style: "min-height: 40px; max-height: 200px; overflow-y: auto; resize: none;",
                 placeholder: if disabled { "Waiting for response..." } else { "Type a message..." },
                 disabled: disabled,
+                oninput: on_input,
+                onkeydown: on_keydown,
             }
             button {
                 class: "chat-send-btn",
-                r#type: "submit",
+                r#type: "button",
                 disabled: disabled,
+                onclick: on_click,
                 "Send"
             }
         }


### PR DESCRIPTION
Closes #189.

## Symptom

Pick's chat panel accepts typing but pressing Enter (or clicking Send) delivers nothing on the Windows MSI build of StrikeHub. Linux and macOS work. KubeStudio's chat panel (also hosted inside StrikeHub) works on Windows.

## Root cause

The rerouting in #132 sends keystrokes through `document::eval`'s reverse channel (`dioxus.send(text)` → `eval.recv::<String>().await`). That channel does not deliver in the WebView2 + LiveView + StrikeHub-iframe combination. Three other places in the StrikeHub stack already document this exact class of failure and route around it:

- `strikehub/crates/sh-core/src/ws_relay.rs:198` — `__st` token appended to the connector WebSocket URL to avoid the polling fallback that fails on Windows WebView2.
- `strikehub/crates/sh-ui/src/app.rs:691` — `MATRIX_AUTH_TOKEN` passed via env because the `document::eval()` polling path fails on Windows WebView2.
- `pick/crates/ui/src/components/chat_panel/mod.rs:568` — post-send UI evals are fire-and-forget because `document::eval` responses hang indefinitely on Windows WebView2 in LiveView mode.

Chat send was the one remaining consumer of that channel that hadn't been worked around.

## What #132 actually did, and what this reverts

#132 bundled two changes:

1. Removed per-bubble `onmounted` listeners in `messages.rs`.
2. Rerouted `onsubmit`/`onkeydown`/`oninput`/`onclick` through a JavaScript bridge (`installChatSendBridge` in `utils.js`) using the eval reverse channel.

Change (1) is what actually fixed #130. The panic at `dioxus-liveview-0.7.x/src/events.rs:91:54` is in `convert_mounted_data` (verified against #130's stack trace and the `messages.rs` diff in f0e5455), not `convert_form_data`/`convert_keyboard_data` as `input.rs` claimed. Change (2) was a defensive precaution that mistook the crash site and traded #130 for a Windows-only bug.

A `dioxus-liveview` version bump does not help here: 0.7.3 and 0.7.9 sources are byte-identical (`diff -r` returns empty). KubeStudio isn't spared by its 0.7.9 pin — it's spared because it never registered per-bubble `onmounted`, so it never reaches events.rs:91.

This PR reverts only the send-path rerouting from #132, matching KubeStudio's native-event pattern (`oninput` + `onkeydown` + `onclick`), and leaves the `messages.rs` `onmounted` removal intact so #130 stays fixed. Also removes the now-unused `installChatSendBridge` helper from `utils.js`.

## Verification

Empirically confirmed on Windows MSI:

1. Bumped `PICK_REF` on a strikehub test branch to this fix's SHA.
2. Windows MSI job in strikehub's `Release` workflow (`dry_run=true`) built pentest-agent from this branch and produced `strikehub-windows-x86_64.msi`.
3. Installed on a Windows machine. Because `sh-core/connector_fetch.rs` prefers the cached fetched binary over the bundled sibling, manually swapped `~/.strike48/strikehub/bin/pentest-agent.exe` with the MSI-bundled fix (SHA `88a67f71…84805`) while leaving the `pentest-agent.version` marker at `v0.1.6` so the background update check stays quiet.
4. Pick chat in StrikeHub sends messages via Enter and via Send button. Chat previously did nothing.

## Test plan for review

- [x] Native events fire on Windows MSI (confirmed 2026-07-02).
- [x] `messages.rs` retains `onmounted` removal so #130 does not regress on history reload.
- [x] `installChatSendBridge` no longer referenced anywhere in pick.
- [ ] Reviewer sanity check: Shift+Enter still inserts a newline (not send).
- [ ] Reviewer sanity check: history reload does not panic on macOS or Linux.

## Deployment note

Once merged and tagged (e.g. `v0.1.7`), existing StrikeHub installs on all platforms pick up the fixed `pentest-agent` on next launch via `connector_fetch` (`strikehub b20d29b`). No StrikeHub release needed.