### PR TITLE
fix(run): restore ~/.strike48 key ownership after sudo launches (#226)

### DIFF
--- a/RUNNING.md
+++ b/RUNNING.md
@@ -172,6 +172,31 @@ just run-headless-dev        # Has sudo built-in
 ./run-pentest.sh headless   # Has sudo built-in
 ```
 
+### "Failed to read private key: Permission denied (os error 13)"
+
+**Cause**: The connector was previously launched with `sudo`, which wrote the
+SDK private key into `~/.strike48/keys/` owned by `root` (mode `0600`). A later
+launch as your normal user can no longer read that key, so OTT registration
+fails 3 times and the agent stays in `WaitingForApproval`.
+
+**Immediate fix**:
+```bash
+# Restore ownership of the whole key/credential store to your user
+sudo scripts/restore-key-ownership.sh
+```
+
+**Prevention** (both are already wired in):
+
+1. The sudo launch paths (`run-pentest.sh`, `just run-headless-sudo`,
+   `run-headless-dev`, `run-desktop-sudo`, `run-desktop-release-sudo`) restore
+   ownership to `$SUDO_USER` on exit via `scripts/restore-key-ownership.sh`.
+2. Grant raw-socket capabilities so most scans need no sudo at all:
+   ```bash
+   sudo setcap 'cap_net_raw,cap_net_admin+eip' target/debug/pentest-agent
+   ```
+   Re-apply after each rebuild (the binary is replaced). Note: monitor-mode
+   WiFi tools (airmon-ng etc.) still self-escalate.
+
 ### "Connection refused" or "Failed to connect"
 
 **Cause**: Incorrect Strike48 host or network issues

--- a/justfile
+++ b/justfile
@@ -24,6 +24,8 @@ run-desktop:
 
 # Run desktop app with sudo (for WiFi hardware access)
 run-desktop-sudo:
+    #!/usr/bin/env bash
+    trap 'sudo scripts/restore-key-ownership.sh "${SUDO_USER:-$USER}" || true' EXIT
     sudo -E cargo run --package pentest-desktop
 
 # Run desktop app (release)
@@ -32,6 +34,8 @@ run-desktop-release:
 
 # Run desktop app (release) with sudo
 run-desktop-release-sudo:
+    #!/usr/bin/env bash
+    trap 'sudo scripts/restore-key-ownership.sh "${SUDO_USER:-$USER}" || true' EXIT
     sudo -E cargo run --package pentest-desktop --release
 
 # ============ Headless Agent ============
@@ -82,11 +86,18 @@ run-headless-release *ARGS:
 
 # Run headless agent with sudo (for WiFi hardware access)
 run-headless-sudo *ARGS:
+    #!/usr/bin/env bash
+    # Restore ~/.strike48 ownership on exit so a later non-sudo launch can still
+    # read the SDK key (see scripts/restore-key-ownership.sh).
+    trap 'sudo scripts/restore-key-ownership.sh "${SUDO_USER:-$USER}" || true' EXIT
     sudo -E cargo run --package pentest-headless -- {{ARGS}}
 
 # Run headless agent with default env vars (sudo for raw socket access)
 run-headless-dev *ARGS:
     #!/usr/bin/env bash
+    # Restore ~/.strike48 ownership on exit so a later non-sudo launch can still
+    # read the SDK key (see scripts/restore-key-ownership.sh).
+    trap 'sudo scripts/restore-key-ownership.sh "${SUDO_USER:-$USER}" || true' EXIT
     sudo -E HOME="$HOME" PATH="$PATH" \
         CARGO_HOME="${CARGO_HOME:-$HOME/.cargo}" \
         RUSTUP_HOME="${RUSTUP_HOME:-$HOME/.rustup}" \

--- a/run-pentest.sh
+++ b/run-pentest.sh
@@ -57,6 +57,7 @@ fi
 # Get the original user if running via sudo
 ORIGINAL_USER="${SUDO_USER:-$USER}"
 ORIGINAL_HOME=$(eval echo "~$ORIGINAL_USER")
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Note: WiFi tools (airmon-ng, etc.) will prompt for sudo when needed
 # No need to run the entire script as root
@@ -65,12 +66,13 @@ if [[ $EUID -eq 0 ]]; then
     log_info "WiFi tools will request sudo when needed"
     log_info ""
 
-    # If running as root, ensure .pick directory is owned by the original user
     if [[ -n "$SUDO_USER" ]]; then
-        PICK_DIR="${ORIGINAL_HOME}/.pick"
-        if [[ -d "$PICK_DIR" ]]; then
-            chown -R "${ORIGINAL_USER}:${ORIGINAL_USER}" "$PICK_DIR" 2>/dev/null || true
-        fi
+        # Running the connector as root writes the SDK key/credentials into the
+        # operator's ~/.strike48 owned by root, which strands a later non-sudo
+        # launch ("Failed to read private key: Permission denied"). Restore
+        # ownership on exit (covers Ctrl+C) so mixing sudo/non-sudo is safe.
+        # shellcheck disable=SC2064
+        trap "'${SCRIPT_DIR}/scripts/restore-key-ownership.sh' '${ORIGINAL_USER}' || true" EXIT
 
         # Set up Rust environment from the original user
         export PATH="${ORIGINAL_HOME}/.cargo/bin:$PATH"

--- a/scripts/restore-key-ownership.sh
+++ b/scripts/restore-key-ownership.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Restore ownership of the SDK key/credential store to the invoking user.
+#
+# Why this exists: WiFi hardware access needs sudo, so several launch paths run
+# the whole connector as root with HOME preserved (`sudo -E ... HOME=$HOME`).
+# The Strike48 SDK then writes its 0600 private key and credentials into the
+# operator's ~/.strike48 owned by root. A later NON-sudo launch (as the operator)
+# can no longer read that root-owned 0600 key and OTT registration fails with
+# "Failed to read private key: Permission denied (os error 13)".
+#
+# This script re-chowns the store back to the login user so mixing sudo and
+# non-sudo launches never strands the key. Safe to run when not root (no-op).
+#
+# Usage:
+#   scripts/restore-key-ownership.sh            # uses $SUDO_USER
+#   scripts/restore-key-ownership.sh <user>     # explicit target user
+
+set -euo pipefail
+
+# Only meaningful when running as root; otherwise the files are already ours.
+if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
+  exit 0
+fi
+
+TARGET_USER="${1:-${SUDO_USER:-}}"
+if [[ -z "$TARGET_USER" || "$TARGET_USER" == "root" ]]; then
+  # Launched as a genuine root login (no sudo drop-back target): nothing to do.
+  exit 0
+fi
+
+TARGET_HOME="$(getent passwd "$TARGET_USER" | cut -d: -f6)"
+if [[ -z "$TARGET_HOME" || ! -d "$TARGET_HOME" ]]; then
+  echo "[restore-key-ownership] cannot resolve home for '$TARGET_USER'; skipping" >&2
+  exit 0
+fi
+
+STORE="${STRIKE48_KEYS_DIR:-}"
+# STRIKE48_KEYS_DIR points at the keys dir specifically; the store root is its
+# parent. When unset, the SDK default store is ~/.strike48.
+if [[ -n "$STORE" ]]; then
+  STORE_ROOT="$(dirname "$STORE")"
+else
+  STORE_ROOT="${TARGET_HOME}/.strike48"
+fi
+
+fixed=0
+for dir in "$STORE_ROOT" "${TARGET_HOME}/.pick"; do
+  if [[ -e "$dir" ]]; then
+    # Only touch files not already owned by the target user (idempotent, quiet).
+    if find "$dir" ! -user "$TARGET_USER" -print -quit 2>/dev/null | grep -q .; then
+      chown -R "${TARGET_USER}:${TARGET_USER}" "$dir" && fixed=1
+    fi
+  fi
+done
+
+if [[ "$fixed" -eq 1 ]]; then
+  echo "[restore-key-ownership] restored ${STORE_ROOT} to ${TARGET_USER}"
+fi


### PR DESCRIPTION
Closes #226 (child of parity epic #183).

## Problem

WiFi hardware access needs `sudo`, so several launch paths run the whole connector as root with `HOME` preserved (`sudo -E ... HOME=$HOME`). The SDK then writes its `0600` private key + credentials into the operator's `~/.strike48` owned by `root`. A later **non-sudo** launch can no longer read that key, so OTT registration fails 3x with `Failed to read private key: Permission denied (os error 13)` and the agent sits in `WaitingForApproval`. The key/credential pair is intact and valid - it is just unreadable by the current uid, so the "re-issue approval in Studio" hint is misleading.

## Fix

- **New `scripts/restore-key-ownership.sh`** - idempotent, no-op when not root; restores `~/.strike48` (+ `~/.pick`) ownership to `$SUDO_USER`. Honors `$STRIKE48_KEYS_DIR`.
- **Wired as an `EXIT` trap** into every sudo launch path: `run-pentest.sh` and just recipes `run-headless-sudo`, `run-headless-dev`, `run-desktop-sudo`, `run-desktop-release-sudo`. Covers Ctrl+C. Previously `run-pentest.sh` only chowned `~/.pick`, not `~/.strike48` where keys live.
- **`RUNNING.md`** documents the symptom, the immediate `sudo scripts/restore-key-ownership.sh` fix, and the `setcap cap_net_raw,cap_net_admin` no-sudo alternative for raw-socket scans.

## Test plan

- [x] `bash -n` clean on helper + `run-pentest.sh`; `just --list` parses all edited recipes
- [x] Non-root invocation is a no-op (exit 0, no output)
- [x] Reproduce break (chown key to root) -> run helper as root with `SUDO_USER` -> key restored to user and readable
- [x] Idempotent: second run is a quiet no-op, no stray root-owned files remain
- [ ] CI green on push

## Notes

Complements capability-gating epic #183: same "silent operator footgun" family. An optional upstream follow-up (noted in #226) is for `strike48-connector` to emit a clearer message than bare os-error-13 when the key is owned by another user.