### PR TITLE
fix(platform): recognize Windows WiFi adapter names case-insensitively (#185, part C)

### DIFF
--- a/crates/platform/src/desktop/system.rs
+++ b/crates/platform/src/desktop/system.rs
@@ -428,11 +428,31 @@ pub async fn get_wifi_networks(_interface: Option<String>) -> Result<Vec<WifiNet
 
     #[cfg(not(feature = "wifi_scan"))]
     {
-        let _ = interface; // Suppress unused warning
+        let _ = _interface; // Suppress unused warning (param is `_interface`)
         Err(Error::PlatformNotSupported(
             "WiFi scanning requires the 'wifi_scan' feature".into(),
         ))
     }
+}
+
+/// Whether a network-interface name looks like a WiFi adapter.
+///
+/// Matches Linux (`wlan0`, `wlp2s0`, monitor-mode `wlan0mon`), macOS (`en0`),
+/// and Windows (`Wi-Fi`, `Wireless Network Connection`) naming. All matching is
+/// done case-insensitively: Windows names the primary adapter "Wi-Fi" (capital
+/// W), which the previous case-sensitive `contains("wi-fi")` missed, causing
+/// `check_wifi_connection_status` to report 0 adapters / `safe_to_scan = true`
+/// on Windows even while connected over WiFi. See GitHub issue #185.
+fn is_wifi_name(name: &str) -> bool {
+    let n = name.to_lowercase();
+    n.starts_with("wlan")
+        || n.starts_with("wlp")
+        || n.starts_with("wl")
+        || n.starts_with("en0") // macOS WiFi (usually)
+        || n.contains("wi-fi") // Windows "Wi-Fi"
+        || n.contains("wireless") // Windows "Wireless Network Connection"
+        || n.contains("wifi")
+        || n.ends_with("mon") // monitor-mode interfaces (e.g. wlan0mon)
 }
 
 /// Check WiFi connection status for scan safety assessment
@@ -444,19 +464,6 @@ pub async fn check_wifi_connection_status(
     selected_adapter: Option<String>,
 ) -> Result<WifiConnectionStatus> {
     let interfaces = get_network_interfaces().await?;
-
-    // WiFi interface name patterns (Linux, macOS, Windows)
-    // Also recognises monitor-mode variants like wlan0mon, wlp2s0mon
-    let is_wifi_name = |name: &str| {
-        name.starts_with("wlan")
-            || name.starts_with("wlp")
-            || name.starts_with("wl")
-            || name.starts_with("en0") // macOS WiFi (usually)
-            || name.contains("wi-fi")
-            || name.contains("wireless")
-            || name.to_lowercase().contains("wifi")
-            || name.ends_with("mon") // monitor-mode interfaces (e.g. wlan0mon)
-    };
 
     // Find active WiFi interfaces (up + has IP)
     let active_wifi: Vec<_> = interfaces
@@ -497,4 +504,38 @@ pub async fn check_wifi_connection_status(
         safe_to_scan,
         all_wifi_interfaces: all_wifi,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_wifi_name_recognizes_windows_adapter_names() {
+        // The regression this guards (GitHub #185): Windows names its primary
+        // adapter "Wi-Fi" (capital W), which the old case-sensitive
+        // `contains("wi-fi")` missed — making check_wifi_connection_status
+        // report 0 adapters and safe_to_scan=true while actually on WiFi.
+        assert!(is_wifi_name("Wi-Fi"));
+        assert!(is_wifi_name("Wi-Fi 2"));
+        assert!(is_wifi_name("Wireless Network Connection"));
+        assert!(is_wifi_name("WiFi"));
+    }
+
+    #[test]
+    fn is_wifi_name_recognizes_linux_and_macos_names() {
+        assert!(is_wifi_name("wlan0"));
+        assert!(is_wifi_name("wlp2s0"));
+        assert!(is_wifi_name("wlan0mon")); // monitor mode
+        assert!(is_wifi_name("en0")); // macOS
+    }
+
+    #[test]
+    fn is_wifi_name_rejects_non_wifi_names() {
+        assert!(!is_wifi_name("eth0"));
+        assert!(!is_wifi_name("Ethernet"));
+        assert!(!is_wifi_name("lo"));
+        assert!(!is_wifi_name("docker0"));
+        assert!(!is_wifi_name("en1")); // macOS non-WiFi (only en0 heuristically WiFi)
+    }
 }


### PR DESCRIPTION
Fixes **Part C** of #185 (Child E of the Windows/Linux parity epic #183).

## Bug

`check_wifi_connection_status` matched adapter names with a case-sensitive `contains("wi-fi")` / `contains("wireless")`. Windows names its primary adapter **"Wi-Fi"** (capital W) — which matched none of the branches (`to_lowercase().contains("wifi")` also missed it, because "wi-fi" has a hyphen). Result on Windows: `total_adapters=0`, `connected_via_wifi=false`, `safe_to_scan=true` — a false negative while actually connected over WiFi. That is exactly the silent-empty / false-safe hazard EPIC #183 targets.

## Fix

- Promote the `is_wifi_name` closure to a free function (now unit-testable).
- Lowercase the name once and match all patterns against the lowercased form, so "Wi-Fi", "Wi-Fi 2", and "Wireless Network Connection" are recognized. Behavior-preserving for every previously-matching name (`wlan*`, `wlp*`, `wl*`, `en0`, `wifi`, `*mon`).
- Fix a latent `let _ = interface;` (param is `_interface`) in the compiled-out `not(feature="wifi_scan")` arm of `get_wifi_networks`.

## Scope note (why only Part C)

There is no Windows runner in CI (only ubuntu + macOS), so `#[cfg(target_os="windows")]` code is compiled/run by neither local dev nor CI. Part C is pure, cross-platform-testable string logic, so it ships now. Parts **A** (honor the operator-selected adapter on Windows) and **B** (distinguish scan-failure from genuinely-empty) require a new `netsh`/Native WiFi scanner — the `wifi_scan` crate v0.7.0 exposes no interface selection and hardcodes `interfaces.first()`. Writing that unvalidated on a protected branch would risk shipping bugs, so A/B are deferred to a Windows-hardware session and tracked on #185.

## Review

rust-reviewer pre-push pass: **CLEAN, no findings**. Verified behavior preservation, no false positives (tested Ethernet/eth0/lo/docker0/vEthernet/Bluetooth/Local Area Connection/en1), doc-comment placement, and the `_interface` fix.

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --locked --features pentest-platform/desktop-pcap -- -D warnings` clean
- [x] `cargo test -p pentest-platform` — 3 new `is_wifi_name` tests pass (Windows/Linux/macOS/negative)
- [ ] CI green on push (Dependency Audit will fail on the pre-existing transitive `quick-xml` RUSTSEC-2026-0194/-0195, unrelated to this PR; ignore lands via #190)