### PR TITLE
fix(#217): unwrap .parameters for connector input_schema_json so Bedr…

### DIFF
--- a/crates/ui/src/liveview_connector/pick_connector.rs
+++ b/crates/ui/src/liveview_connector/pick_connector.rs
@@ -163,15 +163,28 @@ impl BaseConnector for PickConnector {
             .supported_schemas()
             .iter()
             .map(|schema| {
+                // `to_json_schema()` returns the full tool wrapper
+                // `{name, description, parameters: {type, properties, required}, ...}`.
+                // `TaskTypeSchema.input_schema_json` must carry ONLY the JSON schema
+                // (the `parameters` sub-object): the SDK's `build_registration_metadata`
+                // wraps `input_schema_json` under a `"parameters"` key itself, so passing
+                // the full wrapper here produces a double-nested schema whose ROOT has no
+                // `type`, which AWS Bedrock rejects
+                // (`toolConfig.tools.N.toolSpec.inputSchema.json.type must be object`).
+                // Unwrap `.parameters` to match `PentestConnector::build_task_types`.
                 let json_schema = schema.to_json_schema();
+                let input_schema = json_schema
+                    .get("parameters")
+                    .cloned()
+                    .unwrap_or_else(|| serde_json::json!({"type": "object", "properties": {}}));
                 TaskTypeSchema {
                     task_type_id: schema.name.clone(),
                     name: schema.name.clone(),
                     description: schema.description.clone(),
                     category: String::new(),
                     icon: String::new(),
-                    input_schema_json: serde_json::to_string(&json_schema)
-                        .unwrap_or_else(|_| "{}".to_string()),
+                    input_schema_json: serde_json::to_string(&input_schema)
+                        .unwrap_or_else(|_| r#"{"type":"object","properties":{}}"#.to_string()),
                     output_schema_json: "{}".to_string(),
                 }
             })
@@ -599,5 +612,73 @@ impl BaseConnector for PickConnector {
     fn handle_ws_close(&self, req: WsCloseRequest) {
         tracing::info!("Closing WebSocket: {}", req.connection_id);
         self.ws_connections.remove(&req.connection_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pentest_core::aggression::AggressionLevel;
+
+    // Build a PickConnector backed by the real tool registry so `capabilities()`
+    // exercises the exact production schema-emission path.
+    fn test_connector() -> PickConnector {
+        let (event_tx, _event_rx) = broadcast::channel(16);
+        PickConnector {
+            tools: Arc::new(RwLock::new(pentest_tools::create_tool_registry())),
+            workspace_path: None,
+            event_tx,
+            ws_connections: Arc::new(DashMap::new()),
+            matrix_client: Arc::new(RwLock::new(None)),
+            connector_name: "pentest-connector".to_string(),
+            instance_id: "test".to_string(),
+            aggression_level: Arc::new(RwLock::new(AggressionLevel::default())),
+            ipc_addr: Arc::new(RwLock::new(None)),
+            runner: Arc::new(RwLock::new(None)),
+            matrix_api_url: String::new(),
+        }
+    }
+
+    /// Regression guard: every `capabilities()` entry's `input_schema_json` must be
+    /// the JSON schema itself — a ROOT object with `type: "object"` — NOT the full
+    /// `to_json_schema()` wrapper (`{name, description, parameters, ...}`).
+    ///
+    /// The SDK's `build_registration_metadata` wraps `input_schema_json` under a
+    /// `"parameters"` key, so emitting the full wrapper here produces a double-nested
+    /// schema whose root lacks `type`, which AWS Bedrock rejects
+    /// (`toolConfig.tools.N.toolSpec.inputSchema.json.type must be object`).
+    #[test]
+    fn capabilities_input_schema_is_root_object_not_wrapper() {
+        let connector = test_connector();
+        let caps = connector.capabilities();
+        assert!(
+            !caps.is_empty(),
+            "expected the real registry to expose tools"
+        );
+
+        for cap in &caps {
+            let parsed: Value = serde_json::from_str(&cap.input_schema_json)
+                .unwrap_or_else(|e| panic!("{}: input_schema_json not valid JSON: {e}", cap.name));
+
+            // Root must declare an object schema.
+            assert_eq!(
+                parsed["type"], "object",
+                "{}: input_schema_json root must have type=object, got: {}",
+                cap.name, cap.input_schema_json
+            );
+
+            // Must NOT be the tool wrapper: a wrapper has a nested `parameters`
+            // object and carries the tool `name`/`description` at its root.
+            assert!(
+                !parsed["parameters"].is_object(),
+                "{}: input_schema_json is double-wrapped (nested `parameters` present)",
+                cap.name
+            );
+            assert!(
+                parsed.get("name").is_none(),
+                "{}: input_schema_json leaked the tool wrapper (root `name` present)",
+                cap.name
+            );
+        }
     }
 }


### PR DESCRIPTION
…ock accepts tool schemas

  Summary
  
  Fixes #217. The Pick connector registered tool schemas in a shape AWS Bedrock rejects, breaking all StrikeKit engagement execution. Once find_tools promoted a connector tool into the Bedrock tool list,
  Bedrock rejected the entire request:

  ProviderError: The value at toolConfig.tools.N.toolSpec.inputSchema.json.type must be one of the following: object.

  Execution appeared "stuck at tool discovery" and no connector tool (nmap, masscan, …) could run.

  Root cause
  
  PickConnector::capabilities() put the full to_json_schema() output — {name, description, parameters:{type,properties,required}, external_dependencies} — into TaskTypeSchema.input_schema_json.

  But the Strike48 Connector SDK's build_registration_metadata (strike48-connector 0.4.4) wraps input_schema_json under a "parameters" key itself:

  let parameters = serde_json::from_str(&tt.input_schema_json).unwrap_or(Value::Null);
  json!({ "name": tt.task_type_id, "description": tt.description, "parameters": parameters })

  So the SDK contract is: input_schema_json must be only the JSON schema ({type, properties, required}). Passing the full wrapper produced a double-nested schema (parameters.parameters) whose root has no 
  type. Matrix forwards it verbatim to Bedrock as inputSchema.json, which Bedrock rejects.

  The sibling builder PentestConnector::build_task_types (crates/core/src/connector.rs) already unwraps .parameters correctly — capabilities() was the one place that didn't.

  Fix
  
  PickConnector::capabilities() now unwraps .parameters before assigning input_schema_json, matching build_task_types:

  let json_schema = schema.to_json_schema();
  let input_schema = json_schema
      .get("parameters")
      .cloned()
      .unwrap_or_else(|| serde_json::json!({"type": "object", "properties": {}}));

  external_dependencies (a wrapper-root field, not part of the JSON schema) is intentionally not sent in input_schema_json — no consumer reads it from the wire schema; it is only accessed struct-side. The
  serialization fallback is a valid root object ({"type":"object","properties":{}}) rather than a type-less {}, so a (theoretical) serialization failure can't reintroduce the rejected shape.

  Why it regressed now (not a day-one bug)

  Two independent changes had to line up:

  1. Pick: the SDK BaseConnector/ConnectorRunner migration (#141) + SDK bump 0.3.4 → 0.4.4 routed registration through capabilities() + build_registration_metadata. The pre-migration path built the
  registration message manually and emitted the correct single-wrap — which is why earlier StrikeKit testing never hit this.
  2. Matrix: the tool-optimizer find_tools promotion path only sends a connector tool to Bedrock as a full spec once it's registered + auto-approved + discovered. A Matrix change that made StrikeKit connector
  tools register + auto-approve is what first exposed the latent malformed schema.

  Testing
  
  Regression unit test added: capabilities_input_schema_is_root_object_not_wrapper — builds the real tool registry, calls the production capabilities(), and asserts every entry's input_schema_json is a root
  object with type == "object" and is NOT the tool wrapper (no nested parameters, no root name). Verified it fails on the pre-fix code.

  CI gates (local):
  - cargo fmt --all -- --check — clean
  - cargo clippy --features connector,shell-ws,desktop -- -D warnings — clean
  - cargo test --features connector,shell-ws,desktop — 63 passed, 0 failed
  
  Runtime E2E (controlled A/B/A on the same Matrix server):

  ┌──────────────────────────┬────────────────────────────┬────────────────────────────────────┐
  │       Pick binary        │     Registered schema      │               Result               │
  ├──────────────────────────┼────────────────────────────┼────────────────────────────────────┤
  │ Pre-migration            │ single-wrap                │ ✅ Bedrock accepts, nmap runs      │
  ├──────────────────────────┼────────────────────────────┼────────────────────────────────────┤
  │ Post-migration, unfixed  │ double-wrap (no root type) │ 🔴 Bedrock rejects, execution dead │
  ├──────────────────────────┼────────────────────────────┼────────────────────────────────────┤
  │ Post-migration, this fix │ single-wrap                │ ✅ Bedrock accepts, nmap runs      │
  └──────────────────────────┴────────────────────────────┴────────────────────────────────────┘
  
  Confirmed by logging the exact wire payload at both the Pick send side and the Matrix ingest side.

