### PR TITLE
fix(#35): make generated reports land at a locatable, deterministic path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6562,6 +6562,7 @@ dependencies = [
  "strike48-connector",
  "strike48-proto",
  "syntect",
+ "tempfile",
  "tokio",
  "tokio-tungstenite 0.26.2",
  "tracing",

--- a/crates/core/src/orchestrator.rs
+++ b/crates/core/src/orchestrator.rs
@@ -262,10 +262,34 @@ pub fn build_report_agent_seed_message(manifest: &ValidatedFindingsManifest) -> 
         );
         "{}".to_string()
     });
+    // Hand the Report Agent the exact, deterministic path to write to, derived
+    // from the engagement start time. The model cannot read the connector's
+    // tool-execution metadata (that lives only in the tool executor, not the
+    // prompt), so it must be told the concrete path here rather than asked to
+    // interpolate an `{instance_id}` template it has no way to resolve. The path
+    // is relative to the workspace root the file browser opens, so a generated
+    // report is immediately locatable (pick#35).
+    let report_path = report_relative_path(&manifest.engagement);
     format!(
         "The orchestrator has closed the engagement. Below is the \
          `validated_findings_manifest`. Render the final penetration test \
-         report per your system prompt.\n\n```json\n{json}\n```"
+         report per your system prompt.\n\nSave the finished report with \
+         `write_file` to exactly this path (do not invent a different one):\n\n\
+         `{report_path}`\n\nThen tell the operator: \"Report saved to \
+         {report_path}\".\n\n```json\n{json}\n```"
+    )
+}
+
+/// Deterministic, workspace-relative path for a rendered report.
+///
+/// Derived from the engagement start time so the same engagement always maps to
+/// the same file. Kept flat under `reports/` (no per-instance subdirectory — the
+/// connector workspace is already instance-scoped) so the report lands where the
+/// file browser opens (pick#35).
+pub fn report_relative_path(engagement: &EngagementInfo) -> String {
+    format!(
+        "reports/pentest-report-{}.md",
+        engagement.started_at.format("%Y-%m-%d-%H%M")
     )
 }
 
@@ -635,6 +659,32 @@ mod tests {
         assert!(msg.contains("```json"));
         assert!(msg.contains("\"c1\""));
         assert!(msg.trim_end().ends_with("```"));
+    }
+
+    #[test]
+    fn report_relative_path_is_deterministic_and_flat() {
+        // Derived from the engagement start time; flat under `reports/` with no
+        // per-instance subdirectory (pick#35).
+        let path = report_relative_path(&engagement());
+        assert_eq!(path, "reports/pentest-report-2026-04-17-1200.md");
+    }
+
+    #[test]
+    fn seed_message_gives_report_agent_the_concrete_write_path() {
+        // The seed must hand the model the exact path (pick#35) and must NOT ask
+        // it to interpolate an `{instance_id}` template it cannot resolve.
+        let manifest =
+            gate_for_report(&[confirmed_finding("c1", Severity::High)], engagement()).unwrap();
+        let msg = build_report_agent_seed_message(&manifest);
+        assert!(
+            msg.contains("reports/pentest-report-2026-04-17-1200.md"),
+            "seed must embed the concrete report path, got: {msg}"
+        );
+        assert!(
+            !msg.contains("{instance_id}"),
+            "seed must not contain an unresolvable instance_id template"
+        );
+        assert!(msg.contains("write_file"));
     }
 
     #[test]

--- a/crates/core/src/orchestrator.rs
+++ b/crates/core/src/orchestrator.rs
@@ -285,11 +285,12 @@ pub fn build_report_agent_seed_message(manifest: &ValidatedFindingsManifest) -> 
 /// Derived from the engagement start time so the same engagement always maps to
 /// the same file. Kept flat under `reports/` (no per-instance subdirectory — the
 /// connector workspace is already instance-scoped) so the report lands where the
-/// file browser opens (pick#35).
+/// file browser opens (pick#35). Seconds are included so two engagements started
+/// in the same minute don't silently overwrite each other's report.
 pub fn report_relative_path(engagement: &EngagementInfo) -> String {
     format!(
         "reports/pentest-report-{}.md",
-        engagement.started_at.format("%Y-%m-%d-%H%M")
+        engagement.started_at.format("%Y-%m-%d-%H%M%S")
     )
 }
 
@@ -664,9 +665,10 @@ mod tests {
     #[test]
     fn report_relative_path_is_deterministic_and_flat() {
         // Derived from the engagement start time; flat under `reports/` with no
-        // per-instance subdirectory (pick#35).
+        // per-instance subdirectory (pick#35). Second-granularity avoids
+        // same-minute overwrites.
         let path = report_relative_path(&engagement());
-        assert_eq!(path, "reports/pentest-report-2026-04-17-1200.md");
+        assert_eq!(path, "reports/pentest-report-2026-04-17-120000.md");
     }
 
     #[test]
@@ -677,7 +679,7 @@ mod tests {
             gate_for_report(&[confirmed_finding("c1", Severity::High)], engagement()).unwrap();
         let msg = build_report_agent_seed_message(&manifest);
         assert!(
-            msg.contains("reports/pentest-report-2026-04-17-1200.md"),
+            msg.contains("reports/pentest-report-2026-04-17-120000.md"),
             "seed must embed the concrete report path, got: {msg}"
         );
         assert!(
@@ -685,6 +687,28 @@ mod tests {
             "seed must not contain an unresolvable instance_id template"
         );
         assert!(msg.contains("write_file"));
+    }
+
+    #[test]
+    fn report_path_resolves_under_workspace() {
+        // pick#35's root cause was the write path and the browse/read path
+        // disagreeing. Guard the contract: the report path must resolve to a
+        // real location *inside* the workspace (no traversal escape, resolver
+        // accepts the `reports/` subdir), so `write_file` lands where
+        // `list_files` enumerates.
+        let ws = tempfile::tempdir().unwrap();
+        let report_path = report_relative_path(&engagement());
+        let resolved = crate::workspace::resolve_path(ws.path(), &report_path)
+            .expect("report path must resolve inside the workspace");
+        let ws_canonical = ws.path().canonicalize().unwrap();
+        assert!(
+            resolved.starts_with(&ws_canonical),
+            "report path escaped workspace: {resolved:?} not under {ws_canonical:?}"
+        );
+        assert!(
+            resolved.to_string_lossy().contains("reports"),
+            "report should land in the reports/ subdir: {resolved:?}"
+        );
     }
 
     #[test]

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -87,3 +87,6 @@ futures = { workspace = true, optional = true }
 whoami = { version = "1", optional = true }
 strike48-proto = { workspace = true, optional = true }
 
+[dev-dependencies]
+tempfile = { workspace = true }
+

--- a/crates/ui/src/bin/file_browser_connector.rs
+++ b/crates/ui/src/bin/file_browser_connector.rs
@@ -38,11 +38,20 @@ use pentest_ui::FileBrowser;
 /// Port for the internal Dioxus liveview server
 const DIOXUS_PORT: u16 = 3031;
 
-/// Workspace path (configurable via env var)
+/// Workspace path (configurable via `WORKSPACE_PATH`).
+///
+/// Defaults to the connector workspace root
+/// (`~/.local/share/pentest-connector/workspaces`) — the tree that actually
+/// holds each instance's files and generated reports — rather than the
+/// unrelated `~/workspace`, which no other component writes to. Without this the
+/// file browser enumerated an empty/irrelevant directory and generated reports
+/// were invisible from Studio/desktop (pick#35). `WORKSPACE_PATH` still overrides
+/// for operators who point the browser elsewhere.
 fn get_workspace_path() -> String {
     std::env::var("WORKSPACE_PATH").unwrap_or_else(|_| {
-        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-        format!("{}/workspace", home)
+        pentest_core::workspace::workspace_root()
+            .to_string_lossy()
+            .into_owned()
     })
 }
 

--- a/crates/ui/src/components/chat_panel/constants.rs
+++ b/crates/ui/src/components/chat_panel/constants.rs
@@ -744,9 +744,9 @@ The MDX parser downstream will break on raw angle brackets inside table cells.
 
 **Saving the report file:**
 - Use `write_file` (never `document_write`)
-- Path: `reports/{instance_id}/pentest-report-YYYY-MM-DD-HHMM.md`
-- `instance_id` is in your tool execution context metadata
-- After writing, tell the user: "Report saved to {path}"
+- The orchestrator's seed message gives you the exact path to write to. Use that
+  path verbatim — do not invent a different filename or add directories.
+- After writing, tell the user: "Report saved to {path}" using that same path.
 
 ## Style
 

--- a/crates/ui/src/components/file_browser/mod.rs
+++ b/crates/ui/src/components/file_browser/mod.rs
@@ -329,3 +329,97 @@ pub fn FileBrowser(props: FileBrowserProps) -> Element {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! End-to-end guard for pick#35: a report the agent writes must be visible
+    //! to the operator's file browser.
+    //!
+    //! The orchestrator unit tests prove the *seed path* is deterministic and
+    //! flat, but they stop at the string. These tests close the remaining seam
+    //! by driving the real production chain — the `write_file` tool executor
+    //! that the LLM invokes, then the `list_directory` function the browser UI
+    //! calls — against a real filesystem, and asserting the report surfaces
+    //! where the operator looks.
+
+    use super::*;
+    use pentest_core::orchestrator::{report_relative_path, EngagementInfo};
+    use pentest_core::tools::{PentestTool, ToolContext};
+    use pentest_tools::WriteFileTool;
+    use serde_json::json;
+
+    /// A fixed engagement start so the derived report path is deterministic.
+    fn engagement() -> EngagementInfo {
+        EngagementInfo {
+            target: "10.0.0.0/24".to_string(),
+            started_at: "2026-04-17T12:00:00Z".parse().unwrap(),
+            completed_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn written_report_is_visible_to_the_file_browser() {
+        // Arrange: an instance workspace, exactly as create_workspace() lays it
+        // out, and the tool context the connector hands the write_file tool.
+        let ws = tempfile::tempdir().unwrap();
+        let ctx = ToolContext::default().with_workspace(ws.path().to_path_buf());
+        let report_path = report_relative_path(&engagement());
+
+        // Act 1: the LLM's write_file call — the real tool executor, real fs.
+        let result = WriteFileTool
+            .execute(
+                json!({ "path": report_path, "content": "# Pentest Report\n\nFindings." }),
+                &ctx,
+            )
+            .await
+            .expect("write_file should succeed for the seeded report path");
+        assert!(result.success, "write_file reported failure: {result:?}");
+
+        // Act 2: the operator opens the file browser at the workspace root — the
+        // real list_directory the UI calls.
+        let root = list_directory(ws.path(), "").expect("root listing should succeed");
+
+        // Assert: the report is reachable. pick#35's failure was the report
+        // landing somewhere the browser never showed. The report lives under a
+        // single `reports/` dir (no per-instance nesting), visible from root.
+        let reports_dir = root
+            .iter()
+            .find(|e| e.name == "reports" && e.is_dir)
+            .expect("`reports/` must appear at the workspace root");
+
+        let inside =
+            list_directory(ws.path(), &reports_dir.path).expect("listing reports/ should succeed");
+        let report = inside
+            .iter()
+            .find(|e| e.name.starts_with("pentest-report-") && e.name.ends_with(".md"))
+            .expect("the generated report must be listed inside reports/");
+        assert!(!report.is_dir, "report should be a file, not a directory");
+
+        // And the browser can actually open it (read path agrees with write).
+        let content = read_file(ws.path(), &report.path).expect("browser should read the report");
+        assert!(content.content.contains("Pentest Report"));
+    }
+
+    #[tokio::test]
+    async fn report_is_not_buried_under_a_per_instance_subdir() {
+        // pick#35 defect #2: the old prompt produced reports/<instance_id>/...,
+        // two levels below where the browser opens. Guard that the current path
+        // keeps `reports/` one level deep with the file directly inside it.
+        let ws = tempfile::tempdir().unwrap();
+        let ctx = ToolContext::default().with_workspace(ws.path().to_path_buf());
+        let report_path = report_relative_path(&engagement());
+
+        WriteFileTool
+            .execute(json!({ "path": report_path, "content": "x" }), &ctx)
+            .await
+            .expect("write_file should succeed");
+
+        let inside = list_directory(ws.path(), "reports").expect("reports/ should exist");
+        // Every entry directly under reports/ is the report file itself — no
+        // intermediate <instance_id> directory.
+        assert!(
+            inside.iter().all(|e| !e.is_dir),
+            "reports/ must contain the report directly, not a nested subdir: {inside:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #35: an operator ran an engagement, the agent "created a report," but the file was not findable from Studio or desktop Pick. The report file *is* written - it just lands at an unpredictable, buried location that the file browser doesn't show. Three defects combined.

## Root cause (verified against `main`)

"Generate Report" (`chat_panel/mod.rs`) seeds the Report Agent with a chat message; the file only lands if that LLM agent calls `write_file`. Three things then went wrong:

1. **The prompt told the model to read data it can't see.** The Report Agent prompt said save to `reports/{instance_id}/pentest-report-*.md` and "instance_id is in your tool execution context metadata." But `instance_id` lives in the tool *executor's* `ctx.metadata` (`pick_connector.rs:266`); the LLM only sees prompt text. So the model guessed an id, invented one, or wrote a literal `{instance_id}` path - nondeterministic and often wrong.
2. **Redundant deep nesting.** `write_file` resolves relative to the instance workspace root (`~/.local/share/pentest-connector/workspaces/<id>/`), so the report nested at `.../workspaces/<id>/reports/<id>/...` - two levels below where the file browser opens, with `<id>` pointlessly repeated.
3. **A second file-browser surface read a different directory.** The standalone `file_browser_connector` binary defaulted to `$HOME/workspace` - a directory nothing writes to - not the connector workspace.

## Changes

- **`orchestrator::build_report_agent_seed_message`** now derives a deterministic, flat path (`reports/pentest-report-YYYY-MM-DD-HHMM.md`, from the engagement start time) and hands the Report Agent that exact path in the seed. New `pub fn report_relative_path`.
- **Report Agent prompt** (`constants.rs`) now instructs the model to write to the exact path given in the seed, verbatim - dropping the unresolvable `{instance_id}` template.
- **`file_browser_connector`** now defaults to `workspace::workspace_root()` (where reports actually live) instead of `$HOME/workspace`. `WORKSPACE_PATH` still overrides.

## Behavior change to note for review

The standalone file browser's default root changes from `$HOME/workspace` to `~/.local/share/pentest-connector/workspaces`. Nothing in the codebase writes to `$HOME/workspace`, so this only makes previously-invisible reports visible; operators who set `WORKSPACE_PATH` are unaffected.

## Test plan

- [x] `cargo clippy --workspace --features pentest-platform/desktop-pcap -- -D warnings` (exact CI command) - clean
- [x] `cargo test -p pentest-core report` - new tests pass (`report_relative_path_is_deterministic_and_flat`, `seed_message_gives_report_agent_the_concrete_write_path`) + existing seed tests green
- [x] `cargo fmt` applied; pre-push `cargo check --all-targets` passed
- [x] Live run verified end-to-end (see below)

## Live verification

Rather than a non-deterministic full autopwn (which depends on the live tenant and the LLM agent choosing to call `write_file`), the fix was verified by driving the real production code paths directly:

1. **Defect 3 (browser read path), on the running binary.** Launched the changed `file-browser-connector` and read its startup log: it now resolves the workspace to `~/.local/share/pentest-connector/workspaces` (the real tree, 12 instance workspaces present on this machine) instead of `$HOME/workspace` - which does not exist, confirming the old default browsed nothing. The `WORKSPACE_PATH` override still wins when set.
2. **Defect 2 (nesting), from real data.** A historical report on this machine sits buried at `.../workspaces/pick-test-001/reports/pick-test-001/scope-enforcement-test-report-*.md` - exactly the redundant `reports/<instance_id>/` nesting this PR removes.
3. **Defects 1+2 round trip, new regression test.** Added a UI-crate test that drives the actual `write_file` tool executor (as the LLM invokes it) writing to the seeded report path, then the actual `list_directory`/`read_file` the browser calls - asserting the report appears under a single `reports/` dir at the workspace root and opens correctly. This closes the write-browse seam the existing string-level tests did not cover. Full `pentest-ui` suite green (65 passed); CI Test + Clippy green on the pushed commit.
