### PR TITLE
fix(#223): unblock standalone Pick auth flow end-to-end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,14 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install gitleaks
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          GITLEAKS_VERSION=$(curl -s https://api.github.com/repos/gitleaks/gitleaks/releases/latest | grep '"tag_name"' | sed 's/.*"v\(.*\)".*/\1/')
+          # `gh api` gives us a proper JSON parse via --jq so we don't have to
+          # regex our way through GitHub's compact JSON, which used to catch
+          # the whole `"tag_name":"v8.30.1","draft":...` blob and produce a
+          # malformed download URL.
+          GITLEAKS_VERSION=$(gh api repos/gitleaks/gitleaks/releases/latest --jq '.tag_name' | sed 's/^v//')
           curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar xz
           sudo mv gitleaks /usr/local/bin/
       - run: gitleaks detect --source . --verbose

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -351,6 +351,45 @@ impl ConnectorConfig {
         }
     }
 
+    /// Read the tenant UUID the SDK stored during OTT approval, if any.
+    ///
+    /// Studio addresses App-behavior connectors by tenant UUID
+    /// (`/#/apps/matrix%3A<uuid>%3A<connector>%3A...`). The connector's
+    /// initial pending-approval registration can carry either a tenant
+    /// slug or a UUID — the server accepts both — but Studio only routes
+    /// app-viewer traffic to the identity that matches its URL. When the
+    /// operator types the slug, the server-issued JWT is minted against
+    /// the canonical UUID and the SDK writes it to
+    /// `~/.strike48/credentials/<connector>_<instance_id>.json`. Reading
+    /// that file at connect time lets us reuse the UUID for subsequent
+    /// registrations so the slug→UUID gap is invisible to the operator
+    /// (pick#223).
+    ///
+    /// StrikeHub does the equivalent server-side: it pre-resolves the
+    /// user's tenant via a `userDetails { domain.id }` GraphQL query
+    /// (`strikehub/crates/sh-core/src/auth.rs::fetch_tenant_id`) and
+    /// injects the UUID into every spawned connector's env. Standalone
+    /// Pick has no authenticated context up front, so we rely on the
+    /// post-OTT credentials file instead.
+    ///
+    /// Returns `None` when the file is missing, unreadable, or the
+    /// `tenant_id` field is absent — callers should fall back to the
+    /// user-supplied tenant string.
+    pub fn read_credentials_tenant_id(connector_name: &str, instance_id: &str) -> Option<String> {
+        let home = std::env::var("HOME").ok()?;
+        let path = std::path::PathBuf::from(home)
+            .join(".strike48")
+            .join("credentials")
+            .join(format!("{connector_name}_{instance_id}.json"));
+        let content = std::fs::read_to_string(&path).ok()?;
+        let value: serde_json::Value = serde_json::from_str(&content).ok()?;
+        value
+            .get("tenant_id")
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+    }
+
     /// Split a Strike48-style URL (accepts anything [`normalize_host`] produces
     /// plus bare hosts) into `(hostname, port)`.
     ///
@@ -854,6 +893,44 @@ mod tests {
         let second = ConnectorConfig::normalize_host(&first.value).unwrap();
         assert_eq!(first.value, second.value);
         assert!(!second.was_inferred(), "second pass should not re-infer");
+    }
+
+    #[test]
+    fn read_credentials_tenant_id_extracts_uuid() {
+        // Isolate HOME so the test doesn't touch the real credentials dir.
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let creds_dir = tmp.path().join(".strike48").join("credentials");
+        std::fs::create_dir_all(&creds_dir).expect("mkdir creds");
+        let file = creds_dir.join("pentest-connector_dev-abc.json");
+        std::fs::write(
+            &file,
+            r#"{"client_id":"matrix:connector:local:019f4d37-0212-72cb-945a-f8d01726ebf5:pentest-connector:dev-abc","keycloak_url":"https://auth.example","tenant_id":"019f4d37-0212-72cb-945a-f8d01726ebf5"}"#,
+        )
+        .expect("write creds");
+
+        // SAFETY: single-threaded config tests, no other thread reads HOME here.
+        let prev = std::env::var("HOME").ok();
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let got = ConnectorConfig::read_credentials_tenant_id("pentest-connector", "dev-abc");
+        // Restore before assertions so a failing test doesn't leak env state.
+        match prev {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        assert_eq!(got.as_deref(), Some("019f4d37-0212-72cb-945a-f8d01726ebf5"));
+    }
+
+    #[test]
+    fn read_credentials_tenant_id_returns_none_when_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prev = std::env::var("HOME").ok();
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        let got = ConnectorConfig::read_credentials_tenant_id("pentest-connector", "never-ott");
+        match prev {
+            Some(v) => unsafe { std::env::set_var("HOME", v) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+        assert!(got.is_none());
     }
 
     #[test]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -297,7 +297,7 @@ impl ConnectorConfig {
         // ending in `/`, which would produce `strike48.example.com/:443` when
         // we append the inferred port (pick#223).
         let bare_str = bare_str
-            .split(|c| c == '/' || c == '?' || c == '#')
+            .split(['/', '?', '#'])
             .next()
             .unwrap_or(&bare_str)
             .to_string();
@@ -767,8 +767,7 @@ mod tests {
 
     #[test]
     fn strips_query_and_fragment() {
-        let n =
-            ConnectorConfig::normalize_host("https://strike48.example.com/?x=1#frag").unwrap();
+        let n = ConnectorConfig::normalize_host("https://strike48.example.com/?x=1#frag").unwrap();
         assert_eq!(n.value, "https://strike48.example.com:443");
     }
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -292,6 +292,16 @@ impl ConnectorConfig {
                 }
             };
 
+        // Trim any path/query suffix and trailing slash so a pasted browser
+        // URL (`https://strike48.example.com/`) doesn't leave the bare form
+        // ending in `/`, which would produce `strike48.example.com/:443` when
+        // we append the inferred port (pick#223).
+        let bare_str = bare_str
+            .split(|c| c == '/' || c == '?' || c == '#')
+            .next()
+            .unwrap_or(&bare_str)
+            .to_string();
+
         if bare_str.is_empty() {
             return Err(format!(
                 "Invalid host: missing hostname after scheme. Try {}strike48.example.com",
@@ -737,6 +747,29 @@ mod tests {
         let n = ConnectorConfig::normalize_host("localhost:50061").unwrap();
         assert_eq!(n.value, "localhost:50061");
         assert!(!n.was_inferred());
+    }
+
+    #[test]
+    fn strips_trailing_slash_before_inferring_port() {
+        // Pasting a browser URL with a trailing `/` used to produce
+        // `wss://host/:443` because the slash was baked into the bare form
+        // before we appended the default port (pick#223).
+        let n = ConnectorConfig::normalize_host("https://non-prod.strike48.test/").unwrap();
+        assert_eq!(n.value, "https://non-prod.strike48.test:443");
+        assert_eq!(n.inferred_port, Some(443));
+    }
+
+    #[test]
+    fn strips_path_after_authority() {
+        let n = ConnectorConfig::normalize_host("wss://strike48.example.com/socket/foo").unwrap();
+        assert_eq!(n.value, "wss://strike48.example.com:443");
+    }
+
+    #[test]
+    fn strips_query_and_fragment() {
+        let n =
+            ConnectorConfig::normalize_host("https://strike48.example.com/?x=1#frag").unwrap();
+        assert_eq!(n.value, "https://strike48.example.com:443");
     }
 
     #[test]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -351,6 +351,44 @@ impl ConnectorConfig {
         }
     }
 
+    /// The env vars operators use to pin a tenant identity, in preference
+    /// order. `MATRIX_TENANT_ID` comes first because operators typically
+    /// use it to carry an explicit UUID (aligning with StrikeHub's own
+    /// convention). `STRIKE48_TENANT` and its `TENANT_ID` alias are legacy
+    /// slug carriers; they still work but Studio's app-viewer routes by
+    /// UUID, so we prefer any UUID-shaped value we can find (pick#223).
+    pub const TENANT_ENV_VARS: &'static [&'static str] =
+        &["MATRIX_TENANT_ID", "STRIKE48_TENANT", "TENANT_ID"];
+
+    /// Does `s` parse as a canonical UUID?
+    ///
+    /// Used to distinguish tenant UUIDs from slugs when picking between
+    /// multiple env-var carriers or between a form value and an env
+    /// override. Trims whitespace so pasted values with newlines still
+    /// match.
+    pub fn is_uuid_like(s: &str) -> bool {
+        Uuid::parse_str(s.trim()).is_ok()
+    }
+
+    /// Return a tenant UUID from the first `TENANT_ENV_VARS` entry that
+    /// carries one, if any.
+    ///
+    /// Callers use this to promote a UUID over a slug the operator typed
+    /// in the ConfigForm — the slug is a valid registration identity but
+    /// Studio addresses the App-behavior connector by UUID, so an
+    /// explicit env-var UUID wins (see [`is_uuid_like`]).
+    pub fn tenant_uuid_from_env() -> Option<String> {
+        for var in Self::TENANT_ENV_VARS {
+            if let Ok(v) = std::env::var(var) {
+                let trimmed = v.trim();
+                if !trimmed.is_empty() && Self::is_uuid_like(trimmed) {
+                    return Some(trimmed.to_string());
+                }
+            }
+        }
+        None
+    }
+
     /// Read the tenant UUID the SDK stored during OTT approval, if any.
     ///
     /// Studio addresses App-behavior connectors by tenant UUID
@@ -624,8 +662,29 @@ pub fn load_connector_config(args: &[String]) -> ConfigLoadResult {
     if let Ok(token) = std::env::var("STRIKE48_TOKEN") {
         config.auth_token = token;
     }
-    if let Ok(tenant) = std::env::var("STRIKE48_TENANT").or_else(|_| std::env::var("TENANT_ID")) {
-        config.tenant_id = tenant;
+    // Tenant resolution: prefer any UUID-shaped value over a slug across
+    // the supported carriers (MATRIX_TENANT_ID, STRIKE48_TENANT, TENANT_ID),
+    // then fall back to the first non-empty slug. Studio addresses
+    // App-behavior connectors by tenant UUID, so a UUID env var wins even
+    // if a slug is present (pick#223).
+    let mut env_slug_fallback: Option<String> = None;
+    for var in ConnectorConfig::TENANT_ENV_VARS {
+        let Ok(v) = std::env::var(var) else { continue };
+        let trimmed = v.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if ConnectorConfig::is_uuid_like(trimmed) {
+            config.tenant_id = trimmed.to_string();
+            env_slug_fallback = None;
+            break;
+        }
+        if env_slug_fallback.is_none() {
+            env_slug_fallback = Some(trimmed.to_string());
+        }
+    }
+    if let Some(slug) = env_slug_fallback {
+        config.tenant_id = slug;
     }
     if let Ok(id) = std::env::var("STRIKE48_INSTANCE_ID").or_else(|_| std::env::var("INSTANCE_ID"))
     {
@@ -893,6 +952,83 @@ mod tests {
         let second = ConnectorConfig::normalize_host(&first.value).unwrap();
         assert_eq!(first.value, second.value);
         assert!(!second.was_inferred(), "second pass should not re-infer");
+    }
+
+    #[test]
+    fn is_uuid_like_accepts_canonical_and_rejects_slug() {
+        assert!(ConnectorConfig::is_uuid_like(
+            "019f4d37-0212-72cb-945a-f8d01726ebf5"
+        ));
+        assert!(ConnectorConfig::is_uuid_like(
+            "  019f4d37-0212-72cb-945a-f8d01726ebf5\n"
+        ));
+        assert!(!ConnectorConfig::is_uuid_like("non-prod"));
+        assert!(!ConnectorConfig::is_uuid_like(""));
+        assert!(!ConnectorConfig::is_uuid_like("019f4d37-0212"));
+    }
+
+    #[test]
+    fn tenant_uuid_from_env_prefers_matrix_tenant_id() {
+        // Serialise all tenant-env manipulation on a single lock so parallel
+        // tests can't leak into each other's env-var view.
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let previous: Vec<(&str, Option<String>)> = ConnectorConfig::TENANT_ENV_VARS
+            .iter()
+            .map(|k| (*k, std::env::var(k).ok()))
+            .collect();
+        // SAFETY: `LOCK` above serialises access to these env vars across
+        // config tests; other threads in this binary do not read them.
+        unsafe {
+            for k in ConnectorConfig::TENANT_ENV_VARS {
+                std::env::remove_var(k);
+            }
+            std::env::set_var("STRIKE48_TENANT", "non-prod");
+            std::env::set_var("MATRIX_TENANT_ID", "019f4d37-0212-72cb-945a-f8d01726ebf5");
+        }
+
+        let got = ConnectorConfig::tenant_uuid_from_env();
+
+        // Restore before asserting so failure doesn't leak state.
+        unsafe {
+            for (k, v) in previous {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+        assert_eq!(got.as_deref(), Some("019f4d37-0212-72cb-945a-f8d01726ebf5"));
+    }
+
+    #[test]
+    fn tenant_uuid_from_env_returns_none_when_only_slugs_present() {
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+
+        let previous: Vec<(&str, Option<String>)> = ConnectorConfig::TENANT_ENV_VARS
+            .iter()
+            .map(|k| (*k, std::env::var(k).ok()))
+            .collect();
+        unsafe {
+            for k in ConnectorConfig::TENANT_ENV_VARS {
+                std::env::remove_var(k);
+            }
+            std::env::set_var("STRIKE48_TENANT", "non-prod");
+        }
+
+        let got = ConnectorConfig::tenant_uuid_from_env();
+
+        unsafe {
+            for (k, v) in previous {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+        assert!(got.is_none());
     }
 
     #[test]

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -351,6 +351,63 @@ impl ConnectorConfig {
         }
     }
 
+    /// Split a Strike48-style URL (accepts anything [`normalize_host`] produces
+    /// plus bare hosts) into `(hostname, port)`.
+    ///
+    /// Callers that only need to open a TCP/TLS socket — e.g. the pre-connect
+    /// probe in `pentest-ui` — should use this rather than re-parsing by hand,
+    /// so the two ends of the connect pipeline agree on port defaulting, IPv6
+    /// bracket handling, and trailing-slash trimming. Returns `Err` on empty
+    /// input or a non-numeric port.
+    ///
+    /// When no port is present the default is `443`, matching
+    /// [`normalize_host`]'s Cloudflare-fronted-WebSocket default.
+    pub fn split_authority(url: &str) -> Result<(String, u16), String> {
+        let trimmed = url.trim();
+        if trimmed.is_empty() {
+            return Err("Strike48 host is empty".to_string());
+        }
+
+        let after_scheme = trimmed
+            .split_once("://")
+            .map(|(_, rest)| rest)
+            .unwrap_or(trimmed);
+
+        let authority = after_scheme
+            .split('/')
+            .next()
+            .unwrap_or(after_scheme)
+            .trim_end_matches('/');
+
+        // IPv6 literal `[::1]:443`
+        if let Some((host, tail)) = authority
+            .strip_prefix('[')
+            .and_then(|rest| rest.find(']').map(|end| (&rest[..end], &rest[end + 1..])))
+        {
+            let port = tail
+                .strip_prefix(':')
+                .and_then(|p| p.parse::<u16>().ok())
+                .unwrap_or(443);
+            return Ok((host.to_string(), port));
+        }
+
+        let (host, port) = match authority.rsplit_once(':') {
+            Some((h, p)) if !h.is_empty() => {
+                let port = p
+                    .parse::<u16>()
+                    .map_err(|_| format!("Invalid port in URL: {}", url))?;
+                (h.to_string(), port)
+            }
+            _ => (authority.to_string(), 443),
+        };
+
+        if host.is_empty() {
+            return Err(format!("Missing hostname in URL: {}", url));
+        }
+
+        Ok((host, port))
+    }
+
     /// Reduce a host URL to a short, stable identifier slug: scheme and port are
     /// stripped and any run of non-alphanumeric characters collapses to a single
     /// `-` (e.g. `wss://studio.example.com:443` -> `studio-example-com`).
@@ -797,6 +854,49 @@ mod tests {
         let second = ConnectorConfig::normalize_host(&first.value).unwrap();
         assert_eq!(first.value, second.value);
         assert!(!second.was_inferred(), "second pass should not re-infer");
+    }
+
+    #[test]
+    fn split_authority_parses_wss_with_port() {
+        assert_eq!(
+            ConnectorConfig::split_authority("wss://studio.example.com:443").unwrap(),
+            ("studio.example.com".to_string(), 443)
+        );
+    }
+
+    #[test]
+    fn split_authority_defaults_bare_host_to_443() {
+        assert_eq!(
+            ConnectorConfig::split_authority("studio.example.com").unwrap(),
+            ("studio.example.com".to_string(), 443)
+        );
+    }
+
+    #[test]
+    fn split_authority_parses_ipv6_bracketed() {
+        assert_eq!(
+            ConnectorConfig::split_authority("wss://[::1]:8443").unwrap(),
+            ("::1".to_string(), 8443)
+        );
+    }
+
+    #[test]
+    fn split_authority_preserves_custom_port() {
+        assert_eq!(
+            ConnectorConfig::split_authority("grpc://localhost:50061").unwrap(),
+            ("localhost".to_string(), 50061)
+        );
+    }
+
+    #[test]
+    fn split_authority_rejects_empty() {
+        assert!(ConnectorConfig::split_authority("").is_err());
+        assert!(ConnectorConfig::split_authority("   ").is_err());
+    }
+
+    #[test]
+    fn split_authority_rejects_invalid_port() {
+        assert!(ConnectorConfig::split_authority("wss://x.example.com:notaport").is_err());
     }
 
     #[test]

--- a/crates/ui/src/components/chat_panel/mod.rs
+++ b/crates/ui/src/components/chat_panel/mod.rs
@@ -49,6 +49,29 @@ use render::{CHART_PROCESSOR_JS, UTILS_JS};
 /// and does not capture the component's signal soup. The behaviour it composes
 /// is covered by the `parse_validator_verdicts` tests in `pentest-core` and the
 /// `apply_validator_verdicts` tests in `crate::session`.
+/// Return a Matrix session token supplied via `MATRIX_AUTH_TOKEN`, if any.
+///
+/// Standalone Pick has no way to launch the browser-OAuth flow when ports
+/// 4000/5173 are taken (Matrix's CORS whitelist), so we honor an explicit
+/// `MATRIX_AUTH_TOKEN` env var as a paste-in escape hatch (pick#223).
+fn try_env_matrix_token() -> Option<String> {
+    std::env::var("MATRIX_AUTH_TOKEN")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Whether `KEYCLOAK_USERNAME` and `KEYCLOAK_PASSWORD` are both non-empty in
+/// the environment, i.e. the headless OAuth flow is available.
+fn programmatic_auth_env_present() -> bool {
+    let has = |name: &str| {
+        std::env::var(name)
+            .map(|v| !v.trim().is_empty())
+            .unwrap_or(false)
+    };
+    has("KEYCLOAK_USERNAME") && has("KEYCLOAK_PASSWORD")
+}
+
 fn apply_validator_reply(
     messages: &[ChatMessage],
     pending_count: usize,
@@ -278,27 +301,73 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
     }
 
     // -----------------------------------------------------------------------
-    // Lazy browser-OAuth: trigger on first Chat panel visit when token is missing
+    // Lazy Matrix-session-token acquisition on first Chat visit.
+    //
+    // Standalone Pick has no session token by default (unlike the StrikeHub
+    // launch, which injects one via MATRIX_AUTH_TOKEN). We try, in order:
+    //
+    // 1. MATRIX_AUTH_TOKEN env var — operator can paste a token they got
+    //    from Studio and skip the whole dance.
+    // 2. Programmatic OAuth via KEYCLOAK_USERNAME/KEYCLOAK_PASSWORD — the
+    //    headless flow, doesn't need any local port to be free.
+    // 3. Browser OAuth — only if 1+2 didn't work, since it hard-requires
+    //    port 4000 or 5173 (Matrix CORS whitelist) and fails cleanly
+    //    otherwise. See pick#223.
+    //
+    // On success the token lands in the session store; failures surface as
+    // terminal-log errors with actionable guidance.
     // -----------------------------------------------------------------------
 
-    // Track whether we've attempted browser auth
-    let mut browser_auth_attempted = use_signal(|| false);
+    let mut token_fetch_attempted = use_signal(|| false);
 
-    // If Chat panel is visible, we don't have a token, and we haven't tried browser auth yet
     if props.visible
         && effective_token.is_empty()
         && !api_url.is_empty()
-        && !browser_auth_attempted()
+        && !token_fetch_attempted()
         && !agents_loaded()
     {
-        browser_auth_attempted.set(true);
+        token_fetch_attempted.set(true);
         let api_url_clone = api_url.clone();
 
         crate::liveview_server::push_terminal_line(TerminalLine::info(
-            "[chat] No auth token — opening browser for authentication...",
+            "[chat] No auth token — acquiring Matrix session token...",
         ));
 
         spawn(async move {
+            if let Some(token) = try_env_matrix_token() {
+                tracing::info!("[chat] Using MATRIX_AUTH_TOKEN from env (len={})", token.len());
+                crate::liveview_server::set_matrix_credentials(&api_url_clone, &token);
+                crate::session::set_auth_token(&token);
+                crate::liveview_server::push_terminal_line(TerminalLine::success(
+                    "[chat] Authenticated via MATRIX_AUTH_TOKEN env var",
+                ));
+                return;
+            }
+
+            if programmatic_auth_env_present() {
+                match pentest_core::matrix::fetch_matrix_token_from(&api_url_clone).await {
+                    Ok(token) => {
+                        tracing::info!(
+                            "[chat] Programmatic auth succeeded (len={})",
+                            token.len()
+                        );
+                        crate::liveview_server::set_matrix_credentials(&api_url_clone, &token);
+                        crate::session::set_auth_token(&token);
+                        crate::liveview_server::push_terminal_line(TerminalLine::success(
+                            "[chat] Authenticated via KEYCLOAK_USERNAME/PASSWORD",
+                        ));
+                        return;
+                    }
+                    Err(e) => {
+                        tracing::warn!("[chat] Programmatic auth failed: {}", e);
+                        crate::liveview_server::push_terminal_line(TerminalLine::info(format!(
+                            "[chat] Programmatic auth failed ({}); falling back to browser…",
+                            e
+                        )));
+                    }
+                }
+            }
+
             match pentest_core::matrix::fetch_matrix_token_browser(&api_url_clone).await {
                 Ok(token) => {
                     tracing::info!(
@@ -314,7 +383,10 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
                 Err(e) => {
                     tracing::warn!("[chat] Browser auth failed: {}", e);
                     crate::liveview_server::push_terminal_line(TerminalLine::error(format!(
-                        "[chat] Authentication failed: {}",
+                        "[chat] Authentication failed: {}. \
+                         Alternatives: set MATRIX_AUTH_TOKEN env var to a session token \
+                         from Studio, or set KEYCLOAK_USERNAME and KEYCLOAK_PASSWORD for \
+                         headless auth.",
                         e
                     )));
                 }

--- a/crates/ui/src/components/chat_panel/mod.rs
+++ b/crates/ui/src/components/chat_panel/mod.rs
@@ -49,29 +49,6 @@ use render::{CHART_PROCESSOR_JS, UTILS_JS};
 /// and does not capture the component's signal soup. The behaviour it composes
 /// is covered by the `parse_validator_verdicts` tests in `pentest-core` and the
 /// `apply_validator_verdicts` tests in `crate::session`.
-/// Return a Matrix session token supplied via `MATRIX_AUTH_TOKEN`, if any.
-///
-/// Standalone Pick has no way to launch the browser-OAuth flow when ports
-/// 4000/5173 are taken (Matrix's CORS whitelist), so we honor an explicit
-/// `MATRIX_AUTH_TOKEN` env var as a paste-in escape hatch (pick#223).
-fn try_env_matrix_token() -> Option<String> {
-    std::env::var("MATRIX_AUTH_TOKEN")
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-}
-
-/// Whether `KEYCLOAK_USERNAME` and `KEYCLOAK_PASSWORD` are both non-empty in
-/// the environment, i.e. the headless OAuth flow is available.
-fn programmatic_auth_env_present() -> bool {
-    let has = |name: &str| {
-        std::env::var(name)
-            .map(|v| !v.trim().is_empty())
-            .unwrap_or(false)
-    };
-    has("KEYCLOAK_USERNAME") && has("KEYCLOAK_PASSWORD")
-}
-
 fn apply_validator_reply(
     messages: &[ChatMessage],
     pending_count: usize,
@@ -301,73 +278,27 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
     }
 
     // -----------------------------------------------------------------------
-    // Lazy Matrix-session-token acquisition on first Chat visit.
-    //
-    // Standalone Pick has no session token by default (unlike the StrikeHub
-    // launch, which injects one via MATRIX_AUTH_TOKEN). We try, in order:
-    //
-    // 1. MATRIX_AUTH_TOKEN env var — operator can paste a token they got
-    //    from Studio and skip the whole dance.
-    // 2. Programmatic OAuth via KEYCLOAK_USERNAME/KEYCLOAK_PASSWORD — the
-    //    headless flow, doesn't need any local port to be free.
-    // 3. Browser OAuth — only if 1+2 didn't work, since it hard-requires
-    //    port 4000 or 5173 (Matrix CORS whitelist) and fails cleanly
-    //    otherwise. See pick#223.
-    //
-    // On success the token lands in the session store; failures surface as
-    // terminal-log errors with actionable guidance.
+    // Lazy browser-OAuth: trigger on first Chat panel visit when token is missing
     // -----------------------------------------------------------------------
 
-    let mut token_fetch_attempted = use_signal(|| false);
+    // Track whether we've attempted browser auth
+    let mut browser_auth_attempted = use_signal(|| false);
 
+    // If Chat panel is visible, we don't have a token, and we haven't tried browser auth yet
     if props.visible
         && effective_token.is_empty()
         && !api_url.is_empty()
-        && !token_fetch_attempted()
+        && !browser_auth_attempted()
         && !agents_loaded()
     {
-        token_fetch_attempted.set(true);
+        browser_auth_attempted.set(true);
         let api_url_clone = api_url.clone();
 
         crate::liveview_server::push_terminal_line(TerminalLine::info(
-            "[chat] No auth token — acquiring Matrix session token...",
+            "[chat] No auth token — opening browser for authentication...",
         ));
 
         spawn(async move {
-            if let Some(token) = try_env_matrix_token() {
-                tracing::info!(
-                    "[chat] Using MATRIX_AUTH_TOKEN from env (len={})",
-                    token.len()
-                );
-                crate::liveview_server::set_matrix_credentials(&api_url_clone, &token);
-                crate::session::set_auth_token(&token);
-                crate::liveview_server::push_terminal_line(TerminalLine::success(
-                    "[chat] Authenticated via MATRIX_AUTH_TOKEN env var",
-                ));
-                return;
-            }
-
-            if programmatic_auth_env_present() {
-                match pentest_core::matrix::fetch_matrix_token_from(&api_url_clone).await {
-                    Ok(token) => {
-                        tracing::info!("[chat] Programmatic auth succeeded (len={})", token.len());
-                        crate::liveview_server::set_matrix_credentials(&api_url_clone, &token);
-                        crate::session::set_auth_token(&token);
-                        crate::liveview_server::push_terminal_line(TerminalLine::success(
-                            "[chat] Authenticated via KEYCLOAK_USERNAME/PASSWORD",
-                        ));
-                        return;
-                    }
-                    Err(e) => {
-                        tracing::warn!("[chat] Programmatic auth failed: {}", e);
-                        crate::liveview_server::push_terminal_line(TerminalLine::info(format!(
-                            "[chat] Programmatic auth failed ({}); falling back to browser…",
-                            e
-                        )));
-                    }
-                }
-            }
-
             match pentest_core::matrix::fetch_matrix_token_browser(&api_url_clone).await {
                 Ok(token) => {
                     tracing::info!(
@@ -383,10 +314,7 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
                 Err(e) => {
                     tracing::warn!("[chat] Browser auth failed: {}", e);
                     crate::liveview_server::push_terminal_line(TerminalLine::error(format!(
-                        "[chat] Authentication failed: {}. \
-                         Alternatives: set MATRIX_AUTH_TOKEN env var to a session token \
-                         from Studio, or set KEYCLOAK_USERNAME and KEYCLOAK_PASSWORD for \
-                         headless auth.",
+                        "[chat] Authentication failed: {}",
                         e
                     )));
                 }

--- a/crates/ui/src/components/chat_panel/mod.rs
+++ b/crates/ui/src/components/chat_panel/mod.rs
@@ -335,7 +335,10 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
 
         spawn(async move {
             if let Some(token) = try_env_matrix_token() {
-                tracing::info!("[chat] Using MATRIX_AUTH_TOKEN from env (len={})", token.len());
+                tracing::info!(
+                    "[chat] Using MATRIX_AUTH_TOKEN from env (len={})",
+                    token.len()
+                );
                 crate::liveview_server::set_matrix_credentials(&api_url_clone, &token);
                 crate::session::set_auth_token(&token);
                 crate::liveview_server::push_terminal_line(TerminalLine::success(
@@ -347,10 +350,7 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
             if programmatic_auth_env_present() {
                 match pentest_core::matrix::fetch_matrix_token_from(&api_url_clone).await {
                     Ok(token) => {
-                        tracing::info!(
-                            "[chat] Programmatic auth succeeded (len={})",
-                            token.len()
-                        );
+                        tracing::info!("[chat] Programmatic auth succeeded (len={})", token.len());
                         crate::liveview_server::set_matrix_credentials(&api_url_clone, &token);
                         crate::session::set_auth_token(&token);
                         crate::liveview_server::push_terminal_line(TerminalLine::success(

--- a/crates/ui/src/connector_app.rs
+++ b/crates/ui/src/connector_app.rs
@@ -362,6 +362,27 @@ pub fn connector_app(cfg: ConnectorAppConfig) -> Element {
         // for every env, so a token minted for env A is rejected by env B.
         new_config.instance_id =
             ConnectorConfig::env_scoped_instance_id(&device_id, &new_config.host);
+
+        // Studio addresses App-behavior connectors by tenant UUID, so when
+        // the operator typed the slug we need to substitute the canonical
+        // UUID before registering. The SDK writes it to
+        // `~/.strike48/credentials/<connector>_<instance>.json` on first
+        // successful OTT; if that file exists, honor its `tenant_id`
+        // regardless of what's in the form. StrikeHub's launcher does the
+        // equivalent server-side (`strikehub/crates/sh-core/src/auth.rs::
+        // fetch_tenant_id`). See pick#223.
+        if let Some(canonical) = ConnectorConfig::read_credentials_tenant_id(
+            &new_config.connector_name,
+            &new_config.instance_id,
+        ) {
+            if canonical != new_config.tenant_id {
+                terminal_lines.write().push(TerminalLine::info(format!(
+                    "Using tenant UUID {} from saved credentials (form value: {})",
+                    canonical, new_config.tenant_id,
+                )));
+                new_config.tenant_id = canonical;
+            }
+        }
         config.set(new_config.clone());
         status.set(ConnectorStatus::Connecting);
         connecting_step.set(Some(ConnectingStep::Connecting));
@@ -382,6 +403,13 @@ pub fn connector_app(cfg: ConnectorAppConfig) -> Element {
         let mut terminal_lines = terminal_lines;
         let connecting_step = connecting_step;
         let mut workspace_path = workspace_path;
+
+        // Clone identity fields before we consume `new_config` in the
+        // spawned connector task — we still need them for the first-run
+        // OTT self-heal poll below.
+        let connector_name_for_poll = new_config.connector_name.clone();
+        let instance_id_for_poll = new_config.instance_id.clone();
+        let initial_tenant_for_poll = new_config.tenant_id.clone();
 
         spawn(async move {
             let tools = (cfg.create_tools)();
@@ -425,6 +453,53 @@ pub fn connector_app(cfg: ConnectorAppConfig) -> Element {
             let event_rx = lv_connector.event_rx();
             let lv_connector = Arc::new(RwLock::new(lv_connector));
             connector.set(Some(lv_connector.clone()));
+
+            // First-run OTT self-heal: the SDK writes the canonical tenant
+            // UUID to disk once OTT approval completes, but Pick's config
+            // still carries whatever the operator typed. Poll for a bounded
+            // window so that (a) the current session picks up the UUID for
+            // any subsequent connect and (b) settings persist the UUID for
+            // the next launch, keeping the slug detour to at most one
+            // reconnect. See pick#223.
+            {
+                let connector_name = connector_name_for_poll;
+                let instance_id = instance_id_for_poll;
+                let initial_tenant = initial_tenant_for_poll;
+                spawn(async move {
+                    for _ in 0..60 {
+                        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                        let Some(canonical) = ConnectorConfig::read_credentials_tenant_id(
+                            &connector_name,
+                            &instance_id,
+                        ) else {
+                            continue;
+                        };
+                        if canonical == initial_tenant {
+                            return;
+                        }
+                        let mut s = settings.peek().clone();
+                        let updated = match s.last_config.clone() {
+                            Some(mut c) => {
+                                if c.tenant_id == canonical {
+                                    return;
+                                }
+                                c.tenant_id = canonical.clone();
+                                Some(c)
+                            }
+                            None => None,
+                        };
+                        if let Some(c) = updated {
+                            s.last_config = Some(c);
+                            let _ = save_settings(&s);
+                            terminal_lines.write().push(TerminalLine::info(format!(
+                                "Saved canonical tenant UUID {} for next launch.",
+                                canonical
+                            )));
+                        }
+                        return;
+                    }
+                });
+            }
 
             // Spawn event handler
             spawn(run_event_loop(

--- a/crates/ui/src/connector_app.rs
+++ b/crates/ui/src/connector_app.rs
@@ -365,12 +365,29 @@ pub fn connector_app(cfg: ConnectorAppConfig) -> Element {
 
         // Studio addresses App-behavior connectors by tenant UUID, so when
         // the operator typed the slug we need to substitute the canonical
-        // UUID before registering. The SDK writes it to
-        // `~/.strike48/credentials/<connector>_<instance>.json` on first
-        // successful OTT; if that file exists, honor its `tenant_id`
-        // regardless of what's in the form. StrikeHub's launcher does the
-        // equivalent server-side (`strikehub/crates/sh-core/src/auth.rs::
-        // fetch_tenant_id`). See pick#223.
+        // UUID before registering. Two sources, tried in order:
+        //
+        // 1. A UUID env var (`MATRIX_TENANT_ID`, `STRIKE48_TENANT`, or
+        //    `TENANT_ID` — whichever carries a UUID). This is the common
+        //    case: the operator sets `STRIKE48_TENANT=slug` and pins the
+        //    UUID as `MATRIX_TENANT_ID`, then still types the slug in the
+        //    form out of habit.
+        // 2. The SDK's post-OTT credentials file at
+        //    `~/.strike48/credentials/<connector>_<instance>.json`, which
+        //    carries the canonical `tenant_id` the server minted.
+        //
+        // StrikeHub's launcher does the equivalent server-side via
+        // `fetch_tenant_id` (`strikehub/crates/sh-core/src/auth.rs`). See
+        // pick#223.
+        if !ConnectorConfig::is_uuid_like(&new_config.tenant_id) {
+            if let Some(env_uuid) = ConnectorConfig::tenant_uuid_from_env() {
+                terminal_lines.write().push(TerminalLine::info(format!(
+                    "Promoting tenant UUID {} from env (form value: {})",
+                    env_uuid, new_config.tenant_id,
+                )));
+                new_config.tenant_id = env_uuid;
+            }
+        }
         if let Some(canonical) = ConnectorConfig::read_credentials_tenant_id(
             &new_config.connector_name,
             &new_config.instance_id,

--- a/crates/ui/src/liveview_connector/mod.rs
+++ b/crates/ui/src/liveview_connector/mod.rs
@@ -819,16 +819,16 @@ impl LiveViewConnector {
 async fn probe_host_reachable(host: &str) -> Result<(), String> {
     const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(6);
 
-    let (hostname, port) = parse_host_port(host)?;
+    let (hostname, port) = ConnectorConfig::split_authority(host)?;
 
-    // For plain `ws://` / `http://` (unusual for Strike48 but supported for
-    // local dev), skip the TLS handshake and just probe TCP.
-    let use_tls = matches!(
-        host.trim().to_lowercase().as_str(),
-        s if s.starts_with("wss://") || s.starts_with("https://") || s.starts_with("grpcs://")
-    ) || !(host.trim().to_lowercase().starts_with("ws://")
-        || host.trim().to_lowercase().starts_with("http://")
-        || host.trim().to_lowercase().starts_with("grpc://"));
+    // Plain (non-TLS) schemes skip the TLS handshake and settle for TCP-only.
+    // Anything else — including the bare-host case, which `normalize_host`
+    // treats as `wss://` — probes TLS. Trim + lowercase once so we're not
+    // doing four allocations per probe.
+    let scheme_prefix = host.trim().to_lowercase();
+    let use_tls = !(scheme_prefix.starts_with("ws://")
+        || scheme_prefix.starts_with("http://")
+        || scheme_prefix.starts_with("grpc://"));
 
     let target = format!("{}:{}", hostname, port);
 
@@ -860,6 +860,11 @@ async fn probe_host_reachable(host: &str) -> Result<(), String> {
     // TLS handshake: proves that a real TLS endpoint is answering under the
     // hostname the operator typed. Uses reqwest, which is already a
     // workspace dep and configured with rustls + native roots.
+    //
+    // `MATRIX_TLS_INSECURE` matches the existing convention in
+    // `token_refresh::build_client` and `pentest_core::matrix::client`
+    // (self-signed dev clusters). This probe-only relaxation does not touch
+    // the SDK's own TLS trust — it only affects our reachability HEAD.
     let probe_url = format!("https://{}/", target);
     let client = reqwest::Client::builder()
         .timeout(CONNECT_TIMEOUT)
@@ -887,104 +892,5 @@ async fn probe_host_reachable(host: &str) -> Result<(), String> {
             // prove the endpoint answered — accept and let the SDK continue.
             Ok(())
         }
-    }
-}
-
-/// Parse a Strike48-style URL into `(hostname, port)`.
-///
-/// Accepts the same shapes `ConnectorConfig::normalize_host` produces. Assumes
-/// the caller has already run normalize_host, so scheme + port are present.
-fn parse_host_port(url: &str) -> Result<(String, u16), String> {
-    let trimmed = url.trim();
-    if trimmed.is_empty() {
-        return Err("Strike48 host is empty".to_string());
-    }
-
-    let after_scheme = trimmed
-        .split_once("://")
-        .map(|(_, rest)| rest)
-        .unwrap_or(trimmed);
-
-    let authority = after_scheme.split('/').next().unwrap_or(after_scheme);
-
-    // Drop trailing slash if present.
-    let authority = authority.trim_end_matches('/');
-
-    // IPv6 literal `[::1]:443`
-    if let Some(closing) = authority
-        .strip_prefix('[')
-        .and_then(|rest| rest.find(']').map(|end| (&rest[..end], &rest[end + 1..])))
-    {
-        let host = closing.0.to_string();
-        let port = closing
-            .1
-            .strip_prefix(':')
-            .and_then(|p| p.parse::<u16>().ok())
-            .unwrap_or(443);
-        return Ok((host, port));
-    }
-
-    let (host, port) = match authority.rsplit_once(':') {
-        Some((h, p)) if !h.is_empty() => {
-            let port = p
-                .parse::<u16>()
-                .map_err(|_| format!("Invalid port in URL: {}", url))?;
-            (h.to_string(), port)
-        }
-        _ => (authority.to_string(), 443),
-    };
-
-    if host.is_empty() {
-        return Err(format!("Missing hostname in URL: {}", url));
-    }
-
-    Ok((host, port))
-}
-
-#[cfg(test)]
-mod host_probe_tests {
-    use super::parse_host_port;
-
-    #[test]
-    fn parses_wss_with_port() {
-        assert_eq!(
-            parse_host_port("wss://studio.example.com:443").unwrap(),
-            ("studio.example.com".to_string(), 443)
-        );
-    }
-
-    #[test]
-    fn parses_bare_host() {
-        assert_eq!(
-            parse_host_port("studio.example.com").unwrap(),
-            ("studio.example.com".to_string(), 443)
-        );
-    }
-
-    #[test]
-    fn parses_ipv6_bracketed() {
-        assert_eq!(
-            parse_host_port("wss://[::1]:8443").unwrap(),
-            ("::1".to_string(), 8443)
-        );
-    }
-
-    #[test]
-    fn parses_custom_port() {
-        assert_eq!(
-            parse_host_port("grpc://localhost:50061").unwrap(),
-            ("localhost".to_string(), 50061)
-        );
-    }
-
-    #[test]
-    fn rejects_empty() {
-        assert!(parse_host_port("").is_err());
-        assert!(parse_host_port("   ").is_err());
-    }
-
-    #[test]
-    fn rejects_invalid_port() {
-        assert!(parse_host_port("wss://x.example.com:notaport").is_err());
     }
 }

--- a/crates/ui/src/liveview_connector/mod.rs
+++ b/crates/ui/src/liveview_connector/mod.rs
@@ -832,11 +832,8 @@ async fn probe_host_reachable(host: &str) -> Result<(), String> {
 
     let target = format!("{}:{}", hostname, port);
 
-    let connect_result = tokio::time::timeout(
-        CONNECT_TIMEOUT,
-        tokio::net::TcpStream::connect(&target),
-    )
-    .await;
+    let connect_result =
+        tokio::time::timeout(CONNECT_TIMEOUT, tokio::net::TcpStream::connect(&target)).await;
 
     let stream = match connect_result {
         Ok(Ok(s)) => s,
@@ -914,9 +911,10 @@ fn parse_host_port(url: &str) -> Result<(String, u16), String> {
     let authority = authority.trim_end_matches('/');
 
     // IPv6 literal `[::1]:443`
-    if let Some(closing) = authority.strip_prefix('[').and_then(|rest| {
-        rest.find(']').map(|end| (&rest[..end], &rest[end + 1..]))
-    }) {
+    if let Some(closing) = authority
+        .strip_prefix('[')
+        .and_then(|rest| rest.find(']').map(|end| (&rest[..end], &rest[end + 1..])))
+    {
         let host = closing.0.to_string();
         let port = closing
             .1

--- a/crates/ui/src/liveview_connector/mod.rs
+++ b/crates/ui/src/liveview_connector/mod.rs
@@ -682,6 +682,19 @@ impl LiveViewConnector {
             self.config.auth_token.is_empty(),
         );
 
+        // Pre-connect reachability probe: fast-fail on obviously bad URLs
+        // (DNS miss, TLS refused, connect timeout) before the SDK spins up a
+        // full runner + auto-reconnect loop. Without this, a typo like
+        // `https://discoball.strike48.engineering/` leaves the UI stuck on
+        // the connecting spinner with no feedback (pick#223). Returning Err
+        // here lets the caller populate its `connect_error` banner; we skip
+        // emitting a `Disconnected` status event so we don't race the
+        // caller's `Error(_)` set that steers the UI back to the form.
+        if let Err(e) = probe_host_reachable(&self.config.host).await {
+            self.send_event(ConnectorEvent::Log(TerminalLine::error(e.clone())));
+            return Err(e);
+        }
+
         // Build the SDK config from our pentest_core config
         let mut sdk_config = self.config.to_sdk_config();
 
@@ -791,5 +804,189 @@ impl LiveViewConnector {
         if self.workspace_path.is_some() {
             workspace::cleanup_workspace(&self.config.instance_id);
         }
+    }
+}
+
+/// Fast reachability check against the configured Strike48 host.
+///
+/// Runs a bounded TCP+TLS handshake so a typo like
+/// `wss://discoball.strike48.engineering:443` fails immediately with a clear
+/// message instead of leaving the UI stuck on the connecting spinner while
+/// the SDK retries (pick#223). We deliberately do *not* attempt HTTP-level
+/// probing here: the WebSocket path (`/socket/connector/websocket`) is what
+/// the SDK will exercise, and any hard reachability failure surfaces during
+/// the TLS handshake anyway.
+async fn probe_host_reachable(host: &str) -> Result<(), String> {
+    const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(6);
+
+    let (hostname, port) = parse_host_port(host)?;
+
+    // For plain `ws://` / `http://` (unusual for Strike48 but supported for
+    // local dev), skip the TLS handshake and just probe TCP.
+    let use_tls = matches!(
+        host.trim().to_lowercase().as_str(),
+        s if s.starts_with("wss://") || s.starts_with("https://") || s.starts_with("grpcs://")
+    ) || !(host.trim().to_lowercase().starts_with("ws://")
+        || host.trim().to_lowercase().starts_with("http://")
+        || host.trim().to_lowercase().starts_with("grpc://"));
+
+    let target = format!("{}:{}", hostname, port);
+
+    let connect_result = tokio::time::timeout(
+        CONNECT_TIMEOUT,
+        tokio::net::TcpStream::connect(&target),
+    )
+    .await;
+
+    let stream = match connect_result {
+        Ok(Ok(s)) => s,
+        Ok(Err(e)) => {
+            return Err(format!(
+                "Cannot reach {}: {}. Check the URL and your network connection.",
+                target, e
+            ));
+        }
+        Err(_) => {
+            return Err(format!(
+                "Timed out connecting to {} after {}s. Verify the URL is reachable.",
+                target,
+                CONNECT_TIMEOUT.as_secs()
+            ));
+        }
+    };
+
+    if !use_tls {
+        drop(stream);
+        return Ok(());
+    }
+
+    // TLS handshake: proves that a real TLS endpoint is answering under the
+    // hostname the operator typed. Uses reqwest, which is already a
+    // workspace dep and configured with rustls + native roots.
+    let probe_url = format!("https://{}/", target);
+    let client = reqwest::Client::builder()
+        .timeout(CONNECT_TIMEOUT)
+        .danger_accept_invalid_certs(
+            std::env::var("MATRIX_TLS_INSECURE")
+                .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+                .unwrap_or(false),
+        )
+        .build()
+        .map_err(|e| format!("Failed to build TLS probe client: {}", e))?;
+
+    drop(stream);
+    match client.head(&probe_url).send().await {
+        Ok(_) => Ok(()),
+        Err(e) if e.is_status() => {
+            // Any HTTP status is fine — proves the endpoint spoke TLS + HTTP.
+            Ok(())
+        }
+        Err(e) if e.is_connect() || e.is_timeout() => Err(format!(
+            "TLS handshake to {} failed: {}. Verify the URL and TLS trust chain.",
+            target, e
+        )),
+        Err(_) => {
+            // Non-connect errors (redirect loop, body-decode, etc.) still
+            // prove the endpoint answered — accept and let the SDK continue.
+            Ok(())
+        }
+    }
+}
+
+/// Parse a Strike48-style URL into `(hostname, port)`.
+///
+/// Accepts the same shapes `ConnectorConfig::normalize_host` produces. Assumes
+/// the caller has already run normalize_host, so scheme + port are present.
+fn parse_host_port(url: &str) -> Result<(String, u16), String> {
+    let trimmed = url.trim();
+    if trimmed.is_empty() {
+        return Err("Strike48 host is empty".to_string());
+    }
+
+    let after_scheme = trimmed
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or(trimmed);
+
+    let authority = after_scheme.split('/').next().unwrap_or(after_scheme);
+
+    // Drop trailing slash if present.
+    let authority = authority.trim_end_matches('/');
+
+    // IPv6 literal `[::1]:443`
+    if let Some(closing) = authority.strip_prefix('[').and_then(|rest| {
+        rest.find(']').map(|end| (&rest[..end], &rest[end + 1..]))
+    }) {
+        let host = closing.0.to_string();
+        let port = closing
+            .1
+            .strip_prefix(':')
+            .and_then(|p| p.parse::<u16>().ok())
+            .unwrap_or(443);
+        return Ok((host, port));
+    }
+
+    let (host, port) = match authority.rsplit_once(':') {
+        Some((h, p)) if !h.is_empty() => {
+            let port = p
+                .parse::<u16>()
+                .map_err(|_| format!("Invalid port in URL: {}", url))?;
+            (h.to_string(), port)
+        }
+        _ => (authority.to_string(), 443),
+    };
+
+    if host.is_empty() {
+        return Err(format!("Missing hostname in URL: {}", url));
+    }
+
+    Ok((host, port))
+}
+
+#[cfg(test)]
+mod host_probe_tests {
+    use super::parse_host_port;
+
+    #[test]
+    fn parses_wss_with_port() {
+        assert_eq!(
+            parse_host_port("wss://studio.example.com:443").unwrap(),
+            ("studio.example.com".to_string(), 443)
+        );
+    }
+
+    #[test]
+    fn parses_bare_host() {
+        assert_eq!(
+            parse_host_port("studio.example.com").unwrap(),
+            ("studio.example.com".to_string(), 443)
+        );
+    }
+
+    #[test]
+    fn parses_ipv6_bracketed() {
+        assert_eq!(
+            parse_host_port("wss://[::1]:8443").unwrap(),
+            ("::1".to_string(), 8443)
+        );
+    }
+
+    #[test]
+    fn parses_custom_port() {
+        assert_eq!(
+            parse_host_port("grpc://localhost:50061").unwrap(),
+            ("localhost".to_string(), 50061)
+        );
+    }
+
+    #[test]
+    fn rejects_empty() {
+        assert!(parse_host_port("").is_err());
+        assert!(parse_host_port("   ").is_err());
+    }
+
+    #[test]
+    fn rejects_invalid_port() {
+        assert!(parse_host_port("wss://x.example.com:notaport").is_err());
     }
 }

--- a/crates/ui/src/liveview_connector/mod.rs
+++ b/crates/ui/src/liveview_connector/mod.rs
@@ -809,88 +809,27 @@ impl LiveViewConnector {
 
 /// Fast reachability check against the configured Strike48 host.
 ///
-/// Runs a bounded TCP+TLS handshake so a typo like
-/// `wss://discoball.strike48.engineering:443` fails immediately with a clear
-/// message instead of leaving the UI stuck on the connecting spinner while
-/// the SDK retries (pick#223). We deliberately do *not* attempt HTTP-level
-/// probing here: the WebSocket path (`/socket/connector/websocket`) is what
-/// the SDK will exercise, and any hard reachability failure surfaces during
-/// the TLS handshake anyway.
+/// Bounded TCP connect so a typo like `wss://discoball.strike48.engineering`
+/// fails immediately with a clear message instead of leaving the UI stuck on
+/// the connecting spinner while the SDK retries (pick#223). TLS-level
+/// failures still surface through the SDK's own WebSocket handshake, so we
+/// deliberately don't re-probe TLS here — one round-trip, one error path.
 async fn probe_host_reachable(host: &str) -> Result<(), String> {
     const CONNECT_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(6);
 
     let (hostname, port) = ConnectorConfig::split_authority(host)?;
-
-    // Plain (non-TLS) schemes skip the TLS handshake and settle for TCP-only.
-    // Anything else — including the bare-host case, which `normalize_host`
-    // treats as `wss://` — probes TLS. Trim + lowercase once so we're not
-    // doing four allocations per probe.
-    let scheme_prefix = host.trim().to_lowercase();
-    let use_tls = !(scheme_prefix.starts_with("ws://")
-        || scheme_prefix.starts_with("http://")
-        || scheme_prefix.starts_with("grpc://"));
-
     let target = format!("{}:{}", hostname, port);
 
-    let connect_result =
-        tokio::time::timeout(CONNECT_TIMEOUT, tokio::net::TcpStream::connect(&target)).await;
-
-    let stream = match connect_result {
-        Ok(Ok(s)) => s,
-        Ok(Err(e)) => {
-            return Err(format!(
-                "Cannot reach {}: {}. Check the URL and your network connection.",
-                target, e
-            ));
-        }
-        Err(_) => {
-            return Err(format!(
-                "Timed out connecting to {} after {}s. Verify the URL is reachable.",
-                target,
-                CONNECT_TIMEOUT.as_secs()
-            ));
-        }
-    };
-
-    if !use_tls {
-        drop(stream);
-        return Ok(());
-    }
-
-    // TLS handshake: proves that a real TLS endpoint is answering under the
-    // hostname the operator typed. Uses reqwest, which is already a
-    // workspace dep and configured with rustls + native roots.
-    //
-    // `MATRIX_TLS_INSECURE` matches the existing convention in
-    // `token_refresh::build_client` and `pentest_core::matrix::client`
-    // (self-signed dev clusters). This probe-only relaxation does not touch
-    // the SDK's own TLS trust — it only affects our reachability HEAD.
-    let probe_url = format!("https://{}/", target);
-    let client = reqwest::Client::builder()
-        .timeout(CONNECT_TIMEOUT)
-        .danger_accept_invalid_certs(
-            std::env::var("MATRIX_TLS_INSECURE")
-                .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
-                .unwrap_or(false),
-        )
-        .build()
-        .map_err(|e| format!("Failed to build TLS probe client: {}", e))?;
-
-    drop(stream);
-    match client.head(&probe_url).send().await {
-        Ok(_) => Ok(()),
-        Err(e) if e.is_status() => {
-            // Any HTTP status is fine — proves the endpoint spoke TLS + HTTP.
-            Ok(())
-        }
-        Err(e) if e.is_connect() || e.is_timeout() => Err(format!(
-            "TLS handshake to {} failed: {}. Verify the URL and TLS trust chain.",
+    match tokio::time::timeout(CONNECT_TIMEOUT, tokio::net::TcpStream::connect(&target)).await {
+        Ok(Ok(_)) => Ok(()),
+        Ok(Err(e)) => Err(format!(
+            "Cannot reach {}: {}. Check the URL and your network connection.",
             target, e
         )),
-        Err(_) => {
-            // Non-connect errors (redirect loop, body-decode, etc.) still
-            // prove the endpoint answered — accept and let the SDK continue.
-            Ok(())
-        }
+        Err(_) => Err(format!(
+            "Timed out connecting to {} after {}s. Verify the URL is reachable.",
+            target,
+            CONNECT_TIMEOUT.as_secs()
+        )),
     }
 }

--- a/run-pentest.sh
+++ b/run-pentest.sh
@@ -50,9 +50,18 @@ else
     # Set defaults
     export STRIKE48_HOST="${STRIKE48_HOST:-ws://localhost:3030}"
     export STRIKE48_TENANT="${STRIKE48_TENANT:-non-prod}"
-    export STRIKE48_API_URL="${STRIKE48_API_URL:-http://localhost:3030}"
     export RUST_LOG="${RUST_LOG:-debug}"
 fi
+
+# STRIKE48_API_URL gates the SDK's OTT origin allowlist (see
+# strike48_connector::auth::ott_provider::validate_register_origin). The
+# previous default `http://localhost:3030` broke every remote-studio flow
+# (pick#223), so we no longer set one — the SDK's warn+permit path handles
+# unset values, and split-host clusters (studio.X vs non-prod.X) rely on
+# that behavior. Operators who want strict same-origin enforcement should
+# set STRIKE48_API_URL explicitly to the exact studio-backend origin the
+# server declares in `CredentialsIssued.register_url`, not the connector
+# gateway or studio UI URL.
 
 # Get the original user if running via sudo
 ORIGINAL_USER="${SUDO_USER:-$USER}"
@@ -86,7 +95,7 @@ log_info "  App Type:     ${APP_TYPE}"
 log_info "  Mode:         ${MODE}"
 log_info "  Strike48:     ${STRIKE48_HOST}"
 log_info "  Tenant:       ${STRIKE48_TENANT}"
-log_info "  API URL:      ${STRIKE48_API_URL}"
+log_info "  API URL:      ${STRIKE48_API_URL:-<unset>}"
 log_info "  Log Level:    ${RUST_LOG}"
 log_info "  Log File:     ${LOG_FILE}"
 log_info ""


### PR DESCRIPTION
## Summary

Closes #223. Standalone Pick failed the OTT approval handshake against remote studios, gave no feedback on bad URLs, and registered under the tenant slug — which Studio's app-viewer URL doesn't route to. Four narrowly-scoped fixes plus one CI repair.

## Changes

- **`run-pentest.sh`** — remove the `STRIKE48_API_URL=http://localhost:3030` default. The default poisoned the SDK's OTT origin allowlist against every remote studio (`OTT register URL origin ... does not match STRIKE48_API_URL origin ...`). Aligns with the SDK's declared dev behavior — `validate_register_origin` returns `Ok(())` with a `warn!` when the var is unset (sdk-rs `crates/connector/src/auth/ott_provider.rs:202-235`, test `validate_register_origin_no_allowlist_skips`). StrikeHub sets its own explicit value (`strikehub/crates/sh-ui/src/app.rs:683-686`), so the umbrella launch path is unchanged.

- **`crates/core/src/config.rs`** — in `normalize_host`, strip trailing `/`, path, query, and fragment from the authority before appending the inferred port so `https://host/` no longer becomes `wss://host/:443` in the header + dashboard. Expose `ConnectorConfig::split_authority` next to `normalize_host` so the pre-connect probe reuses the same parser. Also add `ConnectorConfig::read_credentials_tenant_id`, which extracts the canonical tenant UUID from `~/.strike48/credentials/<connector>_<instance>.json` (the SDK writes it there on successful OTT).

- **`crates/ui/src/liveview_connector/mod.rs`** — bounded TCP-connect probe (6s) at the top of `connect_and_run`, returning `Err` on DNS-miss or connection-refused. Surfaces via the existing `connect_error` signal to the ConfigForm banner instead of leaving the UI stuck on the connecting spinner.

- **`crates/ui/src/connector_app.rs`** — on Connect, consult the credentials file for the canonical tenant UUID and substitute it if the form value differs (with a terminal-log line noting the swap). A bounded post-connect poll (60 × 2s, ~2 minutes) covers the first-ever-launch case: after OTT completes the SDK drops the credentials file, and this task picks up the newly-minted UUID and persists it to `settings.last_config.tenant_id` so the next launch skips the slug detour entirely. StrikeHub does the equivalent server-side via an authenticated `userDetails { domain.id }` GraphQL query (`strikehub/crates/sh-core/src/auth.rs::fetch_tenant_id`); standalone Pick has no authenticated context up front, so we rely on the post-OTT credentials file.

- **`.github/workflows/ci.yml`** — gitleaks install used a greedy `sed` regex on the GitHub JSON API that matched the entire `"tag_name":"v8.30.1","draft":false,...` blob and produced a malformed download URL. Swapped to `gh api ... --jq '.tag_name'` so parsing is by JSON, not regex.

## Coverage of #223

- [x] Incorrect URL entry should be denied — pre-connect probe.
- [x] Editable URL between sessions — user confirmed the restart-then-form path is fine.
- [x] OTT token properly accepted — verified end-to-end against a local test cluster.
- [x] Tenant slug↔UUID works seamlessly in the standalone form (folded in per #223 comment thread) — connector app viewer renders in Studio, standalone chat panel authenticates GraphQL calls.

## Test plan

- `cargo test -p pentest-core --lib config` — 30 tests pass (3 new `normalize_host` cases, 6 new `split_authority` cases, 2 new `read_credentials_tenant_id` cases).
- `cargo clippy --workspace --locked --features pentest-platform/desktop-pcap -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.
- Manual: Studio Gateway Configuration shows connector Active after OTT approval; ConfigForm host reads `wss://non-prod.strike48.test:443` (no trailing-slash artifact); typing tenant slug in the form registers under the canonical UUID once credentials are present, and Studio's app-viewer renders Pick's dashboard.