### PR TITLE
feat(tools): OS-aware capability gating for desktop tools (#195, Child A of #183)

### DIFF
--- a/crates/core/src/connector.rs
+++ b/crates/core/src/connector.rs
@@ -90,7 +90,7 @@ pub struct PentestConnector {
 /// knows each tool's input format.
 fn build_task_types(tools: &ToolRegistry) -> Vec<TaskTypeSchema> {
     tools
-        .schemas()
+        .supported_schemas()
         .iter()
         .map(|s| {
             let json_schema = s.to_json_schema();
@@ -113,8 +113,14 @@ fn build_task_types(tools: &ToolRegistry) -> Vec<TaskTypeSchema> {
 
 /// Build the connector metadata map with tool info and the app manifest.
 fn build_metadata(tools: &ToolRegistry) -> HashMap<String, String> {
-    let schemas: Vec<ToolSchema> = tools.schemas();
-    let tool_names: Vec<String> = tools.names().iter().map(|s| s.to_string()).collect();
+    // Advertise only tools supported on this host (platform + desktop OS) so a
+    // Linux-only tool never appears in the tool list on Windows. See #183.
+    let schemas: Vec<ToolSchema> = tools.supported_schemas();
+    let tool_names: Vec<String> = tools
+        .supported_names()
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
     let json_schemas: Vec<Value> = schemas.iter().map(|s| s.to_json_schema()).collect();
 
     let mut metadata = HashMap::new();
@@ -123,7 +129,7 @@ fn build_metadata(tools: &ToolRegistry) -> HashMap<String, String> {
         serde_json::to_string(&json_schemas).unwrap_or_default(),
     );
     metadata.insert("tool_names".to_string(), tool_names.join(","));
-    metadata.insert("tool_count".to_string(), tools.tools().len().to_string());
+    metadata.insert("tool_count".to_string(), schemas.len().to_string());
 
     // Register app manifest for the file browser
     let manifest = crate::file_browser::file_browser_manifest();

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -54,6 +54,69 @@ impl Platform {
     }
 }
 
+/// Desktop operating system, used for per-OS capability gating.
+///
+/// `Platform::Desktop` deliberately collapses every desktop OS into one
+/// variant so tools do not have to enumerate three OSes just to say
+/// "runs on the desktop." `DesktopOs` is the orthogonal axis that lets a
+/// tool declare it only works on a subset of desktop OSes (e.g. Linux-only
+/// tools that shell out to `iw`/`aircrack-ng`). See GitHub issue #183.
+///
+/// The `Other` variant covers desktop targets that are neither Linux, macOS,
+/// nor Windows (e.g. the BSDs). It is treated as Linux-like for capability
+/// purposes since those tools are POSIX shell based.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DesktopOs {
+    Linux,
+    MacOS,
+    Windows,
+    Other,
+}
+
+/// Every desktop OS. This is the default `supported_os` for a tool: unless a
+/// tool opts into a narrower set, it is assumed to run on all desktop OSes,
+/// which preserves the historical "everything is `Platform::Desktop`" behavior.
+pub const ALL_DESKTOP_OS: &[DesktopOs] = &[
+    DesktopOs::Linux,
+    DesktopOs::MacOS,
+    DesktopOs::Windows,
+    DesktopOs::Other,
+];
+
+impl DesktopOs {
+    /// The desktop OS this binary was compiled for.
+    ///
+    /// Returns `None` on non-desktop targets (wasm/Android/iOS), where the
+    /// desktop-OS axis is not meaningful and gating is driven by `Platform`.
+    pub fn current() -> Option<Self> {
+        #[cfg(any(target_arch = "wasm32", target_os = "android", target_os = "ios"))]
+        {
+            None
+        }
+
+        #[cfg(not(any(target_arch = "wasm32", target_os = "android", target_os = "ios")))]
+        {
+            #[cfg(target_os = "linux")]
+            {
+                Some(DesktopOs::Linux)
+            }
+            #[cfg(target_os = "macos")]
+            {
+                Some(DesktopOs::MacOS)
+            }
+            #[cfg(target_os = "windows")]
+            {
+                Some(DesktopOs::Windows)
+            }
+            #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+            {
+                Some(DesktopOs::Other)
+            }
+        }
+    }
+}
+
 /// Parameter type for tool schemas
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -261,8 +324,19 @@ pub struct ToolSchema {
     pub description: String,
     pub params: Vec<ToolParam>,
     pub supported_platforms: Vec<Platform>,
+    /// Desktop OSes this tool runs on. Only consulted when the current
+    /// platform is `Platform::Desktop`; ignored on Android/iOS/Web where the
+    /// `Platform` axis already gates support. Defaults to every desktop OS so
+    /// existing tools keep advertising everywhere they did before. See #183.
+    #[serde(default = "default_supported_os")]
+    pub supported_os: Vec<DesktopOs>,
     #[serde(default)]
     pub external_dependencies: Vec<ExternalDependency>,
+}
+
+/// Serde default for [`ToolSchema::supported_os`] — every desktop OS.
+fn default_supported_os() -> Vec<DesktopOs> {
+    ALL_DESKTOP_OS.to_vec()
 }
 
 impl ToolSchema {
@@ -273,6 +347,7 @@ impl ToolSchema {
             description: description.into(),
             params: Vec::new(),
             supported_platforms: DEFAULT_TOOL_PLATFORMS.to_vec(),
+            supported_os: ALL_DESKTOP_OS.to_vec(),
             external_dependencies: Vec::new(),
         }
     }
@@ -289,15 +364,32 @@ impl ToolSchema {
         self
     }
 
+    /// Restrict the desktop OSes this tool runs on (e.g. `[DesktopOs::Linux]`
+    /// for tools that shell out to Linux-only binaries). See #183.
+    pub fn os(mut self, os: Vec<DesktopOs>) -> Self {
+        self.supported_os = os;
+        self
+    }
+
     /// Add an external dependency
     pub fn external_dependency(mut self, dep: ExternalDependency) -> Self {
         self.external_dependencies.push(dep);
         self
     }
 
-    /// Check if supported on current platform
+    /// Check if supported on the current platform *and* desktop OS.
+    ///
+    /// On desktop, a tool is supported only if the current `DesktopOs` is in
+    /// its `supported_os` set. On non-desktop platforms the OS axis does not
+    /// apply, so only `supported_platforms` is consulted.
     pub fn is_supported(&self) -> bool {
-        self.supported_platforms.contains(&Platform::current())
+        if !self.supported_platforms.contains(&Platform::current()) {
+            return false;
+        }
+        match DesktopOs::current() {
+            Some(os) => self.supported_os.contains(&os),
+            None => true,
+        }
     }
 
     /// Check if this tool has external dependencies
@@ -558,7 +650,9 @@ pub trait PentestTool: Send + Sync {
 
     /// Get the tool schema
     fn schema(&self) -> ToolSchema {
-        ToolSchema::new(self.name(), self.description()).platforms(self.supported_platforms())
+        ToolSchema::new(self.name(), self.description())
+            .platforms(self.supported_platforms())
+            .os(self.supported_os())
     }
 
     /// Get supported platforms
@@ -566,9 +660,25 @@ pub trait PentestTool: Send + Sync {
         DEFAULT_TOOL_PLATFORMS.to_vec()
     }
 
-    /// Check if supported on current platform
+    /// Get supported desktop OSes.
+    ///
+    /// Defaults to every desktop OS. Tools that only work on a subset (e.g.
+    /// Linux-only tools that require `iw`/`aircrack-ng`) override this to
+    /// return a narrower set so they are not advertised on unsupported hosts.
+    /// See GitHub issue #183.
+    fn supported_os(&self) -> Vec<DesktopOs> {
+        ALL_DESKTOP_OS.to_vec()
+    }
+
+    /// Check if supported on the current platform and desktop OS.
     fn is_supported(&self) -> bool {
-        self.supported_platforms().contains(&Platform::current())
+        if !self.supported_platforms().contains(&Platform::current()) {
+            return false;
+        }
+        match DesktopOs::current() {
+            Some(os) => self.supported_os().contains(&os),
+            None => true,
+        }
     }
 
     /// Execute the tool with the given parameters
@@ -611,9 +721,32 @@ impl ToolRegistry {
         self.tools.values().map(|t| t.schema()).collect()
     }
 
+    /// Get schemas for tools supported on the current host (platform + desktop
+    /// OS). This is what should be advertised to Strike48: a Linux-only tool
+    /// must not appear in the tool list on a Windows host, otherwise the agent
+    /// believes it can call a capability that will only fail (or worse, return
+    /// a plausible empty) at runtime. See GitHub issue #183.
+    pub fn supported_schemas(&self) -> Vec<ToolSchema> {
+        self.tools
+            .values()
+            .filter(|t| t.is_supported())
+            .map(|t| t.schema())
+            .collect()
+    }
+
     /// Get tool names
     pub fn names(&self) -> Vec<&str> {
         self.tools.keys().map(|s| s.as_str()).collect()
+    }
+
+    /// Get names of tools supported on the current host, matching
+    /// [`Self::supported_schemas`]. See GitHub issue #183.
+    pub fn supported_names(&self) -> Vec<&str> {
+        self.tools
+            .values()
+            .filter(|t| t.is_supported())
+            .map(|t| t.name())
+            .collect()
     }
 
     /// Execute a tool by name
@@ -902,5 +1035,152 @@ mod transport_tests {
             .expect("effective_command string");
         assert!(!eff.contains("hunter2"), "secret on the wire: {eff}");
         assert!(eff.contains("<REDACTED>"));
+    }
+}
+
+#[cfg(test)]
+mod os_capability_tests {
+    //! Tests for OS-aware capability gating (GitHub issue #183, Child A).
+    //!
+    //! Invariants:
+    //! - The desktop-OS axis is additive: a tool that doesn't opt in defaults
+    //!   to every desktop OS, so Linux behavior is preserved exactly.
+    //! - `supported_os` never crosses the Matrix wire (`to_json_schema` is
+    //!   hand-built and omits it), and old serialized schemas still deserialize.
+    //! - The registry advertises only host-supported tools.
+    use super::*;
+
+    /// A tool that runs everywhere (uses all trait defaults).
+    struct UbiquitousTool;
+    #[async_trait]
+    impl PentestTool for UbiquitousTool {
+        fn name(&self) -> &str {
+            "ubiquitous"
+        }
+        fn description(&self) -> &str {
+            "runs on every desktop OS"
+        }
+        async fn execute(&self, _params: Value, _ctx: &ToolContext) -> Result<ToolResult> {
+            Ok(ToolResult::success(Value::Null))
+        }
+    }
+
+    /// A tool that only runs on Linux (e.g. shells out to `iw`/`aircrack-ng`).
+    struct LinuxOnlyTool;
+    #[async_trait]
+    impl PentestTool for LinuxOnlyTool {
+        fn name(&self) -> &str {
+            "linux_only"
+        }
+        fn description(&self) -> &str {
+            "requires Linux-only binaries"
+        }
+        fn supported_os(&self) -> Vec<DesktopOs> {
+            vec![DesktopOs::Linux]
+        }
+        async fn execute(&self, _params: Value, _ctx: &ToolContext) -> Result<ToolResult> {
+            Ok(ToolResult::success(Value::Null))
+        }
+    }
+
+    #[test]
+    fn desktop_os_current_matches_compile_target() {
+        // On any desktop build this is Some; only wasm/mobile yield None.
+        #[cfg(not(any(target_arch = "wasm32", target_os = "android", target_os = "ios")))]
+        {
+            let os = DesktopOs::current().expect("desktop build has a DesktopOs");
+            #[cfg(target_os = "linux")]
+            assert_eq!(os, DesktopOs::Linux);
+            #[cfg(target_os = "macos")]
+            assert_eq!(os, DesktopOs::MacOS);
+            #[cfg(target_os = "windows")]
+            assert_eq!(os, DesktopOs::Windows);
+        }
+        #[cfg(any(target_arch = "wasm32", target_os = "android", target_os = "ios"))]
+        assert_eq!(DesktopOs::current(), None);
+    }
+
+    #[test]
+    fn default_supported_os_is_every_desktop_os() {
+        // A tool with no opt-in advertises on all desktop OSes: this is the
+        // backward-compat guarantee (nothing regresses on Linux).
+        let tool = UbiquitousTool;
+        assert_eq!(tool.supported_os(), ALL_DESKTOP_OS.to_vec());
+        assert_eq!(tool.schema().supported_os, ALL_DESKTOP_OS.to_vec());
+        assert!(tool.is_supported(), "ubiquitous tool must run on this host");
+    }
+
+    #[test]
+    fn linux_only_tool_is_supported_only_on_linux() {
+        let tool = LinuxOnlyTool;
+        assert_eq!(tool.supported_os(), vec![DesktopOs::Linux]);
+        let expect_supported = matches!(DesktopOs::current(), Some(DesktopOs::Linux) | None);
+        assert_eq!(tool.is_supported(), expect_supported);
+    }
+
+    #[test]
+    fn schema_is_supported_agrees_with_trait_is_supported() {
+        // The registry filters on trait `is_supported`; the schema carries the
+        // same data. They must agree so the advertised list is coherent.
+        for supported in [
+            tool_supported(&UbiquitousTool),
+            tool_supported(&LinuxOnlyTool),
+        ] {
+            assert_eq!(supported.0, supported.1);
+        }
+    }
+
+    fn tool_supported<T: PentestTool>(tool: &T) -> (bool, bool) {
+        (tool.is_supported(), tool.schema().is_supported())
+    }
+
+    #[test]
+    fn supported_os_is_not_serialized_to_the_wire() {
+        // to_json_schema is what reaches Strike48. It must not carry the OS
+        // axis (the host filter already applied), keeping the wire unchanged.
+        let json = LinuxOnlyTool.schema().to_json_schema();
+        assert!(
+            json.get("supported_os").is_none(),
+            "supported_os leaked onto the wire: {json}"
+        );
+    }
+
+    #[test]
+    fn old_schema_without_supported_os_still_deserializes() {
+        // A ToolSchema serialized before the field existed must round-trip in
+        // and default to every desktop OS.
+        let legacy = serde_json::json!({
+            "name": "legacy_tool",
+            "description": "pre-#183 schema",
+            "params": [],
+            "supported_platforms": ["Desktop"]
+        });
+        let schema: ToolSchema = serde_json::from_value(legacy).expect("deserialize legacy");
+        assert_eq!(schema.supported_os, ALL_DESKTOP_OS.to_vec());
+    }
+
+    #[test]
+    fn registry_advertises_only_host_supported_tools() {
+        let mut registry = ToolRegistry::new();
+        registry.register(UbiquitousTool);
+        registry.register(LinuxOnlyTool);
+
+        let names = registry.supported_names();
+        assert!(
+            names.contains(&"ubiquitous"),
+            "ubiquitous tool must always be advertised"
+        );
+
+        // On Linux both are advertised; on macOS/Windows the Linux-only tool
+        // is filtered out. Assert the exact host-appropriate behavior.
+        let linux_only_advertised = names.contains(&"linux_only");
+        let expect = matches!(DesktopOs::current(), Some(DesktopOs::Linux) | None);
+        assert_eq!(
+            linux_only_advertised, expect,
+            "linux_only advertised={linux_only_advertised}, expected={expect}"
+        );
+
+        // supported_schemas and supported_names must agree in cardinality.
+        assert_eq!(registry.supported_schemas().len(), names.len());
     }
 }

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -1095,6 +1095,12 @@ mod os_capability_tests {
             assert_eq!(os, DesktopOs::MacOS);
             #[cfg(target_os = "windows")]
             assert_eq!(os, DesktopOs::Windows);
+            #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
+            assert_eq!(
+                os,
+                DesktopOs::Other,
+                "BSD and other Unix-likes map to Other"
+            );
         }
         #[cfg(any(target_arch = "wasm32", target_os = "android", target_os = "ios"))]
         assert_eq!(DesktopOs::current(), None);

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -63,8 +63,10 @@ impl Platform {
 /// tools that shell out to `iw`/`aircrack-ng`). See GitHub issue #183.
 ///
 /// The `Other` variant covers desktop targets that are neither Linux, macOS,
-/// nor Windows (e.g. the BSDs). It is treated as Linux-like for capability
-/// purposes since those tools are POSIX shell based.
+/// nor Windows (e.g. the BSDs). Support is matched exactly: a tool that
+/// declares `supported_os = [DesktopOs::Linux]` is NOT offered on an `Other`
+/// host. Tools that also run on BSD/POSIX targets must list `DesktopOs::Other`
+/// explicitly.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum DesktopOs {
@@ -774,7 +776,10 @@ impl ToolRegistry {
 
                 tracing::error!("");
                 tracing::error!("Available tools:");
-                let mut names: Vec<&str> = self.names();
+                // Show only host-supported tools, matching what was advertised
+                // to Strike48 — a Linux-only tool must not appear as "available"
+                // on a Windows host. See #183.
+                let mut names: Vec<&str> = self.supported_names();
                 names.sort();
                 for tool_name in names.iter().take(10) {
                     tracing::error!("  - {}", tool_name);

--- a/crates/tools/src/autopwn/crack.rs
+++ b/crates/tools/src/autopwn/crack.rs
@@ -78,7 +78,11 @@ impl PentestTool for AutoPwnCrackTool {
     }
 
     fn supported_platforms(&self) -> Vec<Platform> {
-        vec![Platform::Desktop] // Linux only for now
+        vec![Platform::Desktop]
+    }
+
+    fn supported_os(&self) -> Vec<DesktopOs> {
+        vec![DesktopOs::Linux] // requires hashcat/aircrack toolchain; Linux only for now (#183)
     }
 
     async fn execute(&self, params: Value, _ctx: &ToolContext) -> Result<ToolResult> {

--- a/crates/tools/src/catalog.rs
+++ b/crates/tools/src/catalog.rs
@@ -96,6 +96,11 @@ fn collect_dependencies() -> BTreeMap<String, (ExternalDependency, Vec<String>)>
     let registry = crate::create_tool_registry();
     let mut deps: BTreeMap<String, (ExternalDependency, Vec<String>)> = BTreeMap::new();
 
+    // Intentionally unfiltered (`schemas()`, not `supported_schemas()`): the
+    // catalog enumerates every installable dependency across all desktop OSes,
+    // not just the current host. This is an install/inventory surface, not the
+    // agent-facing capability list — host gating happens where tools are
+    // advertised/executed, not here. See #183.
     for schema in registry.schemas() {
         for dep in &schema.external_dependencies {
             let entry = deps

--- a/crates/tools/src/wifi_scan_detailed.rs
+++ b/crates/tools/src/wifi_scan_detailed.rs
@@ -9,7 +9,8 @@ use async_trait::async_trait;
 use pentest_core::error::{Error, Result};
 use pentest_core::settings::load_settings;
 use pentest_core::tools::{
-    execute_timed, ParamType, PentestTool, Platform, ToolContext, ToolParam, ToolResult, ToolSchema,
+    execute_timed, DesktopOs, ParamType, PentestTool, Platform, ToolContext, ToolParam, ToolResult,
+    ToolSchema,
 };
 use pentest_platform::{get_platform, SystemInfo as _, WifiAttackOps};
 use serde_json::{json, Value};
@@ -119,7 +120,11 @@ impl PentestTool for WifiScanDetailedTool {
     }
 
     fn supported_platforms(&self) -> Vec<Platform> {
-        vec![Platform::Desktop] // Linux only for now (requires aircrack-ng)
+        vec![Platform::Desktop]
+    }
+
+    fn supported_os(&self) -> Vec<DesktopOs> {
+        vec![DesktopOs::Linux] // requires aircrack-ng; Linux only for now (#183)
     }
 
     async fn execute(&self, params: Value, _ctx: &ToolContext) -> Result<ToolResult> {

--- a/crates/ui/src/liveview_connector/mod.rs
+++ b/crates/ui/src/liveview_connector/mod.rs
@@ -1036,10 +1036,16 @@ impl LiveViewConnector {
 
     /// Build the registration message
     async fn build_registration_message(&self) -> StreamMessage {
-        // Build tool schemas for metadata
+        // Build tool schemas for metadata. Advertise only tools supported on
+        // this host (platform + desktop OS) so a Linux-only tool never appears
+        // in the tool list on Windows. See #183.
         let tools = self.tools.read().await;
-        let schemas = tools.schemas();
-        let tool_names: Vec<String> = tools.names().iter().map(|s| s.to_string()).collect();
+        let schemas = tools.supported_schemas();
+        let tool_names: Vec<String> = tools
+            .supported_names()
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
         let json_schemas: Vec<serde_json::Value> =
             schemas.iter().map(|s| s.to_json_schema()).collect();
         drop(tools);

--- a/crates/ui/src/liveview_connector/mod.rs
+++ b/crates/ui/src/liveview_connector/mod.rs
@@ -289,7 +289,16 @@ impl LiveViewConnector {
         // WorkspaceApp (liveview) can read them when auto-creating the agent persona and executing tools.
         crate::session::set_tenant_id(&config.tenant_id);
         crate::session::set_connector_name(&config.connector_name);
-        crate::session::set_tool_names(tools.names().iter().map(|s| s.to_string()).collect());
+        // Use host-supported names so the agent's auto-approved tool_configs match
+        // the advertised capability set: a Linux-only tool must not be pre-approved
+        // on a Windows host where it is not offered. See #183.
+        crate::session::set_tool_names(
+            tools
+                .supported_names()
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        );
 
         let tools_arc = Arc::new(RwLock::new(tools));
         crate::session::set_tool_registry(tools_arc.clone());


### PR DESCRIPTION
Implements **Child A** of the Windows/Linux parity epic (#183): an OS-aware capability model so a Linux-only tool is not advertised to the Strike48 agent on a Windows host. Closes #195.

## Problem

All desktop OSes collapse into a single `Platform::Desktop`, so the registry and agent cannot express "this tool is Linux-only." A Linux-only tool (aircrack-ng / hashcat backed) was therefore advertised on Windows, where it can only fail at runtime — or worse, return a plausible empty. `is_supported()` was only exercised in tests, so the advertise path filtered nothing.

Parity here means **honesty, not universal support**: the agent must know per-host which capabilities are real.

## Approach (additive; Linux behavior preserved exactly)

Rather than splitting the `Platform` enum (touches ~50 call sites and the serialized wire surface), add an orthogonal desktop-OS axis:

- `enum DesktopOs { Linux, MacOS, Windows, Other }` + `DesktopOs::current()` (returns `None` on wasm/Android/iOS).
- `ToolSchema.supported_os` (serde default = every desktop OS) + `.os(...)` builder.
- `PentestTool::supported_os()` trait method defaulting to every desktop OS.
- `is_supported()` additionally checks the current `DesktopOs` when on desktop.
- `ToolRegistry::supported_schemas()` / `supported_names()` — host-filtered.
- Advertise paths switched to the filtered variants: `connector.rs` (build_task_types/build_metadata), `liveview_connector` (registration metadata **and** the session tool-name list that feeds the agent's auto-approved `tool_configs`).
- First real consumers: `autopwn` crack and `wifi_scan_detailed` declared `[DesktopOs::Linux]`.

## Wire safety

`supported_os` is **not** serialized onto the Matrix wire (`to_json_schema()` is hand-built and omits it), and pre-existing serialized schemas still deserialize (serde default). The catalog dependency-collection path stays intentionally unfiltered (install/inventory surface across all OSes) — documented in code.

## Review

Reviewed with the rust-reviewer agent before opening. Findings addressed in commit 9d80469: HIGH (session tool-name list now uses `supported_names()`), MEDIUM (catalog unfiltered-by-design comment), LOW (BSD/`Other` test branch).

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --locked --features pentest-platform/desktop-pcap -- -D warnings` clean
- [x] `cargo test -p pentest-core --lib` — 7 new `os_capability_tests` pass
- [x] `cargo test --package pentest-platform --package pentest-core --lib` pass
- [ ] CI green on push