### PR TITLE
fix(nmap): accept a `flags` string arg and steer the schema away from it

### DIFF
--- a/crates/tools/src/external/nmap.rs
+++ b/crates/tools/src/external/nmap.rs
@@ -496,14 +496,15 @@ async fn validate_nse_scripts<P: CommandExec>(
 /// target can be recovered, the original params are returned so the normal
 /// "target parameter is required" error still fires.
 fn normalize_legacy_nmap_params(params: Value) -> Value {
-    // A `flags` string (e.g. {"flags": "-sn -T4 ...", "target": "..."}) is a
-    // shape the LLM emits by analogy to a raw CLI, but there is no `flags`
-    // schema param. Fold its recognized flags into structured params FIRST —
-    // this must run even when `target` is already present (otherwise the
-    // target-present short-circuit below would silently drop the flags, which
-    // is exactly the bug where -sn/-T4 never took effect). Same allowlist +
-    // drop-unknown safety as the `args`/`command` path.
-    let params = fold_flags_string(params);
+    // A `flags` value (e.g. {"flags": "-sn -T4 ...", "target": "..."} or the
+    // array shape {"flags": ["-sn", "-T4"], "target": "..."}) is a shape the LLM
+    // emits by analogy to a raw CLI, but there is no `flags` schema param. Fold
+    // its recognized flags into structured params FIRST — this must run even
+    // when `target` is already present (otherwise the target-present
+    // short-circuit below would silently drop the flags, which is exactly the
+    // bug where -sn/-T4 never took effect). Same allowlist + drop-unknown safety
+    // as the `args`/`command` path.
+    let params = fold_flags(params);
 
     // Already in the structured shape — nothing more to do.
     if params
@@ -517,19 +518,7 @@ fn normalize_legacy_nmap_params(params: Value) -> Value {
     // Collect the flag/argument tokens from either `args` (array or string) or
     // a `command` string (with a leading "nmap" stripped).
     let tokens: Vec<String> = match params.get("args") {
-        Some(Value::Array(items)) => items
-            .iter()
-            .filter_map(|v| v.as_str().map(|s| s.to_string()))
-            .collect(),
-        Some(Value::String(s)) => {
-            // The args string may itself be a JSON-encoded array, e.g.
-            // "[\"-sn\", \"10.0.8.0/22\"]" — parse that first, else split on
-            // whitespace.
-            match serde_json::from_str::<Vec<String>>(s) {
-                Ok(parsed) => parsed,
-                Err(_) => s.split_whitespace().map(|t| t.to_string()).collect(),
-            }
-        }
+        Some(v @ (Value::Array(_) | Value::String(_))) => tokenize_flag_value(v),
         _ => match params.get("command").and_then(|v| v.as_str()) {
             Some(cmd) => cmd
                 .split_whitespace()
@@ -547,12 +536,16 @@ fn normalize_legacy_nmap_params(params: Value) -> Value {
     // Start from any structured params the caller DID provide so we don't clobber them.
     let mut out = params.as_object().cloned().unwrap_or_default();
 
-    // Map recognized flags onto `out`, recover ports, and return any target the
-    // tokens contained (shared with the `flags`-string path).
-    let target = apply_flag_tokens(&mut out, &tokens);
+    // Map recognized flags to a fresh `derived` map and recover any target the
+    // tokens contained (shared with the `flags` path). Merge derived values
+    // ONLY into gaps — an explicit structured param the caller set always wins.
+    let (derived, target) = apply_flag_tokens(&tokens);
+    merge_fill(&mut out, derived);
 
     match target {
         Some(t) => {
+            // No valid `target` reached here (the target-present short-circuit
+            // above returned already), so the recovered token is the target.
             out.insert("target".into(), json!(t));
             Value::Object(out)
         }
@@ -562,38 +555,46 @@ fn normalize_legacy_nmap_params(params: Value) -> Value {
     }
 }
 
-/// Fold a `flags` STRING param into structured scan params.
+/// Fold a `flags` param into structured scan params.
 ///
 /// Callers (the LLM generalizing from a raw CLI) sometimes pass
-/// `{"flags": "-sn -T4 ...", "target": "..."}`. There is no `flags` schema
-/// param, so without this the flags are silently ignored (and previously, when
-/// `target` was present, dropped entirely by the early return). This tokenizes
-/// `flags` (whitespace-split), maps the recognized allowlist onto structured
-/// params via the shared [`apply_flag_tokens`], recovers a target from the
-/// flags string if the caller didn't provide one, and removes the raw `flags`
-/// key so it is never passed through or shelled out. Unrecognized flags are
-/// dropped, exactly like the `args`/`command` path.
+/// `{"flags": "-sn -T4 ...", "target": "..."}` or the array form
+/// `{"flags": ["-sn", "-T4"], "target": "..."}` — the same string-or-array shape
+/// the sibling `args` path already tolerates. There is no `flags` schema param,
+/// so without this the flags are silently ignored (and previously, when
+/// `target` was present, dropped entirely by the early return — the exact bug
+/// this PR kills, which an array-shaped `flags` would otherwise reintroduce).
 ///
-/// Non-string or absent `flags` is a no-op.
-fn fold_flags_string(params: Value) -> Value {
-    let Some(flags) = params.get("flags").and_then(|v| v.as_str()) else {
+/// This tokenizes `flags` via the shared [`tokenize_flag_value`], maps the
+/// recognized allowlist onto structured params via [`apply_flag_tokens`],
+/// recovers a target from the flags tokens if the caller didn't provide one,
+/// and ALWAYS removes the raw `flags` key (for any shape — string, array, or an
+/// unexpected object) so it is never passed through or shelled out. Derived
+/// values fill only gaps: an explicit structured param the caller set wins over
+/// a flag (matching the tool description, which makes the typed params
+/// authoritative). Unrecognized flags are dropped, exactly like the
+/// `args`/`command` path.
+///
+/// Absent `flags` is a no-op.
+fn fold_flags(params: Value) -> Value {
+    if params.get("flags").is_none() {
         return params;
-    };
-
-    let tokens: Vec<String> = flags.split_whitespace().map(|t| t.to_string()).collect();
-    if tokens.is_empty() {
-        // Still strip the (empty/whitespace) flags key.
-        let mut out = params.as_object().cloned().unwrap_or_default();
-        out.remove("flags");
-        return Value::Object(out);
     }
 
     let mut out = params.as_object().cloned().unwrap_or_default();
-    out.remove("flags");
+    // Strip the raw `flags` key regardless of its shape — a `flags` value that
+    // is neither a string nor an array (e.g. an object) must NOT ride through
+    // to `execute()`, which would ignore it and silently scan with defaults.
+    let flags = out.remove("flags").unwrap_or(Value::Null);
 
-    let recovered = apply_flag_tokens(&mut out, &tokens);
+    let tokens = tokenize_flag_value(&flags);
+    if tokens.is_empty() {
+        return Value::Object(out);
+    }
 
-    // Only adopt a target from the flags string if the caller didn't set one.
+    let (derived, recovered) = apply_flag_tokens(&tokens);
+
+    // Only adopt a target from the flags tokens if the caller didn't set one.
     let has_target = out
         .get("target")
         .and_then(|v| v.as_str())
@@ -604,66 +605,109 @@ fn fold_flags_string(params: Value) -> Value {
         }
     }
 
+    // Explicit structured params win; flags only fill gaps.
+    merge_fill(&mut out, derived);
+
     Value::Object(out)
+}
+
+/// Tokenize a legacy `flags`/`args` value that may be a JSON array of strings or
+/// a single string (whitespace-split, or a JSON-encoded array string).
+///
+/// Mirrors the tolerance the `args` path always had, so `flags` accepts the
+/// same string-or-array shapes the LLM emits interchangeably. Any other JSON
+/// shape (number, bool, object, null) yields no tokens.
+fn tokenize_flag_value(value: &Value) -> Vec<String> {
+    match value {
+        Value::Array(items) => items
+            .iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect(),
+        Value::String(s) => {
+            // The string may itself be a JSON-encoded array, e.g.
+            // "[\"-sn\", \"10.0.8.0/22\"]" — parse that first, else split on
+            // whitespace.
+            match serde_json::from_str::<Vec<String>>(s) {
+                Ok(parsed) => parsed,
+                Err(_) => s.split_whitespace().map(|t| t.to_string()).collect(),
+            }
+        }
+        _ => Vec::new(),
+    }
+}
+
+/// Insert every entry of `derived` into `out` ONLY where `out` has no value for
+/// that key. An explicit param the caller already set is never overwritten.
+fn merge_fill(out: &mut serde_json::Map<String, Value>, derived: serde_json::Map<String, Value>) {
+    for (k, v) in derived {
+        out.entry(k).or_insert(v);
+    }
 }
 
 /// Map a small allowlist of nmap flag tokens onto structured params in `out`,
 /// returning the first token that validates as a scan target (if any).
 ///
-/// Shared by both legacy shapes (`args`/`command`) and the `flags` string.
+/// Shared by both legacy shapes (`args`/`command`) and the `flags` value.
 /// Recognized: `-sn`/`-sS`/`-sT`/`-sU` (scan_type), `-Pn` (no_ping), `-sV`
 /// (service_detection), `-O` (os_detection), `-A` (aggressive), `-T<n>`
 /// (timing), `-p <spec>` / `-p<spec>` (ports). Every other flag is dropped and
 /// never shelled out. A bare integer is never treated as a target (it's almost
 /// always a dropped flag's value, e.g. `--min-rate 1000`).
-fn apply_flag_tokens(
-    out: &mut serde_json::Map<String, Value>,
-    tokens: &[String],
-) -> Option<String> {
+///
+/// Returns a fresh map of the derived structured params (so callers can merge
+/// them without clobbering explicit caller values) plus the first token that
+/// validates as a scan target (if any). Any token that is dropped is recorded
+/// and emitted at `debug` level so a "why did my scan run with defaults"
+/// investigation can see what the normalizer discarded.
+fn apply_flag_tokens(tokens: &[String]) -> (serde_json::Map<String, Value>, Option<String>) {
+    let mut derived = serde_json::Map::new();
+    let mut dropped: Vec<&str> = Vec::new();
     let mut target: Option<String> = None;
     let mut i = 0;
     while i < tokens.len() {
         let tok = tokens[i].as_str();
         match tok {
             "-sn" => {
-                out.insert("scan_type".into(), json!("ping"));
+                derived.insert("scan_type".into(), json!("ping"));
             }
             "-sS" => {
-                out.insert("scan_type".into(), json!("syn"));
+                derived.insert("scan_type".into(), json!("syn"));
             }
             "-sT" => {
-                out.insert("scan_type".into(), json!("connect"));
+                derived.insert("scan_type".into(), json!("connect"));
             }
             "-sU" => {
-                out.insert("scan_type".into(), json!("udp"));
+                derived.insert("scan_type".into(), json!("udp"));
             }
             "-Pn" => {
-                out.insert("no_ping".into(), json!(true));
+                derived.insert("no_ping".into(), json!(true));
             }
             "-sV" => {
-                out.insert("service_detection".into(), json!(true));
+                derived.insert("service_detection".into(), json!(true));
             }
             "-O" => {
-                out.insert("os_detection".into(), json!(true));
+                derived.insert("os_detection".into(), json!(true));
             }
             "-A" => {
-                out.insert("aggressive".into(), json!(true));
+                derived.insert("aggressive".into(), json!(true));
             }
             "-p" => {
                 // Next token is the port spec.
                 if i + 1 < tokens.len() {
-                    out.insert("ports".into(), json!(tokens[i + 1]));
+                    derived.insert("ports".into(), json!(tokens[i + 1]));
                     i += 1;
                 }
             }
             _ if tok.starts_with("-T") && tok.len() == 3 => {
                 if let Some(d) = tok.chars().nth(2).and_then(|c| c.to_digit(10)) {
-                    out.insert("timing".into(), json!(d));
+                    derived.insert("timing".into(), json!(d));
+                } else {
+                    dropped.push(tok);
                 }
             }
             _ if tok.starts_with("-p") && tok.len() > 2 => {
                 // -p80, -p1-1000 (port spec attached to the flag)
-                out.insert("ports".into(), json!(tok[2..].to_string()));
+                derived.insert("ports".into(), json!(tok[2..].to_string()));
             }
             _ if tok.starts_with('-') => {
                 // Unrecognized flag (e.g. --min-rate, -PE, -PP, -PM): drop it.
@@ -671,6 +715,7 @@ fn apply_flag_tokens(
                 // falls through as a non-flag token below; the target heuristic
                 // only accepts a value that validates as a target, so a stray
                 // numeric like "1000" won't be mistaken for the target.
+                dropped.push(tok);
             }
             _ => {
                 // Non-flag token: candidate target. Take the first one that
@@ -684,12 +729,26 @@ fn apply_flag_tokens(
                 let is_bare_integer = !tok.is_empty() && tok.bytes().all(|b| b.is_ascii_digit());
                 if target.is_none() && !is_bare_integer && validate_target(tok).is_ok() {
                     target = Some(tok.to_string());
+                } else {
+                    // Not adopted as the target (already have one, a bare
+                    // integer, or fails validation) and not a recognized flag —
+                    // it is discarded, so record it for the investigator.
+                    dropped.push(tok);
                 }
             }
         }
         i += 1;
     }
-    target
+
+    if !dropped.is_empty() {
+        tracing::debug!(
+            dropped_tokens = ?dropped,
+            "nmap legacy-arg normalizer dropped unrecognized tokens; \
+             the scan runs only with recognized/structured params"
+        );
+    }
+
+    (derived, target)
 }
 
 /// Calculate smart timeout based on scan parameters
@@ -1266,12 +1325,12 @@ mod tests {
     }
 
     #[test]
-    fn flags_does_not_clobber_explicit_structured_params() {
-        // If the caller ALSO set a structured param, flags-derived values fill
-        // gaps but an explicit conflicting flag still maps (last-writer = flags,
-        // matching how a real nmap invocation's later flag would win). Here the
-        // caller set service_detection=false and flags add -sV; the flag maps it
-        // true. Target from the structured field is preserved.
+    fn flags_do_not_clobber_explicit_structured_params() {
+        // Explicit structured params are authoritative (matching the tool
+        // description): a flag only fills a param the caller left unset. Here the
+        // caller explicitly set service_detection=false, so -sV must NOT flip it
+        // to true; but timing was unset, so -T2 fills it. Target from the
+        // structured field is preserved.
         let p = json!({
             "target": "10.0.0.5",
             "service_detection": false,
@@ -1279,8 +1338,62 @@ mod tests {
         });
         let out = normalize_legacy_nmap_params(p);
         assert_eq!(out["target"], json!("10.0.0.5"));
-        assert_eq!(out["service_detection"], json!(true)); // -sV
-        assert_eq!(out["timing"], json!(2)); // -T2
+        assert_eq!(out["service_detection"], json!(false)); // explicit param wins over -sV
+        assert_eq!(out["timing"], json!(2)); // -T2 fills the unset param
+    }
+
+    #[test]
+    fn flags_as_array_with_target_maps_recognized_flags() {
+        // The array shape {"flags": ["-sn", "-T4"], "target": "..."} — the same
+        // string-or-array tolerance the `args` path has. Before this was handled
+        // the array `flags` rode through unconsumed and execute() ignored it, so
+        // the scan silently ran with defaults (the very bug this PR kills, via a
+        // different shape). Recognized flags must fold in and the raw key must be
+        // consumed.
+        let p = json!({
+            "flags": ["-sn", "-T4", "-PE", "-PP"],
+            "target": "10.0.8.0/22"
+        });
+        let out = normalize_legacy_nmap_params(p);
+        assert_eq!(out["target"], json!("10.0.8.0/22"));
+        assert_eq!(out["scan_type"], json!("ping")); // -sn
+        assert_eq!(out["timing"], json!(4)); // -T4
+        assert!(
+            out.get("flags").is_none(),
+            "array flags value must be consumed, not passed through"
+        );
+    }
+
+    #[test]
+    fn flags_as_object_is_stripped_not_passed_through() {
+        // A `flags` value that is neither string nor array (here an object) yields
+        // no tokens, but it must STILL be removed so it can't ride through to
+        // execute() (which would ignore it and silently scan with defaults). The
+        // structured params the caller did set are preserved unchanged.
+        let p = json!({
+            "target": "10.0.0.5",
+            "scan_type": "syn",
+            "flags": {"unexpected": "shape"}
+        });
+        let out = normalize_legacy_nmap_params(p);
+        assert_eq!(out["target"], json!("10.0.0.5"));
+        assert_eq!(out["scan_type"], json!("syn"));
+        assert!(
+            out.get("flags").is_none(),
+            "non-string/array flags value must be stripped, not passed through"
+        );
+    }
+
+    #[test]
+    fn flags_array_recovers_target_from_tokens() {
+        // Array `flags` with no separate target key still recovers the target
+        // token, mirroring the string path.
+        let p = json!({"flags": ["-sS", "-p", "80,443", "192.168.1.1"]});
+        let out = normalize_legacy_nmap_params(p);
+        assert_eq!(out["target"], json!("192.168.1.1"));
+        assert_eq!(out["scan_type"], json!("syn"));
+        assert_eq!(out["ports"], json!("80,443"));
+        assert!(out.get("flags").is_none());
     }
 
     #[test]

--- a/crates/tools/src/external/nmap.rs
+++ b/crates/tools/src/external/nmap.rs
@@ -30,7 +30,10 @@ impl PentestTool for NmapTool {
     }
 
     fn description(&self) -> &str {
-        "Industry-standard network scanner for host discovery, port scanning, version detection, and OS fingerprinting. STRATEGY: Start with top1000 ports (fast), then target full scans on interesting hosts only. Full port scans (-p-) across many hosts are very slow (15-30+ minutes)."
+        "Industry-standard network scanner for host discovery, port scanning, version detection, and OS fingerprinting. \
+         STRATEGY: Start with top1000 ports (fast), then target full scans on interesting hosts only. Full port scans (-p-) across many hosts are very slow (15-30+ minutes). \
+         ARGUMENTS: Use the STRUCTURED parameters below (target, scan_type, ports, timing, service_detection, os_detection, aggressive, no_ping) — do NOT pass raw nmap CLI flags. \
+         There is no 'flags', 'args', or 'command' parameter: put the scan target in 'target' and express options via the typed params (e.g. host discovery = scan_type:'ping'; -T4 = timing:4; -sV = service_detection:true; -Pn = no_ping:true). Unrecognized raw flags are dropped."
     }
 
     fn schema(&self) -> ToolSchema {
@@ -119,9 +122,10 @@ impl PentestTool for NmapTool {
 
     async fn execute(&self, params: Value, _ctx: &ToolContext) -> Result<ToolResult> {
         // Tolerate the `execute_command`-style `{args: [...]}` / `{command: "..."}`
-        // shape some callers emit instead of the structured schema. Recovers the
-        // `target` (re-validated below) and maps known flags onto structured
-        // params; unrecognized flags are dropped, never shelled out.
+        // and `{flags: "-sn -T4 ...", target: "..."}` shapes some callers emit
+        // instead of the structured schema. Recovers the `target` (re-validated
+        // below) and maps known flags onto structured params; unrecognized flags
+        // are dropped, never shelled out.
         let params = normalize_legacy_nmap_params(params);
 
         execute_timed_with_provenance(|| async move {
@@ -492,7 +496,16 @@ async fn validate_nse_scripts<P: CommandExec>(
 /// target can be recovered, the original params are returned so the normal
 /// "target parameter is required" error still fires.
 fn normalize_legacy_nmap_params(params: Value) -> Value {
-    // Already in the structured shape — nothing to do.
+    // A `flags` string (e.g. {"flags": "-sn -T4 ...", "target": "..."}) is a
+    // shape the LLM emits by analogy to a raw CLI, but there is no `flags`
+    // schema param. Fold its recognized flags into structured params FIRST —
+    // this must run even when `target` is already present (otherwise the
+    // target-present short-circuit below would silently drop the flags, which
+    // is exactly the bug where -sn/-T4 never took effect). Same allowlist +
+    // drop-unknown safety as the `args`/`command` path.
+    let params = fold_flags_string(params);
+
+    // Already in the structured shape — nothing more to do.
     if params
         .get("target")
         .and_then(|v| v.as_str())
@@ -533,9 +546,81 @@ fn normalize_legacy_nmap_params(params: Value) -> Value {
 
     // Start from any structured params the caller DID provide so we don't clobber them.
     let mut out = params.as_object().cloned().unwrap_or_default();
-    let mut target: Option<String> = None;
-    let mut ports: Option<String> = None;
 
+    // Map recognized flags onto `out`, recover ports, and return any target the
+    // tokens contained (shared with the `flags`-string path).
+    let target = apply_flag_tokens(&mut out, &tokens);
+
+    match target {
+        Some(t) => {
+            out.insert("target".into(), json!(t));
+            Value::Object(out)
+        }
+        // Couldn't recover a target — return original so the standard
+        // "target parameter is required" error fires unchanged.
+        None => params,
+    }
+}
+
+/// Fold a `flags` STRING param into structured scan params.
+///
+/// Callers (the LLM generalizing from a raw CLI) sometimes pass
+/// `{"flags": "-sn -T4 ...", "target": "..."}`. There is no `flags` schema
+/// param, so without this the flags are silently ignored (and previously, when
+/// `target` was present, dropped entirely by the early return). This tokenizes
+/// `flags` (whitespace-split), maps the recognized allowlist onto structured
+/// params via the shared [`apply_flag_tokens`], recovers a target from the
+/// flags string if the caller didn't provide one, and removes the raw `flags`
+/// key so it is never passed through or shelled out. Unrecognized flags are
+/// dropped, exactly like the `args`/`command` path.
+///
+/// Non-string or absent `flags` is a no-op.
+fn fold_flags_string(params: Value) -> Value {
+    let Some(flags) = params.get("flags").and_then(|v| v.as_str()) else {
+        return params;
+    };
+
+    let tokens: Vec<String> = flags.split_whitespace().map(|t| t.to_string()).collect();
+    if tokens.is_empty() {
+        // Still strip the (empty/whitespace) flags key.
+        let mut out = params.as_object().cloned().unwrap_or_default();
+        out.remove("flags");
+        return Value::Object(out);
+    }
+
+    let mut out = params.as_object().cloned().unwrap_or_default();
+    out.remove("flags");
+
+    let recovered = apply_flag_tokens(&mut out, &tokens);
+
+    // Only adopt a target from the flags string if the caller didn't set one.
+    let has_target = out
+        .get("target")
+        .and_then(|v| v.as_str())
+        .is_some_and(|s| !s.trim().is_empty());
+    if !has_target {
+        if let Some(t) = recovered {
+            out.insert("target".into(), json!(t));
+        }
+    }
+
+    Value::Object(out)
+}
+
+/// Map a small allowlist of nmap flag tokens onto structured params in `out`,
+/// returning the first token that validates as a scan target (if any).
+///
+/// Shared by both legacy shapes (`args`/`command`) and the `flags` string.
+/// Recognized: `-sn`/`-sS`/`-sT`/`-sU` (scan_type), `-Pn` (no_ping), `-sV`
+/// (service_detection), `-O` (os_detection), `-A` (aggressive), `-T<n>`
+/// (timing), `-p <spec>` / `-p<spec>` (ports). Every other flag is dropped and
+/// never shelled out. A bare integer is never treated as a target (it's almost
+/// always a dropped flag's value, e.g. `--min-rate 1000`).
+fn apply_flag_tokens(
+    out: &mut serde_json::Map<String, Value>,
+    tokens: &[String],
+) -> Option<String> {
+    let mut target: Option<String> = None;
     let mut i = 0;
     while i < tokens.len() {
         let tok = tokens[i].as_str();
@@ -567,7 +652,7 @@ fn normalize_legacy_nmap_params(params: Value) -> Value {
             "-p" => {
                 // Next token is the port spec.
                 if i + 1 < tokens.len() {
-                    ports = Some(tokens[i + 1].clone());
+                    out.insert("ports".into(), json!(tokens[i + 1]));
                     i += 1;
                 }
             }
@@ -578,14 +663,14 @@ fn normalize_legacy_nmap_params(params: Value) -> Value {
             }
             _ if tok.starts_with("-p") && tok.len() > 2 => {
                 // -p80, -p1-1000 (port spec attached to the flag)
-                ports = Some(tok[2..].to_string());
+                out.insert("ports".into(), json!(tok[2..].to_string()));
             }
             _ if tok.starts_with('-') => {
                 // Unrecognized flag (e.g. --min-rate, -PE, -PP, -PM): drop it.
-                // If it's a flag that takes a separate value we can't recognize,
-                // its value falls through as a non-flag token below; the target
-                // heuristic only accepts a value that validates as a target, so
-                // a stray numeric like "1000" won't be mistaken for the target.
+                // If it takes a separate value we can't recognize, its value
+                // falls through as a non-flag token below; the target heuristic
+                // only accepts a value that validates as a target, so a stray
+                // numeric like "1000" won't be mistaken for the target.
             }
             _ => {
                 // Non-flag token: candidate target. Take the first one that
@@ -594,9 +679,8 @@ fn normalize_legacy_nmap_params(params: Value) -> Value {
                 // Reject bare integers: `validate_target` accepts "1000" as a
                 // hostname, but a pure number is never a real scan target — it's
                 // almost always a value belonging to a preceding flag we dropped
-                // (e.g. `--min-rate 1000`, `--max-retries 2`). Excluding them
-                // prevents a dropped flag's value from being mistaken for the
-                // target. Real targets are IPs, CIDRs, or dotted/named hosts.
+                // (e.g. `--min-rate 1000`, `--max-retries 2`). Real targets are
+                // IPs, CIDRs, or dotted/named hosts.
                 let is_bare_integer = !tok.is_empty() && tok.bytes().all(|b| b.is_ascii_digit());
                 if target.is_none() && !is_bare_integer && validate_target(tok).is_ok() {
                     target = Some(tok.to_string());
@@ -605,19 +689,7 @@ fn normalize_legacy_nmap_params(params: Value) -> Value {
         }
         i += 1;
     }
-
-    match target {
-        Some(t) => {
-            out.insert("target".into(), json!(t));
-            if let Some(p) = ports {
-                out.insert("ports".into(), json!(p));
-            }
-            Value::Object(out)
-        }
-        // Couldn't recover a target — return original so the standard
-        // "target parameter is required" error fires unchanged.
-        None => params,
-    }
+    target
 }
 
 /// Calculate smart timeout based on scan parameters
@@ -1158,6 +1230,85 @@ mod tests {
     fn structured_params_pass_through_unchanged() {
         let p = json!({"target": "10.0.8.0/22", "scan_type": "ping"});
         assert_eq!(normalize_legacy_nmap_params(p.clone()), p);
+    }
+
+    #[test]
+    fn flags_string_with_target_maps_recognized_flags() {
+        // The exact field payload: the LLM sent a `flags` STRING alongside a
+        // valid `target`. There is no `flags` schema param, and because target
+        // was present the normalizer used to early-return and drop `flags`
+        // entirely — so -sn/-T4 never became scan_type/timing. Now the
+        // recognized flags fold into structured params and target is kept.
+        let p = json!({
+            "flags": "-sn -T4 -PS22,80,443,445,3389 -PA80,443 -PE -PP",
+            "target": "10.0.8.0/22"
+        });
+        let out = normalize_legacy_nmap_params(p);
+        assert_eq!(out["target"], json!("10.0.8.0/22"));
+        assert_eq!(out["scan_type"], json!("ping")); // -sn
+        assert_eq!(out["timing"], json!(4)); // -T4
+                                             // Unrecognized discovery flags (-PS/-PA/-PE/-PP) are dropped, never shelled.
+        assert!(
+            out.get("flags").is_none(),
+            "raw flags string must be consumed, not passed through"
+        );
+    }
+
+    #[test]
+    fn flags_string_without_target_still_recovers_target_from_flags() {
+        // `flags` may itself contain the target token (no separate target key).
+        let p = json!({"flags": "-sS -p 80,443 192.168.1.1"});
+        let out = normalize_legacy_nmap_params(p);
+        assert_eq!(out["target"], json!("192.168.1.1"));
+        assert_eq!(out["scan_type"], json!("syn"));
+        assert_eq!(out["ports"], json!("80,443"));
+        assert!(out.get("flags").is_none());
+    }
+
+    #[test]
+    fn flags_does_not_clobber_explicit_structured_params() {
+        // If the caller ALSO set a structured param, flags-derived values fill
+        // gaps but an explicit conflicting flag still maps (last-writer = flags,
+        // matching how a real nmap invocation's later flag would win). Here the
+        // caller set service_detection=false and flags add -sV; the flag maps it
+        // true. Target from the structured field is preserved.
+        let p = json!({
+            "target": "10.0.0.5",
+            "service_detection": false,
+            "flags": "-sV -T2"
+        });
+        let out = normalize_legacy_nmap_params(p);
+        assert_eq!(out["target"], json!("10.0.0.5"));
+        assert_eq!(out["service_detection"], json!(true)); // -sV
+        assert_eq!(out["timing"], json!(2)); // -T2
+    }
+
+    #[test]
+    fn flags_injection_payload_never_becomes_target() {
+        // Splitting a flags string on whitespace means a "10.0.0.1; rm -rf /"
+        // payload becomes separate tokens. The dangerous token "10.0.0.1;"
+        // (semicolon) must NOT validate as a target, so the recovered target is
+        // never the injection string. Whatever IS recovered still goes through
+        // validate_target and is passed as a STRUCTURED positional arg (never
+        // shell-interpolated), so this is safe — same contract as the args path.
+        let out = normalize_legacy_nmap_params(json!({"flags": "-sn 10.0.0.1; rm -rf /"}));
+        let recovered = out.get("target").and_then(|v| v.as_str());
+        assert_ne!(recovered, Some("10.0.0.1; rm -rf /"));
+        assert_ne!(recovered, Some("10.0.0.1;"));
+        // And the raw flags string is always consumed, never passed through.
+        assert!(out.get("flags").is_none());
+    }
+
+    #[test]
+    fn flags_semicolon_target_token_is_rejected() {
+        // The clean case: a target carrying a shell metacharacter must be
+        // rejected by validate_target, leaving no target (schema error fires).
+        let out = normalize_legacy_nmap_params(json!({"flags": "-sn 10.0.0.1;rm"}));
+        assert!(
+            out.get("target").is_none(),
+            "a token with ';' must not validate as a target, got: {:?}",
+            out.get("target")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The agent called nmap with a raw-CLI-style payload:

```json
{"flags": "-sn -T4 -PS22,80,443,445,3389 -PA80,443 -PE -PP", "target": "10.0.8.0/22"}
```

There is no `flags` parameter in the nmap schema, and because a valid `target` was present, `normalize_legacy_nmap_params` hit its target-present early-return and **dropped the entire `flags` string** - so `-sn` (ping) and `-T4` (timing) never took effect. The scan silently ran with defaults, and the malformed shape contributed to the stuck engagement turn we saw in the field.

## Fix

- **Fold a `flags` string into structured params BEFORE the target-present short-circuit**, so recognized flags apply even when `target` is already set. The raw `flags` key is always consumed - never passed through or shelled out.
- **Extract the flag-token allowlist into a shared `apply_flag_tokens` helper** reused by the existing `args`/`command` path and the new `flags` path (DRY). A `flags` string with no separate `target` can still recover the target token.
- **Tighten the tool description** to tell the model to use the structured params (`scan_type`/`timing`/`service_detection`/`no_ping`/...) and that there is no `flags`/`args`/`command` param - reducing malformed calls at the source.

## Safety

Unchanged from the existing legacy path: recovered targets go through `validate_target` and are passed as a **structured positional arg** (never shell-interpolated). A token with shell metacharacters (`;`, space) never validates as a target, and bare integers are never treated as targets. Unrecognized flags (`-PS`/`-PA`/`-PE`/`-PP`/`--min-rate`) are dropped.

## Test plan

- [x] RED verified: 3 new tests fail on the old code (flags dropped when target present)
- [x] 5 new tests: flags+target maps recognized flags; flags-only recovers target+ports; flags don't clobber explicit params; injection payload never becomes target; `;`-bearing token rejected
- [x] Full nmap suite **51/51**, `security_tests` **55/55** pass
- [x] `cargo fmt` + `cargo clippy -p pentest-tools --lib` clean
- [x] CI green (Build amd64/arm64, Check Linux+macOS, Clippy, Test, Dependency Audit)

---

## Full investigation context (for the dev team)

This PR is one piece of an end-to-end investigation into the nmap "Running… / Generating…" hang during an engagement phase. The hang had **two independent root causes**, plus adjacent bugs found along the way. Recording the whole picture here so it's in one place.

### The nmap hang: two root causes

1. **Permissions - agent granted zero connector tools.** `StrikekitCore.PhaseExecutor.build_tools_config/2` looked up the connector-tool registry by `ctx.tenant.name` ("non-prod"), but connectors register under the tenant **UUID** prefix (`"<uuid>.<connector_type>.<instance>"`). The name key matched **0** connectors -> `connectors: {}` -> the agent got only `sk_*`/`document_*` system tools, never nmap. Live proof: `list_all_tools("non-prod")` -> 0 tools vs `list_all_tools("<uuid>")` -> 115 (incl. nmap).
   **Status: already fixed on matrix `develop`** (`discover_pentest_connector/2` queries both name and UUID). A redundant standalone PR (matrix#3131) was closed as superseded.

2. **nmap argument shape (this PR).** Even once granted, the model emits `{"flags": "...", "target": "..."}`; Pick dropped the flags. Fixed here.

### Still open / needs verification

- **Client-tool dispatch / consent bridge (matrix#2941).** A granted client tool_call can still park `pending` if the agent-framework->connector dispatch/consent path isn't wired. Partially addressed on `develop` (#2482 consent, #2524 scope enforcement). Needs a fresh end-to-end test on a current-`develop` studio build. Engagement agents use `consent_mode:"auto"`, which may bypass the manual-consent gap.

### Adjacent bugs found & fixed (same investigation)

| Item | Cause | Status |
|------|-------|--------|
| Pick OTT `Permission denied (os error 13)` | prior `sudo` run left `~/.strike48` key root-owned; non-sudo launch can't read it | Fixed - Pick #227 (self-healing chown) + setcap |
| "Seed N/M failed" | `extract_host` didn't strip URL path -> SSRF validator DNS-resolved `host/path` -> mislabeled "private IP" | Fixed - Pick #229 |
| alpaca "no response" | agent model alias `smart` -> `bedrock/qwen.qwen3-next-80b-a3b-v1:0`, which **Bedrock rejects** ("invalid model identifier") - verified unavailable in this account/region even with the correct `-v1:0` suffix (`qwen3-32b-v1:0` and `qwen3-coder-30b-a3b-v1:0` DO work) | Live-patched (configmap -> claude-sonnet-4-5); **durable init-dev fix ON HOLD** - init-dev defaults `ALPACA_FLAVOR=qwen` and its qwen `smart`/`reasoning` aliases point at the unavailable model (also missing the `-v1:0` suffix) |
| "Invalid or expired OTT" | one-time registration token in `.env` consumed; saved cred was for a different tenant | Resolved (operator) - post-approval flow; stale cred moved aside |

### Environment note

The deployed studio image is `matrix-studio:2026-06-13-develop-df78a33` (June 12), `imagePullPolicy: IfNotPresent`, so a restart re-pulls the same stale image. The permissions fix reaches the running pod only via an image rebuild (`task newbuild:build:studio`), which is **blocked**: the zot step decrypts ECR pull credentials (SOPS/age) to a recipient the operator's SSH key isn't. **Dev-team action:** re-encrypt `dev-secrets/secrets/dev-vm/ecr-pull-credentials.yaml` to the operator's age recipient, or provision the authorized key. (Testing was unblocked via an in-memory hot-patch of the permissions fix into the running BEAM node - ephemeral, reverts on restart.)
