### PR TITLE
ci(release): use arduino/setup-protoc on Windows so protoc install can't silently 504 (#221)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install protoc
-        run: choco install protoc -y
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "27.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
         run: cargo build --locked --package pentest-desktop --release
@@ -347,7 +350,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install protoc
-        run: choco install protoc -y
+        uses: arduino/setup-protoc@v3
+        with:
+          version: "27.x"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
         run: cargo build --locked --package pentest-headless --release


### PR DESCRIPTION
## Summary

- Closes #221.
- v0.9.9 release run [29060198475](https://github.com/Strike48-public/pick/actions/runs/29060198475) failed on both Windows jobs because `choco install protoc -y` hit `community.chocolatey.org` 504 Gateway Timeout, installed nothing, and still exited 0. The failure only surfaced ~4 minutes later at `prost-build` time as a misleading "Could not find `protoc`" error.
- This PR swaps the chocolatey step on both `build-desktop-windows` and `build-headless-windows` for `arduino/setup-protoc@v3`, which:
  - pulls the release tarball straight from `github.com/protocolbuffers/protobuf/releases` (no chocolatey feed dependency),
  - writes the bin to `$GITHUB_PATH` so `protoc` is available in the next Build step,
  - fails hard on download errors so the workflow can't silently proceed to a broken build.

## Test plan

- [x] Diff limited to `.github/workflows/release.yml` — no code changes.
- [ ] CI: verify both Windows jobs now find `protoc` and reach the Sign / Package steps.
- [ ] Companion to #215 — both must land before the next tag will produce Windows artifacts.

## Related

- #214 / #215 — separate Windows compile issue in `crates/platform/src/desktop/pty_shell.rs`.