### PR TITLE
fix(platform): gate proot mode() check to unix so Windows builds compile (#214)

### DIFF
--- a/crates/platform/src/desktop/pty_shell.rs
+++ b/crates/platform/src/desktop/pty_shell.rs
@@ -192,6 +192,10 @@ impl PtyShell {
                 let is_executable = std::fs::metadata(&proot_path)
                     .map(|m| m.permissions().mode() & 0o111 != 0)
                     .unwrap_or(false);
+                // Windows: SandboxBackend::Proot is not a runtime target here (no proot
+                // binary is shipped), but this branch must still compile. Fall back to a
+                // plain existence probe rather than re-implementing an executable check
+                // via Windows-specific APIs.
                 #[cfg(not(unix))]
                 let is_executable = proot_path.exists();
                 tracing::info!(

--- a/crates/platform/src/desktop/pty_shell.rs
+++ b/crates/platform/src/desktop/pty_shell.rs
@@ -188,9 +188,12 @@ impl PtyShell {
                 let proot_path = ProotExecutor::get_proot_path(config)
                     .await
                     .map_err(|e| Error::ToolExecution(format!("Proot binary not found: {e}")))?;
+                #[cfg(unix)]
                 let is_executable = std::fs::metadata(&proot_path)
                     .map(|m| m.permissions().mode() & 0o111 != 0)
                     .unwrap_or(false);
+                #[cfg(not(unix))]
+                let is_executable = proot_path.exists();
                 tracing::info!(
                     "[PtyShell] proot binary: path={} exists={} executable={}",
                     proot_path.display(),


### PR DESCRIPTION
## Summary

- Closes #214.
- Windows Desktop and Headless builds have been failing with `E0599: no method named 'mode' found for struct 'Permissions'` at `crates/platform/src/desktop/pty_shell.rs:192`.
- `PermissionsExt::mode()` is Unix-only. The block introduced in faefa8b was not `cfg(unix)`-gated, so the Windows targets no longer compile — v0.1.7 shipped without Windows artifacts.
- This PR gates the mode-bit check behind `#[cfg(unix)]` and falls back to `Path::exists()` on Windows. The `SandboxBackend::Proot` branch isn't a realistic runtime path on Windows, but the code still has to compile there.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo check --all-targets` (aarch64-apple-darwin) — clean
- [x] `cargo check --target x86_64-pc-windows-gnu -p pentest-platform` — clean (this reproduces the CI failure locally before the fix)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo clippy --all-targets --target x86_64-pc-windows-gnu -p pentest-platform -- -D warnings` — clean
- [x] `cargo test --lib --bins` — 601 passed, 9 ignored (expected per CLAUDE.md)
- [ ] CI passes on all platforms, especially Desktop (Windows) and Headless (Windows)