### PR TITLE
fix(platform): probe binaries with where on Windows (#200, Child C of #183)

### DIFF
--- a/crates/platform/src/common.rs
+++ b/crates/platform/src/common.rs
@@ -9,6 +9,25 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Semaphore;
 
+/// The command that reports whether a binary is on the host's PATH.
+///
+/// Unix (Linux/macOS/BSD) uses `which`; Windows has no `which` but ships
+/// `where.exe`, which is PATHEXT-aware and, like `which`, exits 0 when the
+/// binary is found and non-zero otherwise. Using the wrong one makes every
+/// external tool read as "Missing" on Windows. See GitHub issue #183.
+///
+/// This describes the command for the **host** only. Commands sent into the
+/// sandbox (WSL2 on Windows, proot/bwrap on Linux) always run in a Linux
+/// environment where `which` is correct, so the sandbox path must not use this.
+#[must_use]
+pub const fn host_which_command() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "where"
+    } else {
+        "which"
+    }
+}
+
 /// Resolve `host:port` to a [`SocketAddr`], trying a direct parse first and
 /// falling back to DNS resolution via [`ToSocketAddrs`].
 fn resolve_addr(addr: &str, port: u16) -> SocketAddr {
@@ -172,4 +191,21 @@ pub fn parse_ip_neigh(output: &str) -> Vec<ArpEntry> {
             })
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn host_which_command_matches_target_os() {
+        // The host binary-probe command must be `where` on Windows (no `which`
+        // there) and `which` on every Unix-like target. See #183.
+        let cmd = host_which_command();
+        if cfg!(target_os = "windows") {
+            assert_eq!(cmd, "where");
+        } else {
+            assert_eq!(cmd, "which");
+        }
+    }
 }

--- a/crates/platform/src/desktop/command.rs
+++ b/crates/platform/src/desktop/command.rs
@@ -130,12 +130,13 @@ pub async fn execute_command_in_dir(
 
 /// Direct command execution (used as fallback or for internal operations).
 ///
-/// This runs on the **host**, so the Linux-only `which` binary-probe is
+/// This always runs on the **host**, so the Linux-only `which` binary-probe is
 /// rewritten to the host-appropriate command (`where` on Windows) via
-/// [`crate::common::host_which_command`]. The sandbox path in
-/// [`execute_command_in_dir`] does NOT come through here — it sends the command
-/// into a Linux environment (WSL2/proot/bwrap) where `which` is correct — so the
-/// rewrite is confined to host execution. See GitHub issue #183.
+/// [`crate::common::host_which_command`]. The sandbox *success* path does not
+/// come through here — it sends the command into a Linux environment
+/// (WSL2/proot/bwrap) where `which` is correct. A sandbox *failure* does fall
+/// back to this function (see [`execute_command_in_dir`]), but that fallback
+/// executes on the host, so the rewrite is still correct. See GitHub issue #183.
 pub(crate) async fn execute_command_direct(
     cmd: &str,
     args: &[&str],
@@ -145,6 +146,10 @@ pub(crate) async fn execute_command_direct(
     let start = Instant::now();
 
     // Host-only: `which` does not exist on Windows; use `where` there instead.
+    // We match the bare literal "which" (not "./which" or an absolute path)
+    // because every probe caller passes the literal string. Callers check only
+    // the exit code (0 = found); `where` shares that contract, though it may
+    // print multiple paths — fine, since stdout is not parsed. See #183.
     let host_cmd = if cmd == "which" {
         crate::common::host_which_command()
     } else {

--- a/crates/platform/src/desktop/command.rs
+++ b/crates/platform/src/desktop/command.rs
@@ -128,7 +128,14 @@ pub async fn execute_command_in_dir(
     execute_command_direct(cmd, args, timeout_duration, working_dir).await
 }
 
-/// Direct command execution (used as fallback or for internal operations)
+/// Direct command execution (used as fallback or for internal operations).
+///
+/// This runs on the **host**, so the Linux-only `which` binary-probe is
+/// rewritten to the host-appropriate command (`where` on Windows) via
+/// [`crate::common::host_which_command`]. The sandbox path in
+/// [`execute_command_in_dir`] does NOT come through here — it sends the command
+/// into a Linux environment (WSL2/proot/bwrap) where `which` is correct — so the
+/// rewrite is confined to host execution. See GitHub issue #183.
 pub(crate) async fn execute_command_direct(
     cmd: &str,
     args: &[&str],
@@ -137,7 +144,14 @@ pub(crate) async fn execute_command_direct(
 ) -> Result<CommandResult> {
     let start = Instant::now();
 
-    let mut command = Command::new(cmd);
+    // Host-only: `which` does not exist on Windows; use `where` there instead.
+    let host_cmd = if cmd == "which" {
+        crate::common::host_which_command()
+    } else {
+        cmd
+    };
+
+    let mut command = Command::new(host_cmd);
     command
         .args(args)
         .stdout(Stdio::piped())

--- a/crates/tools/src/autopwn/crack.rs
+++ b/crates/tools/src/autopwn/crack.rs
@@ -493,8 +493,14 @@ async fn crack_wpa_mask(
     tracing::info!("  Mask: {}", mask);
     tracing::info!("");
 
-    // Check if hashcat is available
-    let hashcat_check = Command::new("which").arg("hashcat").output().await.ok();
+    // Check if hashcat is available. This probes the host directly (it bypasses
+    // the sandbox CommandExec path), so use the host-appropriate probe command
+    // (`where` on Windows, `which` elsewhere). See #183.
+    let hashcat_check = Command::new(pentest_platform::common::host_which_command())
+        .arg("hashcat")
+        .output()
+        .await
+        .ok();
 
     if hashcat_check.is_none() || !hashcat_check.unwrap().status.success() {
         tracing::error!("✗ Hashcat not found");


### PR DESCRIPTION
Implements **Child C** of the Windows/Linux parity epic (#183). Closes #200.

## Problem

Binary-availability probing shells out to the Linux `which` command. On a Windows host `which` does not exist, so every probe returns non-zero and **every external tool reads as Missing/Unknown** in the catalog (surfaced in the Settings Tools panel). Windows ships `where.exe` — PATHEXT-aware, same exit-code contract (0 = found).

## Fix

- Add `common::host_which_command()` (in the always-compiled `common` module): returns `where` on Windows, `which` elsewhere — a single source of truth.
- Apply it at the **host-execution boundary** in `execute_command_direct`, which fixes all 11 probe sites that route through `CommandExec::execute_command` at once.
- Fix the one raw `Command::new("which")` probe in `autopwn/crack.rs` (probes `hashcat`) that bypasses the trait.

## Why the boundary matters

The `which`/`where` choice depends on *where the command runs*, not just the host OS. `execute_command_direct` is only reached on host paths (sandbox disabled, or fallback after sandbox failure). The sandbox *success* path sends commands into a Linux environment (WSL2 on Windows, proot/bwrap on Linux) via a different code path (`manager.execute()`), where `which` is correct — so it is deliberately untouched. Sandbox-internal `which` probes (`bwrap`/`proot` backend detection) are also left as-is.

All 11 probe callers check only `exit_code == 0` (none parse stdout), so the swap is behavior-preserving on Linux/macOS.

## Review

rust-reviewer pre-push pass: APPROVE, no CRITICAL/HIGH; independently verified the host-vs-sandbox boundary and all three design constraints. Its MEDIUM doc-clarity notes are applied in 36961f3 (fallback-path docstring; string-match + exit-code-only assumption).

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --locked --features pentest-platform/desktop-pcap -- -D warnings` clean
- [x] `cargo test -p pentest-platform` — new `host_which_command_matches_target_os` passes
- [ ] CI green on push (Dependency Audit will fail on the pre-existing transitive `quick-xml` RUSTSEC-2026-0194/-0195, unrelated to this PR; ignore lands via #190)