### PR TITLE
fix: declare items on array param schema so LLM emits well-formed --e…

### DIFF
--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -419,6 +419,16 @@ impl ToolSchema {
                 "description": param.description
             });
 
+            // A JSON-schema `array` without `items` is under-specified: the LLM
+            // doesn't know the element type and may emit a bracketed literal that
+            // gets stringified into a CLI flag (e.g. `--exclude=[10.0.0.1,...]`),
+            // which the tool rejects. Every array param in this codebase is a
+            // list of strings (hosts, args, commands), so declare `items` as
+            // string to give the model a well-formed schema.
+            if matches!(param.param_type, ParamType::Array) {
+                prop["items"] = serde_json::json!({ "type": "string" });
+            }
+
             if let Some(default) = &param.default {
                 prop["default"] = default.clone();
             }
@@ -958,6 +968,37 @@ mod external_dependency_tests {
         assert_eq!(dep["install_method"]["id"], "zap");
         assert_eq!(dep["category"], "web");
         assert_eq!(dep["recommended"], true);
+    }
+
+    #[test]
+    fn array_params_declare_string_items_in_json_schema() {
+        // An array param must serialize with `items: {type: string}` so the LLM
+        // emits a well-formed array instead of a bracketed literal that gets
+        // stringified into a CLI flag (the `--exclude=[...]` failure). Non-array
+        // params must NOT carry `items`.
+        let schema = ToolSchema::new("scan", "test")
+            .param(ToolParam::optional(
+                "exclude",
+                ParamType::Array,
+                "hosts to exclude",
+                serde_json::json!([]),
+            ))
+            .param(ToolParam::required(
+                "target",
+                ParamType::String,
+                "the target",
+            ));
+
+        let json = schema.to_json_schema();
+        let props = &json["parameters"]["properties"];
+
+        assert_eq!(props["exclude"]["type"], "array");
+        assert_eq!(props["exclude"]["items"]["type"], "string");
+        assert_eq!(props["target"]["type"], "string");
+        assert!(
+            props["target"].get("items").is_none(),
+            "non-array param must not declare items"
+        );
     }
 }
 

--- a/crates/tools/src/external/masscan.rs
+++ b/crates/tools/src/external/masscan.rs
@@ -74,7 +74,7 @@ impl PentestTool for MasscanTool {
             .param(ToolParam::optional(
                 "exclude",
                 ParamType::Array,
-                "Hosts/CIDRs to exclude from the scan (maps to masscan --exclude). Use this to scan a range while skipping specific hosts, e.g. target='10.0.0.0/8' exclude=['10.0.0.1']. Out-of-scope hosts are also injected here automatically by the platform.",
+                "Hosts/CIDRs to exclude from the scan (maps to masscan --exclude). Provide a JSON array of individual IP or CIDR strings — one entry per host/range, e.g. [\"10.0.0.1\"]. Do NOT wrap the list in a single string or inline brackets into a value. Use this to scan a range while skipping specific hosts (e.g. target \"10.0.0.0/8\"). Out-of-scope hosts are also injected here automatically by the platform.",
                 json!([]),
             ))
             .platforms(vec![Platform::Desktop, Platform::Tui])

--- a/crates/tools/src/external/nmap.rs
+++ b/crates/tools/src/external/nmap.rs
@@ -101,7 +101,7 @@ impl PentestTool for NmapTool {
             .param(ToolParam::optional(
                 "exclude",
                 ParamType::Array,
-                "Hosts/CIDRs to exclude from the scan (maps to nmap --exclude). Use this to scan a range while skipping specific hosts, e.g. target='10.0.0.0/24' exclude=['10.0.0.1','10.0.0.2']. Out-of-scope hosts are also injected here automatically by the platform.",
+                "Hosts/CIDRs to exclude from the scan (maps to nmap --exclude). Provide a JSON array of individual IP or CIDR strings — one entry per host/range, e.g. [\"10.0.0.1\", \"10.0.0.2\"]. Do NOT wrap the list in a single string or inline brackets into a value. Use this to scan a range while skipping specific hosts (e.g. target \"10.0.0.0/24\"). Out-of-scope hosts are also injected here automatically by the platform.",
                 json!([]),
             ))
             .param(ToolParam::optional(


### PR DESCRIPTION
…xclude (#211)

  Summary

  On the first connector scan call of an engagement, the LLM frequently formatted the exclude parameter as a bracketed array literal that got stringified into the CLI as --exclude=[192.168.64.1, 
  "10.5.0.1", "10.0.0.145"] — which nmap/masscan reject ("hostname contains invalid characters"). The call failed, the LLM self-corrected to the comma form on the next try, and the scan eventually
  ran — but the first-call failure was confusing and demo-unfriendly.
  
  Closes #211.

  Root cause

  The tool schema advertised to the LLM declared exclude as "type": "array" with no "items" (crates/core/src/tools.rs::to_json_schema). A JSON-schema array without items is under-specified — the
  model doesn't know the element type — and the param description made it worse by showing exclude=['10.0.0.1','10.0.0.2'] (a list-literal the model copied straight into the CLI). With no
  in-context example on the first call, the model emitted the bracketed literal; after the failure it had the corrected form in context, so later calls were fine.
  
  The runtime was never the problem: param_exclude_list already accepts both an array and a comma-string and joins to the correct comma form. The bug was purely the schema/description advertised to
  the LLM.

  Changes

  - crates/core/src/tools.rs — to_json_schema now emits "items": {"type": "string"} for every ParamType::Array param. All 5 array params in the codebase are string-lists (nmap/masscan exclude,
  execute_command args, metasploit commands, certipy extra_args), so this is correct for all of them, not just exclude. Adds unit test array_params_declare_string_items_in_json_schema.
  - crates/tools/src/external/nmap.rs, masscan.rs — rewrote the exclude description to show a proper JSON array of strings (["10.0.0.1", "10.0.0.2"]) and explicitly instruct not to inline brackets
  into a value.

  Verification

  - cargo fmt --all -- --check clean; cargo clippy -p pentest-core -p pentest-tools -- -D warnings clean; new unit test + affected-crate tests pass.
  - Manual E2E (rebuilt pentest-headless, live engagement): the first nmap call now dispatches with a clean comma-separated --exclude 10.0.0.145,100.96.2.11,10.5.0.1,192.168.64.1 — no
  bracketed-literal failure, no self-correction round. Confirmed in both the Studio execution feed and the Pick connector log.

  Notes for reviewers

  - Pre-existing test failure (not this PR): all_tools_registered (crates/core/tests/tool_integration.rs:569) fails locally on macOS because wifi_scan_detailed isn't in the connector capabilities
  on non-Linux (a consequence of the WiFi platform-gating in #205/#203). Verified it fails identically on clean main with this change stashed — it is unrelated to this PR and expected to pass on
  Linux CI.

Screenshot before the fix,

<img width="1563" height="1076" alt="Screenshot 2026-07-07 at 10 28 15 AM" src="https://github.com/user-attachments/assets/460a3f92-f0e1-4b71-a547-bd47609c4777" />

Screenshot after the fix,

<img width="1563" height="1076" alt="Screenshot 2026-07-07 at 12 21 50 PM" src="https://github.com/user-attachments/assets/26c40315-b218-49cb-b5d6-21a52eddd014" />





