### PR TITLE
fix(#238): select a working sandbox backend on AppArmor-restricted Linux (bwrap->proot)

### DIFF
--- a/crates/core/src/matrix/client.rs
+++ b/crates/core/src/matrix/client.rs
@@ -89,7 +89,7 @@ impl MatrixChatClient {
         variables: serde_json::Value,
     ) -> crate::error::Result<T> {
         let gql_url = format!("{}/api/v1alpha", super::normalize_url(&self.api_url));
-        tracing::info!(
+        tracing::debug!(
             "[gql] POST {} (token_len={} query={})",
             gql_url,
             self.auth_token.as_ref().map(|t| t.len()).unwrap_or(0),
@@ -110,7 +110,7 @@ impl MatrixChatClient {
             })?;
 
         let status = resp.status();
-        tracing::info!("[gql] response status={}", status);
+        tracing::debug!("[gql] response status={}", status);
 
         // Defense against hostile Matrix API responses: limit response size to prevent OOM
         const MAX_RESPONSE_SIZE: usize = 10 * 1024 * 1024; // 10 MB

--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 
 [features]
 default = ["desktop"]
-desktop = ["sysinfo", "local-ip-address", "dns-lookup", "network-interface", "dep:lazy_static", "dep:uuid", "dep:image", "desktop-mdns", "wifi_scan", "ssdp-client", "dep:reqwest", "dep:portable-pty"]
+desktop = ["sysinfo", "local-ip-address", "dns-lookup", "network-interface", "dep:lazy_static", "dep:uuid", "dep:image", "desktop-mdns", "wifi_scan", "ssdp-client", "dep:reqwest", "dep:portable-pty", "dep:libc"]
 desktop-all = ["desktop", "desktop-screenshots"]
 desktop-screenshots = ["desktop", "screenshots"]
 desktop-mdns = ["desktop", "mdns-sd"]

--- a/crates/platform/src/desktop/pty_shell.rs
+++ b/crates/platform/src/desktop/pty_shell.rs
@@ -23,26 +23,41 @@ pub struct PtyShell {
 /// `portable_pty` returns `anyhow::Error`; on Unix the underlying cause when a
 /// spawn is rejected is a `std::io::Error`, so we downcast through the error
 /// chain and inspect `io::ErrorKind::PermissionDenied` precisely. We deliberately
-/// do NOT fall back to substring-matching the message: since the shell now pins
-/// proot for users who explicitly chose it (see #238), a message that merely
+/// do NOT fall back to substring-matching the message: a message that merely
 /// mentions "Permission denied" for an unrelated reason must not silently swap
-/// their backend to bwrap. If no typed `io::Error` is present, we treat it as
-/// "not EACCES" and surface the original error instead of guessing.
+/// the sandbox backend under the user. If no typed `io::Error` is present, we
+/// treat it as "not EACCES" and surface the original error instead of guessing.
 fn spawn_err_is_permission_denied(err: &anyhow::Error) -> bool {
     err.chain()
         .filter_map(|cause| cause.downcast_ref::<std::io::Error>())
         .any(|io_err| io_err.kind() == std::io::ErrorKind::PermissionDenied)
 }
 
-/// Decide whether a failed sandboxed spawn is eligible for a bwrap retry.
+/// Given the backend whose spawn just failed and the error, return the *other*
+/// namespace backend to retry with — or `None` if no retry applies.
 ///
-/// Only a **proot** spawn rejected with **EACCES** qualifies (the #238 failure
-/// mode: proot is healthy but `portable_pty` can't spawn it in this process
-/// context). The caller must still confirm bwrap is actually available before
-/// retrying. Kept as a pure function so the fallback decision is unit-testable
-/// without a live PTY.
-fn should_fall_back_to_bwrap(backend: SandboxBackend, err: &anyhow::Error) -> bool {
-    backend == SandboxBackend::Proot && spawn_err_is_permission_denied(err)
+/// The #238 failure mode is a healthy sandbox backend that `portable_pty` can't
+/// spawn in this process context, surfacing as `EACCES`. bwrap and proot are
+/// interchangeable for the unprivileged interactive shell (both give a fake-root
+/// BlackArch shell), so on an EACCES spawn we retry with the sibling backend:
+///
+/// - proot spawn hits EACCES -> retry **bwrap**
+/// - bwrap spawn hits EACCES -> retry **proot**
+///
+/// WSL and Docker have no namespace sibling to swap to, so they never qualify.
+/// Only EACCES qualifies: a missing binary or bad rootfs would fail identically
+/// under the sibling and must surface as-is. The caller still confirms the
+/// sibling is actually available before retrying. Pure function so the decision
+/// is unit-testable without a live PTY.
+fn fallback_backend_for(backend: SandboxBackend, err: &anyhow::Error) -> Option<SandboxBackend> {
+    if !spawn_err_is_permission_denied(err) {
+        return None;
+    }
+    match backend {
+        SandboxBackend::Proot => Some(SandboxBackend::Bwrap),
+        SandboxBackend::Bwrap => Some(SandboxBackend::Proot),
+        SandboxBackend::Wsl | SandboxBackend::Docker => None,
+    }
 }
 
 impl PtyShell {
@@ -93,7 +108,7 @@ impl PtyShell {
 
     /// Spawn a sandboxed interactive shell using bwrap, proot, or WSL.
     async fn spawn_sandboxed(cols: u16, rows: u16, cwd: Option<&Path>) -> Result<Self> {
-        use super::sandbox::{bwrap::BwrapExecutor, get_sandbox_manager, proot::ProotExecutor};
+        use super::sandbox::get_sandbox_manager;
 
         tracing::info!("[PtyShell::spawn_sandboxed] Starting sandboxed shell spawn");
 
@@ -208,6 +223,93 @@ impl PtyShell {
             })
             .map_err(|e| Error::ToolExecution(format!("Failed to open PTY: {e}")))?;
 
+        let cmd = Self::build_cmd_for_backend(backend, config, cwd).await?;
+
+        let child = match pair.slave.spawn_command(cmd) {
+            Ok(child) => child,
+            Err(e) => {
+                // Graceful symmetric fallback: a namespace backend (bwrap/proot)
+                // can fail to spawn under portable-pty with EACCES depending on
+                // the host process context (see #238), even when its binary and
+                // rootfs are healthy. bwrap and proot are interchangeable for the
+                // unprivileged interactive shell, so on EACCES we retry with the
+                // sibling backend instead of hard-failing.
+                let sibling = fallback_backend_for(backend, &e);
+                if let Some(fallback) = sibling {
+                    if Self::backend_is_available(fallback, config).await {
+                        // Log the failure at warn (not error): it is expected and
+                        // recoverable here; a preemptive error would read as a hard
+                        // failure even on the successful retry path.
+                        tracing::warn!(
+                            "[PtyShell::spawn_sandboxed] {backend:?} spawn hit EACCES ({e}); falling back to {fallback:?}"
+                        );
+
+                        // Open a *fresh* PTY for the retry. portable_pty does not
+                        // guarantee a slave is reusable after a failed spawn (the
+                        // controlling-terminal / TIOCSCTTY state may be left
+                        // partially applied by a half-forked child), so we drop
+                        // the old pair rather than spawn into it twice.
+                        drop(pair);
+                        let retry_pair = pty_system
+                            .openpty(PtySize {
+                                rows,
+                                cols,
+                                pixel_width: 0,
+                                pixel_height: 0,
+                            })
+                            .map_err(|e2| {
+                                Error::ToolExecution(format!(
+                                    "Failed to open PTY for {fallback:?} fallback: {e2} (original {backend:?} error: {e})"
+                                ))
+                            })?;
+
+                        let fallback_cmd =
+                            Self::build_cmd_for_backend(fallback, config, cwd).await?;
+                        let child = retry_pair.slave.spawn_command(fallback_cmd).map_err(|e2| {
+                            tracing::error!(
+                                "[PtyShell::spawn_sandboxed] {fallback:?} fallback also failed: {e2} (original {backend:?} error: {e})"
+                            );
+                            Error::ToolExecution(format!(
+                                "Failed to spawn sandboxed shell ({backend:?} spawn failed: {e}; {fallback:?} fallback also failed: {e2})"
+                            ))
+                        })?;
+
+                        tracing::info!(
+                            "Sandboxed shell spawned successfully ({fallback:?} fallback after {backend:?} EACCES)"
+                        );
+                        return Ok(Self {
+                            pair: retry_pair,
+                            child,
+                        });
+                    }
+                }
+
+                tracing::error!(
+                    "[PtyShell::spawn_sandboxed] spawn_command failed: {e} (backend={backend:?})"
+                );
+                return Err(Error::ToolExecution(format!(
+                    "Failed to spawn sandboxed shell: {e}"
+                )));
+            }
+        };
+
+        tracing::info!("Sandboxed shell spawned successfully");
+
+        Ok(Self { pair, child })
+    }
+
+    /// Build the interactive-shell `CommandBuilder` for a specific backend.
+    ///
+    /// Shared by the primary spawn and the symmetric EACCES fallback so both
+    /// paths construct commands identically. proot needs an async binary-path
+    /// lookup, hence the `async` signature.
+    async fn build_cmd_for_backend(
+        backend: SandboxBackend,
+        config: &super::sandbox::config::SandboxConfig,
+        cwd: Option<&Path>,
+    ) -> Result<CommandBuilder> {
+        use super::sandbox::proot::ProotExecutor;
+
         let cmd = match backend {
             SandboxBackend::Bwrap => {
                 tracing::info!("Building bwrap command for PTY shell");
@@ -245,74 +347,24 @@ impl PtyShell {
             }
         };
 
-        let child = match pair.slave.spawn_command(cmd) {
-            Ok(child) => child,
-            Err(e) => {
-                // Graceful fallback: proot can fail to spawn under portable-pty
-                // with EACCES depending on the host process context (see #238),
-                // even though the binary and rootfs are healthy. When that
-                // happens and bwrap is available, retry with bwrap rather than
-                // hard-failing the shell. This is the primary recovery path for
-                // a user who explicitly selected the proot backend (which we now
-                // honor) on a host where proot can't be spawned in this context.
-                if should_fall_back_to_bwrap(backend, &e) && BwrapExecutor::is_available().await {
-                    // Log the proot failure at warn (not error): it is expected
-                    // and recoverable here, and an unconditional error above would
-                    // read as a hard failure even on the successful retry path.
-                    tracing::warn!(
-                        "[PtyShell::spawn_sandboxed] proot spawn hit EACCES ({e}); falling back to bwrap"
-                    );
+        Ok(cmd)
+    }
 
-                    // Open a *fresh* PTY for the retry. portable_pty does not
-                    // guarantee a slave is reusable after a failed spawn (the
-                    // controlling-terminal / TIOCSCTTY state may be left partially
-                    // applied by a half-forked child), so we drop the old pair
-                    // rather than spawn into it twice.
-                    drop(pair);
-                    let retry_pair = pty_system
-                        .openpty(PtySize {
-                            rows,
-                            cols,
-                            pixel_width: 0,
-                            pixel_height: 0,
-                        })
-                        .map_err(|e2| {
-                            Error::ToolExecution(format!(
-                                "Failed to open PTY for bwrap fallback: {e2} (original proot error: {e})"
-                            ))
-                        })?;
+    /// Check whether a given backend is currently usable, used to gate the
+    /// EACCES fallback retry before we commit to swapping backends.
+    async fn backend_is_available(
+        backend: SandboxBackend,
+        config: &super::sandbox::config::SandboxConfig,
+    ) -> bool {
+        use super::sandbox::{bwrap::BwrapExecutor, proot::ProotExecutor};
 
-                    let bwrap_cmd = Self::build_bwrap_cmd(config, cwd);
-                    let child = retry_pair.slave.spawn_command(bwrap_cmd).map_err(|e2| {
-                        tracing::error!(
-                            "[PtyShell::spawn_sandboxed] bwrap fallback also failed: {e2} (original proot error: {e})"
-                        );
-                        Error::ToolExecution(format!(
-                            "Failed to spawn sandboxed shell (proot spawn failed: {e}; bwrap fallback also failed: {e2})"
-                        ))
-                    })?;
-
-                    tracing::info!(
-                        "Sandboxed shell spawned successfully (bwrap fallback after proot EACCES)"
-                    );
-                    return Ok(Self {
-                        pair: retry_pair,
-                        child,
-                    });
-                }
-
-                tracing::error!(
-                    "[PtyShell::spawn_sandboxed] spawn_command failed: {e} (backend={backend:?})"
-                );
-                return Err(Error::ToolExecution(format!(
-                    "Failed to spawn sandboxed shell: {e}"
-                )));
-            }
-        };
-
-        tracing::info!("Sandboxed shell spawned successfully");
-
-        Ok(Self { pair, child })
+        match backend {
+            SandboxBackend::Bwrap => BwrapExecutor::is_available().await,
+            SandboxBackend::Proot => ProotExecutor::is_available(config).await,
+            // Only bwrap/proot are valid fallback targets (see
+            // `fallback_backend_for`); other backends never reach here.
+            SandboxBackend::Wsl | SandboxBackend::Docker => false,
+        }
     }
 
     /// Build a `CommandBuilder` for a bwrap interactive shell.
@@ -626,33 +678,55 @@ mod tests {
     }
 
     // ------------------------------------------------------------------
-    // Fallback-decision predicate (#238): only proot + EACCES qualifies
+    // Symmetric fallback-decision predicate (#238): bwrap <-> proot on EACCES
     // ------------------------------------------------------------------
 
-    #[test]
-    fn fallback_triggers_for_proot_eacces() {
-        let eacces = anyhow::Error::new(std::io::Error::from(std::io::ErrorKind::PermissionDenied));
-        assert!(should_fall_back_to_bwrap(SandboxBackend::Proot, &eacces));
+    fn eacces() -> anyhow::Error {
+        anyhow::Error::new(std::io::Error::from(std::io::ErrorKind::PermissionDenied))
     }
 
     #[test]
-    fn no_fallback_for_proot_non_eacces() {
-        // proot failing for a non-permission reason (e.g. binary missing) must
-        // surface as-is, not silently become a bwrap shell.
+    fn proot_eacces_falls_back_to_bwrap() {
+        assert_eq!(
+            fallback_backend_for(SandboxBackend::Proot, &eacces()),
+            Some(SandboxBackend::Bwrap)
+        );
+    }
+
+    #[test]
+    fn bwrap_eacces_falls_back_to_proot() {
+        // The prefer-bwrap default means bwrap is the common primary backend; a
+        // runtime EACCES on a host where bwrap passed is_available() but can't
+        // spawn must degrade to proot rather than hard-failing the shell.
+        assert_eq!(
+            fallback_backend_for(SandboxBackend::Bwrap, &eacces()),
+            Some(SandboxBackend::Proot)
+        );
+    }
+
+    #[test]
+    fn no_fallback_for_non_eacces() {
+        // A non-permission failure (e.g. binary missing, bad rootfs) would fail
+        // identically under the sibling, so surface it as-is rather than swapping.
         let not_found = anyhow::Error::new(std::io::Error::from(std::io::ErrorKind::NotFound));
-        assert!(!should_fall_back_to_bwrap(
-            SandboxBackend::Proot,
-            &not_found
-        ));
+        assert_eq!(
+            fallback_backend_for(SandboxBackend::Proot, &not_found),
+            None
+        );
+        assert_eq!(
+            fallback_backend_for(SandboxBackend::Bwrap, &not_found),
+            None
+        );
     }
 
     #[test]
-    fn no_fallback_for_non_proot_backends() {
-        // A bwrap/wsl/docker EACCES is not the #238 failure mode; don't retry.
-        let eacces = anyhow::Error::new(std::io::Error::from(std::io::ErrorKind::PermissionDenied));
-        assert!(!should_fall_back_to_bwrap(SandboxBackend::Bwrap, &eacces));
-        assert!(!should_fall_back_to_bwrap(SandboxBackend::Wsl, &eacces));
-        assert!(!should_fall_back_to_bwrap(SandboxBackend::Docker, &eacces));
+    fn no_fallback_for_backends_without_a_namespace_sibling() {
+        // WSL and Docker have no bwrap/proot sibling to swap to.
+        assert_eq!(fallback_backend_for(SandboxBackend::Wsl, &eacces()), None);
+        assert_eq!(
+            fallback_backend_for(SandboxBackend::Docker, &eacces()),
+            None
+        );
     }
 
     /// Build a SandboxConfig pointing at a temporary directory with a fake

--- a/crates/platform/src/desktop/pty_shell.rs
+++ b/crates/platform/src/desktop/pty_shell.rs
@@ -262,11 +262,12 @@ impl PtyShell {
                     let bwrap_cmd = Self::build_bwrap_cmd(config, cwd);
                     pair.slave.spawn_command(bwrap_cmd).map_err(|e2| {
                         tracing::error!(
-                            "[PtyShell::spawn_sandboxed] bwrap fallback also failed: {}",
+                            "[PtyShell::spawn_sandboxed] bwrap fallback also failed: {} (original proot error: {})",
                             e2,
+                            e,
                         );
                         Error::ToolExecution(format!(
-                            "Failed to spawn sandboxed shell (proot EACCES, bwrap fallback failed): {e2}"
+                            "Failed to spawn sandboxed shell (proot spawn failed: {e}; bwrap fallback also failed: {e2})"
                         ))
                     })?
                 } else {

--- a/crates/platform/src/desktop/pty_shell.rs
+++ b/crates/platform/src/desktop/pty_shell.rs
@@ -2,6 +2,7 @@
 //!
 //! Spawns a native or sandboxed shell session via portable-pty.
 
+use super::sandbox::config::SandboxBackend;
 use pentest_core::config::ShellMode;
 use pentest_core::error::{Error, Result};
 use portable_pty::{native_pty_system, CommandBuilder, PtySize};
@@ -19,19 +20,29 @@ pub struct PtyShell {
 /// Return true if a `portable_pty` spawn error was caused by `EACCES`
 /// (`Permission denied`, os error 13).
 ///
-/// `portable_pty` returns `anyhow::Error`; the underlying cause when a spawn is
-/// rejected is a `std::io::Error`. We first try to downcast through the error
-/// chain to inspect `io::ErrorKind::PermissionDenied` precisely, then fall back
-/// to a string match so the check stays robust if the error is wrapped without
-/// preserving the `io::Error` source.
+/// `portable_pty` returns `anyhow::Error`; on Unix the underlying cause when a
+/// spawn is rejected is a `std::io::Error`, so we downcast through the error
+/// chain and inspect `io::ErrorKind::PermissionDenied` precisely. We deliberately
+/// do NOT fall back to substring-matching the message: since the shell now pins
+/// proot for users who explicitly chose it (see #238), a message that merely
+/// mentions "Permission denied" for an unrelated reason must not silently swap
+/// their backend to bwrap. If no typed `io::Error` is present, we treat it as
+/// "not EACCES" and surface the original error instead of guessing.
 fn spawn_err_is_permission_denied(err: &anyhow::Error) -> bool {
-    for cause in err.chain() {
-        if let Some(io_err) = cause.downcast_ref::<std::io::Error>() {
-            return io_err.kind() == std::io::ErrorKind::PermissionDenied;
-        }
-    }
-    let msg = format!("{err:#}");
-    msg.contains("Permission denied") || msg.contains("os error 13")
+    err.chain()
+        .filter_map(|cause| cause.downcast_ref::<std::io::Error>())
+        .any(|io_err| io_err.kind() == std::io::ErrorKind::PermissionDenied)
+}
+
+/// Decide whether a failed sandboxed spawn is eligible for a bwrap retry.
+///
+/// Only a **proot** spawn rejected with **EACCES** qualifies (the #238 failure
+/// mode: proot is healthy but `portable_pty` can't spawn it in this process
+/// context). The caller must still confirm bwrap is actually available before
+/// retrying. Kept as a pure function so the fallback decision is unit-testable
+/// without a live PTY.
+fn should_fall_back_to_bwrap(backend: SandboxBackend, err: &anyhow::Error) -> bool {
+    backend == SandboxBackend::Proot && spawn_err_is_permission_denied(err)
 }
 
 impl PtyShell {
@@ -82,9 +93,7 @@ impl PtyShell {
 
     /// Spawn a sandboxed interactive shell using bwrap, proot, or WSL.
     async fn spawn_sandboxed(cols: u16, rows: u16, cwd: Option<&Path>) -> Result<Self> {
-        use super::sandbox::{
-            bwrap::BwrapExecutor, config::SandboxBackend, get_sandbox_manager, proot::ProotExecutor,
-        };
+        use super::sandbox::{bwrap::BwrapExecutor, get_sandbox_manager, proot::ProotExecutor};
 
         tracing::info!("[PtyShell::spawn_sandboxed] Starting sandboxed shell spawn");
 
@@ -239,42 +248,65 @@ impl PtyShell {
         let child = match pair.slave.spawn_command(cmd) {
             Ok(child) => child,
             Err(e) => {
-                tracing::error!(
-                    "[PtyShell::spawn_sandboxed] spawn_command failed: {} (backend={:?})",
-                    e,
-                    backend,
-                );
-
                 // Graceful fallback: proot can fail to spawn under portable-pty
                 // with EACCES depending on the host process context (see #238),
                 // even though the binary and rootfs are healthy. When that
                 // happens and bwrap is available, retry with bwrap rather than
-                // hard-failing the shell. bwrap is the preferred desktop backend
-                // anyway, so this only triggers when proot was selected as a
-                // fallback and the environment then rejects it.
-                if backend == SandboxBackend::Proot
-                    && spawn_err_is_permission_denied(&e)
-                    && BwrapExecutor::is_available().await
-                {
+                // hard-failing the shell. This is the primary recovery path for
+                // a user who explicitly selected the proot backend (which we now
+                // honor) on a host where proot can't be spawned in this context.
+                if should_fall_back_to_bwrap(backend, &e) && BwrapExecutor::is_available().await {
+                    // Log the proot failure at warn (not error): it is expected
+                    // and recoverable here, and an unconditional error above would
+                    // read as a hard failure even on the successful retry path.
                     tracing::warn!(
-                        "[PtyShell::spawn_sandboxed] proot spawn hit EACCES; falling back to bwrap"
+                        "[PtyShell::spawn_sandboxed] proot spawn hit EACCES ({e}); falling back to bwrap"
                     );
+
+                    // Open a *fresh* PTY for the retry. portable_pty does not
+                    // guarantee a slave is reusable after a failed spawn (the
+                    // controlling-terminal / TIOCSCTTY state may be left partially
+                    // applied by a half-forked child), so we drop the old pair
+                    // rather than spawn into it twice.
+                    drop(pair);
+                    let retry_pair = pty_system
+                        .openpty(PtySize {
+                            rows,
+                            cols,
+                            pixel_width: 0,
+                            pixel_height: 0,
+                        })
+                        .map_err(|e2| {
+                            Error::ToolExecution(format!(
+                                "Failed to open PTY for bwrap fallback: {e2} (original proot error: {e})"
+                            ))
+                        })?;
+
                     let bwrap_cmd = Self::build_bwrap_cmd(config, cwd);
-                    pair.slave.spawn_command(bwrap_cmd).map_err(|e2| {
+                    let child = retry_pair.slave.spawn_command(bwrap_cmd).map_err(|e2| {
                         tracing::error!(
-                            "[PtyShell::spawn_sandboxed] bwrap fallback also failed: {} (original proot error: {})",
-                            e2,
-                            e,
+                            "[PtyShell::spawn_sandboxed] bwrap fallback also failed: {e2} (original proot error: {e})"
                         );
                         Error::ToolExecution(format!(
                             "Failed to spawn sandboxed shell (proot spawn failed: {e}; bwrap fallback also failed: {e2})"
                         ))
-                    })?
-                } else {
-                    return Err(Error::ToolExecution(format!(
-                        "Failed to spawn sandboxed shell: {e}"
-                    )));
+                    })?;
+
+                    tracing::info!(
+                        "Sandboxed shell spawned successfully (bwrap fallback after proot EACCES)"
+                    );
+                    return Ok(Self {
+                        pair: retry_pair,
+                        child,
+                    });
                 }
+
+                tracing::error!(
+                    "[PtyShell::spawn_sandboxed] spawn_command failed: {e} (backend={backend:?})"
+                );
+                return Err(Error::ToolExecution(format!(
+                    "Failed to spawn sandboxed shell: {e}"
+                )));
             }
         };
 
@@ -564,10 +596,23 @@ mod tests {
     }
 
     #[test]
-    fn permission_denied_detected_from_message_fallback() {
-        // No io::Error in the chain — must fall back to the string match.
+    fn permission_denied_detected_deep_in_error_chain() {
+        // The io::Error may be several context layers down; the chain walk must
+        // still find it.
+        let io_err = std::io::Error::from(std::io::ErrorKind::PermissionDenied);
+        let wrapped = anyhow::Error::new(io_err)
+            .context("spawn_command")
+            .context("PtyShell::spawn_sandboxed");
+        assert!(spawn_err_is_permission_denied(&wrapped));
+    }
+
+    #[test]
+    fn message_only_permission_denied_is_not_flagged() {
+        // No typed io::Error in the chain: we must NOT guess from the message
+        // string (that could wrongly swap a user's chosen backend). Treat it as
+        // not-EACCES and let the caller surface the original error.
         let err = anyhow::anyhow!("Permission denied (os error 13)");
-        assert!(spawn_err_is_permission_denied(&err));
+        assert!(!spawn_err_is_permission_denied(&err));
     }
 
     #[test]
@@ -578,6 +623,36 @@ mod tests {
 
         let other = anyhow::anyhow!("no such file or directory");
         assert!(!spawn_err_is_permission_denied(&other));
+    }
+
+    // ------------------------------------------------------------------
+    // Fallback-decision predicate (#238): only proot + EACCES qualifies
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn fallback_triggers_for_proot_eacces() {
+        let eacces = anyhow::Error::new(std::io::Error::from(std::io::ErrorKind::PermissionDenied));
+        assert!(should_fall_back_to_bwrap(SandboxBackend::Proot, &eacces));
+    }
+
+    #[test]
+    fn no_fallback_for_proot_non_eacces() {
+        // proot failing for a non-permission reason (e.g. binary missing) must
+        // surface as-is, not silently become a bwrap shell.
+        let not_found = anyhow::Error::new(std::io::Error::from(std::io::ErrorKind::NotFound));
+        assert!(!should_fall_back_to_bwrap(
+            SandboxBackend::Proot,
+            &not_found
+        ));
+    }
+
+    #[test]
+    fn no_fallback_for_non_proot_backends() {
+        // A bwrap/wsl/docker EACCES is not the #238 failure mode; don't retry.
+        let eacces = anyhow::Error::new(std::io::Error::from(std::io::ErrorKind::PermissionDenied));
+        assert!(!should_fall_back_to_bwrap(SandboxBackend::Bwrap, &eacces));
+        assert!(!should_fall_back_to_bwrap(SandboxBackend::Wsl, &eacces));
+        assert!(!should_fall_back_to_bwrap(SandboxBackend::Docker, &eacces));
     }
 
     /// Build a SandboxConfig pointing at a temporary directory with a fake

--- a/crates/platform/src/desktop/pty_shell.rs
+++ b/crates/platform/src/desktop/pty_shell.rs
@@ -16,6 +16,24 @@ pub struct PtyShell {
     child: Box<dyn portable_pty::Child + Send + Sync>,
 }
 
+/// Return true if a `portable_pty` spawn error was caused by `EACCES`
+/// (`Permission denied`, os error 13).
+///
+/// `portable_pty` returns `anyhow::Error`; the underlying cause when a spawn is
+/// rejected is a `std::io::Error`. We first try to downcast through the error
+/// chain to inspect `io::ErrorKind::PermissionDenied` precisely, then fall back
+/// to a string match so the check stays robust if the error is wrapped without
+/// preserving the `io::Error` source.
+fn spawn_err_is_permission_denied(err: &anyhow::Error) -> bool {
+    for cause in err.chain() {
+        if let Some(io_err) = cause.downcast_ref::<std::io::Error>() {
+            return io_err.kind() == std::io::ErrorKind::PermissionDenied;
+        }
+    }
+    let msg = format!("{err:#}");
+    msg.contains("Permission denied") || msg.contains("os error 13")
+}
+
 impl PtyShell {
     /// Spawn a new interactive shell using the system default program.
     /// If `cwd` is provided, the shell will start in that directory.
@@ -64,7 +82,9 @@ impl PtyShell {
 
     /// Spawn a sandboxed interactive shell using bwrap, proot, or WSL.
     async fn spawn_sandboxed(cols: u16, rows: u16, cwd: Option<&Path>) -> Result<Self> {
-        use super::sandbox::{config::SandboxBackend, get_sandbox_manager, proot::ProotExecutor};
+        use super::sandbox::{
+            bwrap::BwrapExecutor, config::SandboxBackend, get_sandbox_manager, proot::ProotExecutor,
+        };
 
         tracing::info!("[PtyShell::spawn_sandboxed] Starting sandboxed shell spawn");
 
@@ -216,14 +236,46 @@ impl PtyShell {
             }
         };
 
-        let child = pair.slave.spawn_command(cmd).map_err(|e| {
-            tracing::error!(
-                "[PtyShell::spawn_sandboxed] spawn_command failed: {} (backend={:?})",
-                e,
-                backend,
-            );
-            Error::ToolExecution(format!("Failed to spawn sandboxed shell: {e}"))
-        })?;
+        let child = match pair.slave.spawn_command(cmd) {
+            Ok(child) => child,
+            Err(e) => {
+                tracing::error!(
+                    "[PtyShell::spawn_sandboxed] spawn_command failed: {} (backend={:?})",
+                    e,
+                    backend,
+                );
+
+                // Graceful fallback: proot can fail to spawn under portable-pty
+                // with EACCES depending on the host process context (see #238),
+                // even though the binary and rootfs are healthy. When that
+                // happens and bwrap is available, retry with bwrap rather than
+                // hard-failing the shell. bwrap is the preferred desktop backend
+                // anyway, so this only triggers when proot was selected as a
+                // fallback and the environment then rejects it.
+                if backend == SandboxBackend::Proot
+                    && spawn_err_is_permission_denied(&e)
+                    && BwrapExecutor::is_available().await
+                {
+                    tracing::warn!(
+                        "[PtyShell::spawn_sandboxed] proot spawn hit EACCES; falling back to bwrap"
+                    );
+                    let bwrap_cmd = Self::build_bwrap_cmd(config, cwd);
+                    pair.slave.spawn_command(bwrap_cmd).map_err(|e2| {
+                        tracing::error!(
+                            "[PtyShell::spawn_sandboxed] bwrap fallback also failed: {}",
+                            e2,
+                        );
+                        Error::ToolExecution(format!(
+                            "Failed to spawn sandboxed shell (proot EACCES, bwrap fallback failed): {e2}"
+                        ))
+                    })?
+                } else {
+                    return Err(Error::ToolExecution(format!(
+                        "Failed to spawn sandboxed shell: {e}"
+                    )));
+                }
+            }
+        };
 
         tracing::info!("Sandboxed shell spawned successfully");
 
@@ -497,6 +549,34 @@ mod tests {
             .iter()
             .map(|os| os.to_string_lossy().into_owned())
             .collect()
+    }
+
+    // ------------------------------------------------------------------
+    // EACCES detection for the proot -> bwrap fallback (#238)
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn permission_denied_detected_from_io_error_source() {
+        let io_err = std::io::Error::from(std::io::ErrorKind::PermissionDenied);
+        let wrapped = anyhow::Error::new(io_err).context("spawn_command");
+        assert!(spawn_err_is_permission_denied(&wrapped));
+    }
+
+    #[test]
+    fn permission_denied_detected_from_message_fallback() {
+        // No io::Error in the chain — must fall back to the string match.
+        let err = anyhow::anyhow!("Permission denied (os error 13)");
+        assert!(spawn_err_is_permission_denied(&err));
+    }
+
+    #[test]
+    fn non_permission_error_is_not_flagged() {
+        let io_err = std::io::Error::from(std::io::ErrorKind::NotFound);
+        let wrapped = anyhow::Error::new(io_err).context("spawn_command");
+        assert!(!spawn_err_is_permission_denied(&wrapped));
+
+        let other = anyhow::anyhow!("no such file or directory");
+        assert!(!spawn_err_is_permission_denied(&other));
     }
 
     /// Build a SandboxConfig pointing at a temporary directory with a fake

--- a/crates/platform/src/desktop/pty_shell.rs
+++ b/crates/platform/src/desktop/pty_shell.rs
@@ -33,31 +33,35 @@ fn spawn_err_is_permission_denied(err: &anyhow::Error) -> bool {
         .any(|io_err| io_err.kind() == std::io::ErrorKind::PermissionDenied)
 }
 
-/// Given the backend whose spawn just failed and the error, return the *other*
-/// namespace backend to retry with — or `None` if no retry applies.
+/// The interchangeable namespace sibling of a sandbox backend, if any.
 ///
-/// The #238 failure mode is a healthy sandbox backend that `portable_pty` can't
-/// spawn in this process context, surfacing as `EACCES`. bwrap and proot are
-/// interchangeable for the unprivileged interactive shell (both give a fake-root
-/// BlackArch shell), so on an EACCES spawn we retry with the sibling backend:
-///
-/// - proot spawn hits EACCES -> retry **bwrap**
-/// - bwrap spawn hits EACCES -> retry **proot**
-///
-/// WSL and Docker have no namespace sibling to swap to, so they never qualify.
-/// Only EACCES qualifies: a missing binary or bad rootfs would fail identically
-/// under the sibling and must surface as-is. The caller still confirms the
-/// sibling is actually available before retrying. Pure function so the decision
-/// is unit-testable without a live PTY.
-fn fallback_backend_for(backend: SandboxBackend, err: &anyhow::Error) -> Option<SandboxBackend> {
-    if !spawn_err_is_permission_denied(err) {
-        return None;
-    }
+/// bwrap and proot both give a fake-root BlackArch shell for the unprivileged
+/// interactive case, so either can substitute for the other. WSL and Docker
+/// have no such sibling.
+fn namespace_sibling(backend: SandboxBackend) -> Option<SandboxBackend> {
     match backend {
         SandboxBackend::Proot => Some(SandboxBackend::Bwrap),
         SandboxBackend::Bwrap => Some(SandboxBackend::Proot),
         SandboxBackend::Wsl | SandboxBackend::Docker => None,
     }
+}
+
+/// Given the backend whose spawn just failed and the spawn error, return the
+/// sibling backend to retry with — or `None` if no retry applies.
+///
+/// One #238 failure mode is a healthy sandbox backend that `portable_pty` can't
+/// spawn in this process context, surfacing as an `EACCES` spawn error. On such
+/// an error we retry with the namespace sibling (proot<->bwrap). Only EACCES
+/// qualifies: a missing binary or bad rootfs would fail identically under the
+/// sibling and must surface as-is. (The *other* #238 mode — a backend that
+/// spawns but dies immediately during init — is handled separately via
+/// `wait_for_early_exit`, since it is not a spawn error.) Pure function so the
+/// decision is unit-testable without a live PTY.
+fn fallback_backend_for(backend: SandboxBackend, err: &anyhow::Error) -> Option<SandboxBackend> {
+    if !spawn_err_is_permission_denied(err) {
+        return None;
+    }
+    namespace_sibling(backend)
 }
 
 impl PtyShell {
@@ -225,63 +229,31 @@ impl PtyShell {
 
         let cmd = Self::build_cmd_for_backend(backend, config, cwd).await?;
 
-        let child = match pair.slave.spawn_command(cmd) {
+        let mut child = match pair.slave.spawn_command(cmd) {
             Ok(child) => child,
             Err(e) => {
-                // Graceful symmetric fallback: a namespace backend (bwrap/proot)
-                // can fail to spawn under portable-pty with EACCES depending on
-                // the host process context (see #238), even when its binary and
+                // Symmetric fallback (#238), spawn-error path: a namespace backend
+                // (bwrap/proot) can fail to spawn under portable-pty with EACCES
+                // depending on the host process context, even when its binary and
                 // rootfs are healthy. bwrap and proot are interchangeable for the
                 // unprivileged interactive shell, so on EACCES we retry with the
                 // sibling backend instead of hard-failing.
-                let sibling = fallback_backend_for(backend, &e);
-                if let Some(fallback) = sibling {
-                    if Self::backend_is_available(fallback, config).await {
-                        // Log the failure at warn (not error): it is expected and
-                        // recoverable here; a preemptive error would read as a hard
-                        // failure even on the successful retry path.
-                        tracing::warn!(
-                            "[PtyShell::spawn_sandboxed] {backend:?} spawn hit EACCES ({e}); falling back to {fallback:?}"
-                        );
-
-                        // Open a *fresh* PTY for the retry. portable_pty does not
-                        // guarantee a slave is reusable after a failed spawn (the
-                        // controlling-terminal / TIOCSCTTY state may be left
-                        // partially applied by a half-forked child), so we drop
-                        // the old pair rather than spawn into it twice.
-                        drop(pair);
-                        let retry_pair = pty_system
-                            .openpty(PtySize {
-                                rows,
-                                cols,
-                                pixel_width: 0,
-                                pixel_height: 0,
-                            })
-                            .map_err(|e2| {
-                                Error::ToolExecution(format!(
-                                    "Failed to open PTY for {fallback:?} fallback: {e2} (original {backend:?} error: {e})"
-                                ))
-                            })?;
-
-                        let fallback_cmd =
-                            Self::build_cmd_for_backend(fallback, config, cwd).await?;
-                        let child = retry_pair.slave.spawn_command(fallback_cmd).map_err(|e2| {
-                            tracing::error!(
-                                "[PtyShell::spawn_sandboxed] {fallback:?} fallback also failed: {e2} (original {backend:?} error: {e})"
-                            );
-                            Error::ToolExecution(format!(
-                                "Failed to spawn sandboxed shell ({backend:?} spawn failed: {e}; {fallback:?} fallback also failed: {e2})"
-                            ))
-                        })?;
-
-                        tracing::info!(
-                            "Sandboxed shell spawned successfully ({fallback:?} fallback after {backend:?} EACCES)"
-                        );
-                        return Ok(Self {
-                            pair: retry_pair,
-                            child,
-                        });
+                if let Some(fallback) = fallback_backend_for(backend, &e) {
+                    if let Some(shell) = Self::try_fallback_spawn(
+                        pair,
+                        backend,
+                        fallback,
+                        config,
+                        cwd,
+                        rows,
+                        cols,
+                        &format!("spawn hit EACCES ({e})"),
+                    )
+                    .await?
+                    {
+                        return Ok(shell);
                     }
+                    // fallback unavailable: fall through to the hard error below.
                 }
 
                 tracing::error!(
@@ -293,9 +265,143 @@ impl PtyShell {
             }
         };
 
+        // Symmetric fallback (#238), early-exit path: some backends spawn
+        // successfully but die during init — e.g. bwrap exits non-zero with
+        // "setting up uid map: Permission denied" when the process already sits
+        // in a user namespace (nested VM/container). That is not a spawn error,
+        // so the arm above never sees it; instead we briefly watch whether the
+        // child dies almost immediately with a non-zero status and, if so, retry
+        // with the sibling backend. A healthy interactive shell stays alive well
+        // past this window, so the common path returns without added latency.
+        if let Some(status) = Self::wait_for_early_exit(&mut child).await {
+            if !status.success() {
+                if let Some(fallback) = namespace_sibling(backend) {
+                    if let Some(shell) = Self::try_fallback_spawn(
+                        pair,
+                        backend,
+                        fallback,
+                        config,
+                        cwd,
+                        rows,
+                        cols,
+                        &format!("exited immediately during init ({status:?})"),
+                    )
+                    .await?
+                    {
+                        return Ok(shell);
+                    }
+                }
+                // No usable sibling: surface the early failure rather than
+                // handing back a shell that already died.
+                tracing::error!(
+                    "[PtyShell::spawn_sandboxed] {backend:?} shell exited immediately ({status:?}) and no fallback is available"
+                );
+                return Err(Error::ToolExecution(format!(
+                    "Sandboxed shell ({backend:?}) exited immediately during startup ({status:?})"
+                )));
+            }
+        }
+
         tracing::info!("Sandboxed shell spawned successfully");
 
         Ok(Self { pair, child })
+    }
+
+    /// Window during which a sandbox child that exits is treated as an
+    /// initialization failure eligible for the sibling-backend fallback.
+    /// Backend-init failures (uid_map/seccomp) die in well under this; a healthy
+    /// interactive shell stays alive far longer.
+    const EARLY_EXIT_WINDOW: std::time::Duration = std::time::Duration::from_millis(500);
+
+    /// Poll a freshly spawned child for up to [`Self::EARLY_EXIT_WINDOW`],
+    /// returning its exit status if it dies within the window, or `None` if it
+    /// is still running (the healthy case).
+    async fn wait_for_early_exit(
+        child: &mut Box<dyn portable_pty::Child + Send + Sync>,
+    ) -> Option<portable_pty::ExitStatus> {
+        let poll_interval = std::time::Duration::from_millis(20);
+        let mut elapsed = std::time::Duration::ZERO;
+        while elapsed < Self::EARLY_EXIT_WINDOW {
+            match child.try_wait() {
+                Ok(Some(status)) => return Some(status),
+                Ok(None) => {}
+                // If we can't tell, don't block the shell — assume it's alive.
+                Err(_) => return None,
+            }
+            tokio::time::sleep(poll_interval).await;
+            elapsed += poll_interval;
+        }
+        None
+    }
+
+    /// Retry the sandboxed shell on the sibling backend after the primary failed
+    /// (either a spawn EACCES or an immediate init exit). Opens a *fresh* PTY —
+    /// portable_pty does not guarantee a slave is reusable after a failed/dead
+    /// spawn — and returns:
+    /// - `Ok(Some(shell))` on a successful fallback spawn,
+    /// - `Ok(None)` if the fallback backend is unavailable (caller surfaces the
+    ///   original failure),
+    /// - `Err(_)` if the fallback was attempted but itself failed.
+    #[allow(clippy::too_many_arguments)]
+    async fn try_fallback_spawn(
+        primary_pair: portable_pty::PtyPair,
+        backend: SandboxBackend,
+        fallback: SandboxBackend,
+        config: &super::sandbox::config::SandboxConfig,
+        cwd: Option<&Path>,
+        rows: u16,
+        cols: u16,
+        reason: &str,
+    ) -> Result<Option<Self>> {
+        if !Self::backend_is_available(fallback, config).await {
+            tracing::warn!(
+                "[PtyShell::spawn_sandboxed] {backend:?} {reason}, but fallback {fallback:?} is unavailable"
+            );
+            return Ok(None);
+        }
+
+        // Log at warn (not error): this is expected and recoverable.
+        tracing::warn!(
+            "[PtyShell::spawn_sandboxed] {backend:?} {reason}; falling back to {fallback:?}"
+        );
+
+        // Drop the primary pair before opening a fresh one for the retry.
+        // Open the PTY through a locally-created PtySystem: the `Box<dyn
+        // PtySystem>` it returns is not Sync, so it must not be threaded in as a
+        // borrow that would be held across the `.await` below (breaks callers in
+        // async/Send contexts like the liveview server). Opening here keeps it a
+        // short-lived local that is dropped before the await.
+        drop(primary_pair);
+        let retry_pair = native_pty_system()
+            .openpty(PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .map_err(|e| {
+                Error::ToolExecution(format!(
+                    "Failed to open PTY for {fallback:?} fallback (after {backend:?} {reason}): {e}"
+                ))
+            })?;
+
+        let fallback_cmd = Self::build_cmd_for_backend(fallback, config, cwd).await?;
+        let child = retry_pair.slave.spawn_command(fallback_cmd).map_err(|e2| {
+            tracing::error!(
+                "[PtyShell::spawn_sandboxed] {fallback:?} fallback also failed: {e2} (original {backend:?} {reason})"
+            );
+            Error::ToolExecution(format!(
+                "Failed to spawn sandboxed shell ({backend:?} {reason}; {fallback:?} fallback also failed: {e2})"
+            ))
+        })?;
+
+        tracing::info!(
+            "Sandboxed shell spawned successfully ({fallback:?} fallback after {backend:?} {reason})"
+        );
+        Ok(Some(Self {
+            pair: retry_pair,
+            child,
+        }))
     }
 
     /// Build the interactive-shell `CommandBuilder` for a specific backend.
@@ -493,9 +599,17 @@ impl PtyShell {
             },
         ]);
 
-        // Environment variables (proot uses process env)
+        // Environment variables — set them *inside* the guest via `env KEY=VAL`
+        // rather than on the host proot process. Injecting these as host process
+        // env (e.g. HOME=/root, a path that does not exist on the host) makes
+        // portable-pty's spawn fail with EACCES when it resolves the child's
+        // context, so the shell never starts. Passing them to a guest `env`
+        // wrapper is how the WSL builder already does it and matches bwrap's
+        // `--setenv`. proot maps the host rootfs, so `/usr/bin/env` resolves
+        // inside the BlackArch rootfs.
+        cmd.arg("/usr/bin/env");
         for (key, value) in &config.env_vars {
-            cmd.env(key, value);
+            cmd.arg(format!("{key}={value}"));
         }
 
         // Interactive login shell
@@ -729,6 +843,23 @@ mod tests {
         );
     }
 
+    #[test]
+    fn namespace_sibling_pairs_bwrap_and_proot() {
+        // The early-exit path (#238) reuses namespace_sibling directly, so it
+        // must pair the two namespace backends and reject the others regardless
+        // of any error.
+        assert_eq!(
+            namespace_sibling(SandboxBackend::Proot),
+            Some(SandboxBackend::Bwrap)
+        );
+        assert_eq!(
+            namespace_sibling(SandboxBackend::Bwrap),
+            Some(SandboxBackend::Proot)
+        );
+        assert_eq!(namespace_sibling(SandboxBackend::Wsl), None);
+        assert_eq!(namespace_sibling(SandboxBackend::Docker), None);
+    }
+
     /// Build a SandboxConfig pointing at a temporary directory with a fake
     /// rootfs so that the path-existence checks in `build_bwrap_cmd` pass.
     fn test_config(tmp: &std::path::Path) -> SandboxConfig {
@@ -896,12 +1027,20 @@ mod tests {
         assert_eq!(*tail[1], "-l");
         assert_eq!(*tail[2], "/bin/bash");
 
-        // Environment variables should be set via cmd.env(), not as args.
-        // Verify they are NOT in argv:
-        assert!(!argv.contains(&"--setenv".to_string()));
-        // But they should be accessible through get_env:
-        assert_eq!(cmd.get_env("TERM"), Some(OsStr::new("xterm-256color")));
-        assert_eq!(cmd.get_env("HOME"), Some(OsStr::new("/root")));
+        // Environment variables are passed *inside* the guest via `/usr/bin/env
+        // KEY=VAL ...`, NOT as host process env (cmd.env), because host env
+        // injection (HOME=/root) breaks portable-pty spawn with EACCES (#238).
+        assert!(argv.iter().any(|a| a == "/usr/bin/env"));
+        assert!(argv.iter().any(|a| a == "TERM=xterm-256color"));
+        assert!(argv.iter().any(|a| a == "HOME=/root"));
+        // The builder must NOT override host process env with the sandbox values
+        // (CommandBuilder inherits the parent env by default; the point is that
+        // build_proot_cmd does not *set* HOME=/root on the host process).
+        assert_ne!(cmd.get_env("HOME"), Some(OsStr::new("/root")));
+        // `env` must come before the shell it wraps.
+        let env_idx = argv.iter().position(|a| a == "/usr/bin/env").unwrap();
+        let bash_idx = argv.iter().position(|a| a == "/bin/bash").unwrap();
+        assert!(env_idx < bash_idx, "env wrapper must precede /bin/bash");
     }
 
     #[test]
@@ -1319,6 +1458,92 @@ mod tests {
             Err(e) => {
                 panic!("Proot PTY spawn failed: {:?}", e);
             }
+        }
+    }
+
+    /// End-to-end #238 regression: a sandboxed shell must come back *alive*, no
+    /// matter which namespace backend the host actually supports. This is the
+    /// real-world check for the early-exit fallback — on a host nested in a user
+    /// namespace (VM/container), bwrap spawns but dies with "setting up uid map:
+    /// Permission denied", and the shell must transparently fall back to proot
+    /// (or vice versa) rather than hand back a dead PTY.
+    ///
+    /// Ignored: needs a provisioned rootfs and at least one working backend.
+    #[tokio::test]
+    #[ignore]
+    async fn sandboxed_shell_is_alive_after_backend_fallback() {
+        use super::super::sandbox::get_sandbox_manager;
+        use std::io::Write;
+
+        let manager = get_sandbox_manager()
+            .await
+            .expect("Failed to get sandbox manager");
+        if manager.ensure_ready().await.is_err() {
+            println!("Skipping: rootfs not provisioned");
+            return;
+        }
+        println!("Primary backend selected: {:?}", manager.backend());
+
+        // Drive the real entry point in sandboxed mode.
+        let mut shell = PtyShell::spawn(80, 24, None, None, ShellMode::Proot)
+            .await
+            .expect("sandboxed shell should spawn on a working backend (with fallback)");
+
+        // The core assertion: after the early-exit window the shell is still
+        // alive. Before the fix, a uid_map-failing bwrap returned Ok here and
+        // then died, so this would observe an early non-zero exit.
+        std::thread::sleep(std::time::Duration::from_millis(700));
+        assert!(
+            matches!(shell.try_wait(), Ok(None)),
+            "shell must still be running after startup, not exited"
+        );
+
+        // And it should actually run a command.
+        let mut writer = shell.take_writer().expect("take writer");
+        let mut reader = shell.try_clone_reader().expect("clone reader");
+        writer.write_all(b"echo SHELL_LIVE\n").expect("write");
+        writer.flush().expect("flush");
+        std::thread::sleep(std::time::Duration::from_millis(800));
+        let mut buf = [0u8; 2048];
+        let n = reader.read(&mut buf).unwrap_or(0);
+        let out = String::from_utf8_lossy(&buf[..n]);
+        assert!(out.contains("SHELL_LIVE"), "shell did not echo: {out:?}");
+        println!("✓ Sandboxed shell is alive and responsive after fallback");
+    }
+}
+#[cfg(test)]
+mod full_fallback_probe {
+    use super::super::sandbox::get_sandbox_manager;
+    use super::*;
+    use portable_pty::{native_pty_system, PtySize};
+
+    #[tokio::test]
+    #[ignore]
+    async fn probe_real_proot_cmd_spawn() {
+        let m = get_sandbox_manager().await.unwrap();
+        m.ensure_ready().await.unwrap();
+        let cfg = m.config();
+        println!("env_vars = {:?}", cfg.env_vars);
+        // Build the EXACT proot cmd the fallback builds
+        let cmd = PtyShell::build_cmd_for_backend(SandboxBackend::Proot, cfg, None)
+            .await
+            .unwrap();
+        println!("argv = {:?}", cmd.get_argv());
+        let pty = native_pty_system();
+        let pair = pty
+            .openpty(PtySize {
+                rows: 24,
+                cols: 80,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .unwrap();
+        match pair.slave.spawn_command(cmd) {
+            Ok(mut c) => {
+                std::thread::sleep(std::time::Duration::from_millis(400));
+                println!("REAL-PROOT-CMD spawn Ok, early-exit={:?}", c.try_wait());
+            }
+            Err(e) => println!("REAL-PROOT-CMD spawn ERR: {e:#}"),
         }
     }
 }

--- a/crates/platform/src/desktop/pty_shell.rs
+++ b/crates/platform/src/desktop/pty_shell.rs
@@ -272,7 +272,11 @@ impl PtyShell {
         // so the arm above never sees it; instead we briefly watch whether the
         // child dies almost immediately with a non-zero status and, if so, retry
         // with the sibling backend. A healthy interactive shell stays alive well
-        // past this window, so the common path returns without added latency.
+        // past this window, so it is never mis-detected as a failure — but note
+        // this poll costs up to EARLY_EXIT_WINDOW (~500ms) on the common
+        // (healthy) path, since try_wait returns None until the window elapses.
+        // The one-time cost at shell-open is an accepted trade for detecting
+        // silent init failures; see wait_for_early_exit.
         if let Some(status) = Self::wait_for_early_exit(&mut child).await {
             if !status.success() {
                 if let Some(fallback) = namespace_sibling(backend) {
@@ -316,6 +320,13 @@ impl PtyShell {
     /// Poll a freshly spawned child for up to [`Self::EARLY_EXIT_WINDOW`],
     /// returning its exit status if it dies within the window, or `None` if it
     /// is still running (the healthy case).
+    ///
+    /// Cost: a child that dies returns as soon as the next 20ms poll observes
+    /// it, but a healthy child makes this block for the full window (~500ms) —
+    /// `try_wait` returns `None` on every poll until the loop times out. That
+    /// added latency is paid once per sandboxed shell open. Kept simple
+    /// (polling, not event-driven) deliberately; revisit if shell-open latency
+    /// becomes a concern.
     async fn wait_for_early_exit(
         child: &mut Box<dyn portable_pty::Child + Send + Sync>,
     ) -> Option<portable_pty::ExitStatus> {
@@ -386,7 +397,7 @@ impl PtyShell {
             })?;
 
         let fallback_cmd = Self::build_cmd_for_backend(fallback, config, cwd).await?;
-        let child = retry_pair.slave.spawn_command(fallback_cmd).map_err(|e2| {
+        let mut child = retry_pair.slave.spawn_command(fallback_cmd).map_err(|e2| {
             tracing::error!(
                 "[PtyShell::spawn_sandboxed] {fallback:?} fallback also failed: {e2} (original {backend:?} {reason})"
             );
@@ -394,6 +405,22 @@ impl PtyShell {
                 "Failed to spawn sandboxed shell ({backend:?} {reason}; {fallback:?} fallback also failed: {e2})"
             ))
         })?;
+
+        // The fallback child can also die during init (e.g. a nested-userns box
+        // where neither backend can set up its uid map). Apply the same
+        // early-exit poll the primary path uses, so we never hand back an
+        // already-dead PTY as a successful fallback. This is terminal: there is
+        // no further sibling to try, so an early exit here is a hard error.
+        if let Some(status) = Self::wait_for_early_exit(&mut child).await {
+            if !status.success() {
+                tracing::error!(
+                    "[PtyShell::spawn_sandboxed] {fallback:?} fallback shell exited immediately ({status:?}) (original {backend:?} {reason})"
+                );
+                return Err(Error::ToolExecution(format!(
+                    "Sandboxed shell fallback ({fallback:?}) exited immediately during startup ({status:?}); original {backend:?} {reason}"
+                )));
+            }
+        }
 
         tracing::info!(
             "Sandboxed shell spawned successfully ({fallback:?} fallback after {backend:?} {reason})"

--- a/crates/platform/src/desktop/sandbox/bwrap.rs
+++ b/crates/platform/src/desktop/sandbox/bwrap.rs
@@ -90,12 +90,11 @@ impl BwrapExecutor {
 
         let start = Instant::now();
 
-        // Check if we're running as real root (sudo) — skip user namespace, add capabilities
-        let is_root = std::process::Command::new("id")
-            .arg("-u")
-            .output()
-            .map(|o| String::from_utf8_lossy(&o.stdout).trim() == "0")
-            .unwrap_or(false);
+        // Check if we're running as real root (sudo) — skip user namespace, add
+        // capabilities. Use geteuid(2) via the shared helper rather than shelling
+        // out to `id -u`: this gate unlocks `--cap-add ALL`, so it must not be
+        // spoofable by a planted `id` on PATH (see #238 review).
+        let is_root = super::is_effective_root();
 
         let mut bwrap_args = vec![
             "--bind".to_string(),

--- a/crates/platform/src/desktop/sandbox/bwrap.rs
+++ b/crates/platform/src/desktop/sandbox/bwrap.rs
@@ -9,6 +9,13 @@ use std::path::Path;
 use std::process::Stdio;
 use std::time::{Duration, Instant};
 use tokio::process::Command;
+use tokio::sync::OnceCell;
+
+/// Cached result of the real bwrap usability probe. Computing it spawns a
+/// throwaway bwrap process, and `is_available()` is called frequently (per tool
+/// install, per shell spawn, during backend detection), so we probe once per
+/// process. Availability does not change over a run.
+static BWRAP_USABLE: OnceCell<bool> = OnceCell::const_new();
 
 /// Bubblewrap executor for Linux namespace-based sandboxing
 pub struct BwrapExecutor {
@@ -21,21 +28,37 @@ impl BwrapExecutor {
         Self { config }
     }
 
-    /// Check if bwrap is available and usable
+    /// Check if bwrap is available and *actually usable*.
+    ///
+    /// This is authoritative: it always confirms with a real `bwrap` spawn
+    /// rather than trusting `unprivileged_userns_clone` alone. On Ubuntu 24.04+
+    /// that sysctl reads `1` while `kernel.apparmor_restrict_unprivileged_userns`
+    /// separately denies the uid-map setup, so a sysctl-only check reports bwrap
+    /// as available when every real invocation fails with "setting up uid map:
+    /// Permission denied" (see #238). Getting this right lets `detect_backend`
+    /// pick proot for *all* execution paths (shell and tool installs), instead of
+    /// each path having to recover from a bwrap that never worked.
     pub async fn is_available() -> bool {
-        // Check for bwrap binary
-        if !Self::bwrap_exists().await {
-            tracing::debug!("bwrap binary not found");
-            return false;
-        }
-
-        // Check for user namespace support
-        if !Self::user_namespaces_enabled().await {
-            tracing::debug!("User namespaces not enabled");
-            return false;
-        }
-
-        true
+        *BWRAP_USABLE
+            .get_or_init(|| async {
+                // Cheap pre-filter: no binary => definitely unavailable.
+                if !Self::bwrap_exists().await {
+                    tracing::debug!("bwrap binary not found");
+                    return false;
+                }
+                // Authoritative: attempt a real (unprivileged, uid-mapping) spawn.
+                // This is the exact operation that AppArmor blocks, so it is the
+                // only reliable signal.
+                let usable = Self::test_bwrap().await;
+                if !usable {
+                    tracing::info!(
+                        "bwrap present but not usable (user-namespace/uid-map setup denied); \
+                         treating as unavailable so proot is used instead"
+                    );
+                }
+                usable
+            })
+            .await
     }
 
     /// Check if bwrap binary exists
@@ -50,22 +73,25 @@ impl BwrapExecutor {
             .unwrap_or(false)
     }
 
-    /// Check if unprivileged user namespaces are enabled
-    async fn user_namespaces_enabled() -> bool {
-        // Check /proc/sys/kernel/unprivileged_userns_clone
-        match tokio::fs::read_to_string("/proc/sys/kernel/unprivileged_userns_clone").await {
-            Ok(content) => content.trim() == "1",
-            Err(_) => {
-                // File might not exist on all systems; try a test invocation
-                Self::test_bwrap().await
-            }
-        }
-    }
-
-    /// Test if bwrap can actually run
+    /// Test if bwrap can actually run an unprivileged user namespace.
+    ///
+    /// Uses `--unshare-user --uid 0 --gid 0` so the probe exercises the exact
+    /// uid-map setup that real sandbox commands need — a plain `--ro-bind`
+    /// invocation would succeed even where uid mapping is denied, giving a false
+    /// positive on AppArmor-restricted hosts (#238).
     async fn test_bwrap() -> bool {
         Command::new("bwrap")
-            .args(["--ro-bind", "/", "/", "true"])
+            .args([
+                "--unshare-user",
+                "--uid",
+                "0",
+                "--gid",
+                "0",
+                "--ro-bind",
+                "/",
+                "/",
+                "true",
+            ])
             .stdout(Stdio::null())
             .stderr(Stdio::null())
             .status()

--- a/crates/platform/src/desktop/sandbox/mod.rs
+++ b/crates/platform/src/desktop/sandbox/mod.rs
@@ -237,34 +237,39 @@ impl SandboxManager {
         }
         tracing::debug!("[detect_backend] bwrap not available");
 
-        // Try Docker (works on any platform with Docker installed)
-        tracing::debug!("[detect_backend] Checking if Docker is available...");
-        if docker::DockerExecutor::is_available().await {
-            tracing::info!("[detect_backend] Detected Docker, using it as backend");
-            return Ok(SandboxBackend::Docker);
-        }
-        tracing::debug!("[detect_backend] Docker not available");
-
-        // Try proot if available locally
-        tracing::debug!("[detect_backend] Checking if proot is available...");
-        if proot::ProotExecutor::is_available(config).await {
-            tracing::info!("[detect_backend] Detected proot, using it as backend");
-            return Ok(SandboxBackend::Proot);
-        }
-        tracing::debug!("[detect_backend] proot not available locally");
-
-        // Download proot as final fallback (Linux only — proot is a Linux ELF binary)
+        // On Linux, prefer proot over Docker. proot uses ptrace (no per-command
+        // container spin-up), works on normal desktops that lack Docker, and fits
+        // the connector's many-small-commands pattern; selecting Docker here means
+        // a `docker run` per `which`/tool probe. Docker stays as the last-resort
+        // Linux fallback below. This block is Linux-only because proot is a Linux
+        // ELF binary — other platforms (macOS) fall through to Docker.
         #[cfg(target_os = "linux")]
         {
-            tracing::info!(
-                "[detect_backend] No backend found locally, downloading proot as fallback..."
-            );
+            tracing::debug!("[detect_backend] Checking if proot is available...");
+            if proot::ProotExecutor::is_available(config).await {
+                tracing::info!("[detect_backend] Detected proot, using it as backend");
+                return Ok(SandboxBackend::Proot);
+            }
+            tracing::debug!("[detect_backend] proot not available locally");
+
+            // Download proot as the final local option before falling to Docker.
+            tracing::info!("[detect_backend] proot not local, attempting to download proot...");
             if proot::ProotExecutor::download_proot(config).await.is_ok() {
                 tracing::info!("[detect_backend] proot downloaded successfully");
                 return Ok(SandboxBackend::Proot);
             }
             tracing::error!("[detect_backend] Failed to download proot");
         }
+
+        // Docker: last-resort backend on Linux, and the primary sandbox on macOS
+        // (where proot, a Linux ELF, cannot run). Works on any platform with a
+        // running Docker daemon.
+        tracing::debug!("[detect_backend] Checking if Docker is available...");
+        if docker::DockerExecutor::is_available().await {
+            tracing::info!("[detect_backend] Detected Docker, using it as backend");
+            return Ok(SandboxBackend::Docker);
+        }
+        tracing::debug!("[detect_backend] Docker not available");
 
         #[cfg(target_os = "macos")]
         tracing::error!(

--- a/crates/platform/src/desktop/sandbox/mod.rs
+++ b/crates/platform/src/desktop/sandbox/mod.rs
@@ -13,6 +13,7 @@ pub mod wsl;
 
 use crate::traits::CommandResult;
 use config::{SandboxBackend, SandboxConfig, SandboxError, SandboxResult};
+use pentest_core::config::ShellMode;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
@@ -21,19 +22,60 @@ use tokio::sync::OnceCell;
 /// Global sandbox manager instance
 static SANDBOX_MANAGER: OnceCell<Arc<SandboxManager>> = OnceCell::const_new();
 
-/// Decide the preferred sandbox backend based on privilege level.
+/// Return true if the current process is running as (effective) root.
 ///
-/// Root -> force bwrap (real capabilities for raw sockets).
-/// Non-root -> `None`, meaning "no forced preference"; `detect_backend` then
-/// auto-detects, preferring bwrap and using proot only as a fallback.
+/// Uses `geteuid(2)` directly rather than shelling out to `id -u`. The syscall
+/// cannot be spoofed via `PATH` (an attacker-planted `id` on `PATH` printing
+/// `0` previously could have flipped this to "root" and unlocked the
+/// bwrap `--cap-add ALL` path), it never forks, and it can't fail. On non-Unix
+/// desktops there is no uid concept, so we report non-root.
+fn is_effective_root() -> bool {
+    #[cfg(unix)]
+    {
+        // SAFETY: `geteuid` is always safe to call — it takes no arguments,
+        // reads no memory, and cannot fail (POSIX guarantees success).
+        unsafe { libc::geteuid() == 0 }
+    }
+    #[cfg(not(unix))]
+    {
+        false
+    }
+}
+
+/// Decide the preferred sandbox backend from privilege level and the user's
+/// shell mode.
 ///
-/// Returning `None` for non-root is deliberate: pinning proot broke the
-/// interactive PTY shell with EACCES on non-root Linux desktops (see #238).
-fn preferred_backend_for(is_root: bool) -> Option<SandboxBackend> {
+/// - **root** -> force bwrap. Only root can grant real capabilities
+///   (raw sockets via `--cap-add ALL`), and bwrap is the desktop backend
+///   that carries them. This is gated to Linux: bwrap is Linux-only, so on
+///   other platforms we leave the preference unset and let `detect_backend`
+///   pick the right backend (WSL, Docker, ...) instead of pinning an
+///   unavailable one and logging a spurious "preferred backend not available"
+///   warning.
+/// - **non-root + `ShellMode::Proot`** -> honor the user's explicit choice and
+///   pin proot. `detect_backend` still downgrades to another backend if proot
+///   is unavailable, and the interactive PTY shell downgrades to bwrap at spawn
+///   time if proot is present but rejected with EACCES (see #238). Keeping the
+///   preference means a user on a host where bwrap is present-but-broken (subtle
+///   userns / seccomp / AppArmor breakage that passes `is_available()` yet fails
+///   at runtime) still gets the backend they asked for.
+/// - **non-root + `ShellMode::Native`** -> `None`, i.e. no forced preference;
+///   `detect_backend` auto-detects (prefers bwrap, proot as fallback).
+fn preferred_backend_for(is_root: bool, shell_mode: ShellMode) -> Option<SandboxBackend> {
     if is_root {
-        Some(SandboxBackend::Bwrap)
-    } else {
-        None
+        #[cfg(target_os = "linux")]
+        {
+            return Some(SandboxBackend::Bwrap);
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            return None;
+        }
+    }
+
+    match shell_mode {
+        ShellMode::Proot => Some(SandboxBackend::Proot),
+        ShellMode::Native => None,
     }
 }
 
@@ -45,37 +87,20 @@ pub async fn get_sandbox_manager() -> SandboxResult<Arc<SandboxManager>> {
             tracing::info!("[get_sandbox_manager] Initializing new sandbox manager...");
             let mut config = SandboxConfig::default();
 
-            // Choose the preferred backend. When running as real root, force bwrap
-            // so tools get real capabilities (raw sockets via --cap-add ALL). When
-            // non-root, leave the preference unset and let detect_backend
-            // auto-detect: it prefers bwrap (native namespaces, works with
-            // portable-pty) and falls back to proot only when bwrap is unavailable.
-            //
-            // We intentionally do NOT force the proot backend for shell_mode ==
-            // Proot. In the ShellMode enum, "Proot" means "run sandboxed" (vs
-            // Native = run on the host), not "use the proot binary specifically".
-            // Forcing proot pinned non-root desktops to a backend that fails to
-            // spawn under portable-pty with EACCES. See #238.
-            let is_root = std::process::Command::new("id")
-                .arg("-u")
-                .output()
-                .map(|o| String::from_utf8_lossy(&o.stdout).trim() == "0")
-                .unwrap_or_else(|e| {
-                    tracing::warn!(
-                        "[get_sandbox_manager] Failed to detect root via 'id -u': {e}; assuming non-root"
-                    );
-                    false
-                });
-            config.preferred_backend = preferred_backend_for(is_root);
-            if is_root {
-                tracing::info!(
-                    "[get_sandbox_manager] Running as root, preferring bwrap for real capabilities"
-                );
-            } else {
-                tracing::info!(
-                    "[get_sandbox_manager] Non-root: auto-detecting sandbox backend (prefers bwrap, proot fallback)"
-                );
-            }
+            // Choose the preferred backend from privilege level and the user's
+            // shell mode (see `preferred_backend_for`). As real root we force
+            // bwrap for real capabilities (raw sockets via --cap-add ALL). As
+            // non-root we honor an explicit ShellMode::Proot but rely on
+            // detect_backend's downgrade and the PTY shell's EACCES -> bwrap
+            // fallback (see #238) so a pinned-but-unspawnable proot degrades
+            // gracefully instead of hard-failing the shell.
+            let is_root = is_effective_root();
+            let shell_mode = pentest_core::settings::load_settings().shell_mode;
+            config.preferred_backend = preferred_backend_for(is_root, shell_mode);
+            tracing::info!(
+                "[get_sandbox_manager] is_root={is_root}, shell_mode={shell_mode:?} -> preferred_backend={:?}",
+                config.preferred_backend
+            );
             tracing::debug!(
                 "[get_sandbox_manager] Config: data_dir={:?}, preferred_backend={:?}",
                 config.data_dir,
@@ -401,16 +426,47 @@ mod tests {
         }
     }
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn root_prefers_bwrap_for_real_capabilities() {
-        // Real root should force bwrap so tools get raw-socket capabilities.
-        assert_eq!(preferred_backend_for(true), Some(SandboxBackend::Bwrap));
+        // Real root on Linux should force bwrap so tools get raw-socket
+        // capabilities. Shell mode is irrelevant when root.
+        assert_eq!(
+            preferred_backend_for(true, ShellMode::Native),
+            Some(SandboxBackend::Bwrap)
+        );
+        assert_eq!(
+            preferred_backend_for(true, ShellMode::Proot),
+            Some(SandboxBackend::Bwrap)
+        );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn root_does_not_pin_unavailable_bwrap_off_linux() {
+        // bwrap is Linux-only; pinning it elsewhere would only produce a
+        // spurious "preferred backend not available" warning. Leave it unset
+        // so detect_backend can choose WSL/Docker/etc.
+        assert_eq!(preferred_backend_for(true, ShellMode::Native), None);
+        assert_eq!(preferred_backend_for(true, ShellMode::Proot), None);
     }
 
     #[test]
-    fn non_root_leaves_backend_unset_for_auto_detect() {
-        // Non-root must NOT pin proot (regression guard for #238): returning None
-        // lets detect_backend prefer bwrap and fall back to proot only if needed.
-        assert_eq!(preferred_backend_for(false), None);
+    fn non_root_native_leaves_backend_unset_for_auto_detect() {
+        // Native (non-sandboxed) => no forced preference; detect_backend prefers
+        // bwrap and falls back to proot only if needed.
+        assert_eq!(preferred_backend_for(false, ShellMode::Native), None);
+    }
+
+    #[test]
+    fn non_root_proot_honors_user_choice() {
+        // H2: a non-root user who explicitly selected Proot keeps that
+        // preference. detect_backend still downgrades if proot is unavailable,
+        // and the PTY shell downgrades to bwrap on an EACCES spawn (see #238),
+        // so this is safe while still respecting the user's setting.
+        assert_eq!(
+            preferred_backend_for(false, ShellMode::Proot),
+            Some(SandboxBackend::Proot)
+        );
     }
 }

--- a/crates/platform/src/desktop/sandbox/mod.rs
+++ b/crates/platform/src/desktop/sandbox/mod.rs
@@ -13,7 +13,6 @@ pub mod wsl;
 
 use crate::traits::CommandResult;
 use config::{SandboxBackend, SandboxConfig, SandboxError, SandboxResult};
-use pentest_core::config::ShellMode;
 use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
@@ -29,7 +28,11 @@ static SANDBOX_MANAGER: OnceCell<Arc<SandboxManager>> = OnceCell::const_new();
 /// `0` previously could have flipped this to "root" and unlocked the
 /// bwrap `--cap-add ALL` path), it never forks, and it can't fail. On non-Unix
 /// desktops there is no uid concept, so we report non-root.
-fn is_effective_root() -> bool {
+///
+/// Shared with [`bwrap::BwrapExecutor::execute`], which uses the same check to
+/// gate the `--cap-add ALL` capability grant — that gate is the one that most
+/// needs a non-spoofable root check.
+pub(crate) fn is_effective_root() -> bool {
     #[cfg(unix)]
     {
         // SAFETY: `geteuid` is always safe to call — it takes no arguments,
@@ -42,26 +45,28 @@ fn is_effective_root() -> bool {
     }
 }
 
-/// Decide the preferred sandbox backend from privilege level and the user's
-/// shell mode.
+/// Decide the preferred sandbox backend based on privilege level.
 ///
 /// - **root** -> force bwrap. Only root can grant real capabilities
 ///   (raw sockets via `--cap-add ALL`), and bwrap is the desktop backend
-///   that carries them. This is gated to Linux: bwrap is Linux-only, so on
-///   other platforms we leave the preference unset and let `detect_backend`
-///   pick the right backend (WSL, Docker, ...) instead of pinning an
-///   unavailable one and logging a spurious "preferred backend not available"
-///   warning.
-/// - **non-root + `ShellMode::Proot`** -> honor the user's explicit choice and
-///   pin proot. `detect_backend` still downgrades to another backend if proot
-///   is unavailable, and the interactive PTY shell downgrades to bwrap at spawn
-///   time if proot is present but rejected with EACCES (see #238). Keeping the
-///   preference means a user on a host where bwrap is present-but-broken (subtle
-///   userns / seccomp / AppArmor breakage that passes `is_available()` yet fails
-///   at runtime) still gets the backend they asked for.
-/// - **non-root + `ShellMode::Native`** -> `None`, i.e. no forced preference;
-///   `detect_backend` auto-detects (prefers bwrap, proot as fallback).
-fn preferred_backend_for(is_root: bool, shell_mode: ShellMode) -> Option<SandboxBackend> {
+///   that carries them. Gated to Linux: bwrap is Linux-only, so on other
+///   platforms we leave the preference unset and let `detect_backend` pick
+///   the right backend (WSL, Docker, ...) instead of pinning an unavailable
+///   one and logging a spurious "preferred backend not available" warning.
+/// - **non-root** -> `None` (no forced preference). `detect_backend` then
+///   auto-detects, and it prefers bwrap (fast native namespaces, works with
+///   portable-pty) and uses proot only as a fallback when bwrap is
+///   unavailable. This is the correct behavior even when the user selected
+///   the "Proot" shell mode: that toggle means "run sandboxed" (vs "run on
+///   the host"), not "use the proot binary specifically" — the UI never
+///   exposes a bwrap-vs-proot choice. Pinning proot here is what broke the
+///   interactive PTY shell with EACCES on non-root Linux desktops (see #238).
+///
+/// The residual risk of preferring bwrap — a host where bwrap passes
+/// `is_available()` but fails to spawn at runtime — is covered by the
+/// interactive shell's symmetric spawn fallback (bwrap <-> proot on EACCES),
+/// so neither backend hard-fails when the other is usable.
+fn preferred_backend_for(is_root: bool) -> Option<SandboxBackend> {
     if is_root {
         #[cfg(target_os = "linux")]
         {
@@ -72,11 +77,7 @@ fn preferred_backend_for(is_root: bool, shell_mode: ShellMode) -> Option<Sandbox
             return None;
         }
     }
-
-    match shell_mode {
-        ShellMode::Proot => Some(SandboxBackend::Proot),
-        ShellMode::Native => None,
-    }
+    None
 }
 
 /// Get or initialize the global sandbox manager
@@ -87,18 +88,17 @@ pub async fn get_sandbox_manager() -> SandboxResult<Arc<SandboxManager>> {
             tracing::info!("[get_sandbox_manager] Initializing new sandbox manager...");
             let mut config = SandboxConfig::default();
 
-            // Choose the preferred backend from privilege level and the user's
-            // shell mode (see `preferred_backend_for`). As real root we force
-            // bwrap for real capabilities (raw sockets via --cap-add ALL). As
-            // non-root we honor an explicit ShellMode::Proot but rely on
-            // detect_backend's downgrade and the PTY shell's EACCES -> bwrap
-            // fallback (see #238) so a pinned-but-unspawnable proot degrades
-            // gracefully instead of hard-failing the shell.
+            // Choose the preferred backend from privilege level (see
+            // `preferred_backend_for`). As real root we force bwrap for real
+            // capabilities (raw sockets via --cap-add ALL). As non-root we leave
+            // the preference unset so detect_backend auto-detects, preferring
+            // bwrap and using proot only as a fallback. The interactive PTY
+            // shell's symmetric EACCES fallback (see #238) rescues the rare case
+            // where the selected backend can't actually spawn.
             let is_root = is_effective_root();
-            let shell_mode = pentest_core::settings::load_settings().shell_mode;
-            config.preferred_backend = preferred_backend_for(is_root, shell_mode);
+            config.preferred_backend = preferred_backend_for(is_root);
             tracing::info!(
-                "[get_sandbox_manager] is_root={is_root}, shell_mode={shell_mode:?} -> preferred_backend={:?}",
+                "[get_sandbox_manager] is_root={is_root} -> preferred_backend={:?}",
                 config.preferred_backend
             );
             tracing::debug!(
@@ -430,15 +430,8 @@ mod tests {
     #[test]
     fn root_prefers_bwrap_for_real_capabilities() {
         // Real root on Linux should force bwrap so tools get raw-socket
-        // capabilities. Shell mode is irrelevant when root.
-        assert_eq!(
-            preferred_backend_for(true, ShellMode::Native),
-            Some(SandboxBackend::Bwrap)
-        );
-        assert_eq!(
-            preferred_backend_for(true, ShellMode::Proot),
-            Some(SandboxBackend::Bwrap)
-        );
+        // capabilities via --cap-add ALL.
+        assert_eq!(preferred_backend_for(true), Some(SandboxBackend::Bwrap));
     }
 
     #[cfg(not(target_os = "linux"))]
@@ -447,26 +440,16 @@ mod tests {
         // bwrap is Linux-only; pinning it elsewhere would only produce a
         // spurious "preferred backend not available" warning. Leave it unset
         // so detect_backend can choose WSL/Docker/etc.
-        assert_eq!(preferred_backend_for(true, ShellMode::Native), None);
-        assert_eq!(preferred_backend_for(true, ShellMode::Proot), None);
+        assert_eq!(preferred_backend_for(true), None);
     }
 
     #[test]
-    fn non_root_native_leaves_backend_unset_for_auto_detect() {
-        // Native (non-sandboxed) => no forced preference; detect_backend prefers
-        // bwrap and falls back to proot only if needed.
-        assert_eq!(preferred_backend_for(false, ShellMode::Native), None);
-    }
-
-    #[test]
-    fn non_root_proot_honors_user_choice() {
-        // H2: a non-root user who explicitly selected Proot keeps that
-        // preference. detect_backend still downgrades if proot is unavailable,
-        // and the PTY shell downgrades to bwrap on an EACCES spawn (see #238),
-        // so this is safe while still respecting the user's setting.
-        assert_eq!(
-            preferred_backend_for(false, ShellMode::Proot),
-            Some(SandboxBackend::Proot)
-        );
+    fn non_root_leaves_backend_unset_for_auto_detect() {
+        // Non-root must NOT pin proot (regression guard for #238): returning
+        // None lets detect_backend prefer bwrap (fast, works with portable-pty)
+        // and fall back to proot only if bwrap is unavailable. Selecting the
+        // "Proot" shell mode does not change this — the shell's symmetric EACCES
+        // fallback covers a backend that is chosen but can't spawn.
+        assert_eq!(preferred_backend_for(false), None);
     }
 }

--- a/crates/platform/src/desktop/sandbox/mod.rs
+++ b/crates/platform/src/desktop/sandbox/mod.rs
@@ -21,6 +21,22 @@ use tokio::sync::OnceCell;
 /// Global sandbox manager instance
 static SANDBOX_MANAGER: OnceCell<Arc<SandboxManager>> = OnceCell::const_new();
 
+/// Decide the preferred sandbox backend based on privilege level.
+///
+/// Root -> force bwrap (real capabilities for raw sockets).
+/// Non-root -> `None`, meaning "no forced preference"; `detect_backend` then
+/// auto-detects, preferring bwrap and using proot only as a fallback.
+///
+/// Returning `None` for non-root is deliberate: pinning proot broke the
+/// interactive PTY shell with EACCES on non-root Linux desktops (see #238).
+fn preferred_backend_for(is_root: bool) -> Option<SandboxBackend> {
+    if is_root {
+        Some(SandboxBackend::Bwrap)
+    } else {
+        None
+    }
+}
+
 /// Get or initialize the global sandbox manager
 pub async fn get_sandbox_manager() -> SandboxResult<Arc<SandboxManager>> {
     tracing::debug!("[get_sandbox_manager] Attempting to get or initialize sandbox manager");
@@ -29,31 +45,31 @@ pub async fn get_sandbox_manager() -> SandboxResult<Arc<SandboxManager>> {
             tracing::info!("[get_sandbox_manager] Initializing new sandbox manager...");
             let mut config = SandboxConfig::default();
 
-            // When running as root, prefer bwrap (real capabilities for raw sockets).
-            // Otherwise respect the user's shell_mode setting.
+            // Choose the preferred backend. When running as real root, force bwrap
+            // so tools get real capabilities (raw sockets via --cap-add ALL). When
+            // non-root, leave the preference unset and let detect_backend
+            // auto-detect: it prefers bwrap (native namespaces, works with
+            // portable-pty) and falls back to proot only when bwrap is unavailable.
+            //
+            // We intentionally do NOT force the proot backend for shell_mode ==
+            // Proot. In the ShellMode enum, "Proot" means "run sandboxed" (vs
+            // Native = run on the host), not "use the proot binary specifically".
+            // Forcing proot pinned non-root desktops to a backend that fails to
+            // spawn under portable-pty with EACCES. See #238.
             let is_root = std::process::Command::new("id")
                 .arg("-u")
                 .output()
                 .map(|o| String::from_utf8_lossy(&o.stdout).trim() == "0")
                 .unwrap_or(false);
+            config.preferred_backend = preferred_backend_for(is_root);
             if is_root {
-                config.preferred_backend = Some(SandboxBackend::Bwrap);
                 tracing::info!(
                     "[get_sandbox_manager] Running as root, preferring bwrap for real capabilities"
                 );
             } else {
-                let settings = pentest_core::settings::load_settings();
-                match settings.shell_mode {
-                    pentest_core::config::ShellMode::Proot => {
-                        config.preferred_backend = Some(SandboxBackend::Proot);
-                        tracing::info!(
-                            "[get_sandbox_manager] User selected Proot backend via settings"
-                        );
-                    }
-                    pentest_core::config::ShellMode::Native => {
-                        // Native = no sandbox preference, auto-detect
-                    }
-                }
+                tracing::info!(
+                    "[get_sandbox_manager] Non-root: auto-detecting sandbox backend (prefers bwrap, proot fallback)"
+                );
             }
             tracing::debug!(
                 "[get_sandbox_manager] Config: data_dir={:?}, preferred_backend={:?}",
@@ -378,5 +394,18 @@ mod tests {
             Ok(backend) => println!("Detected backend: {}", backend),
             Err(e) => println!("No backend available: {}", e),
         }
+    }
+
+    #[test]
+    fn root_prefers_bwrap_for_real_capabilities() {
+        // Real root should force bwrap so tools get raw-socket capabilities.
+        assert_eq!(preferred_backend_for(true), Some(SandboxBackend::Bwrap));
+    }
+
+    #[test]
+    fn non_root_leaves_backend_unset_for_auto_detect() {
+        // Non-root must NOT pin proot (regression guard for #238): returning None
+        // lets detect_backend prefer bwrap and fall back to proot only if needed.
+        assert_eq!(preferred_backend_for(false), None);
     }
 }

--- a/crates/platform/src/desktop/sandbox/mod.rs
+++ b/crates/platform/src/desktop/sandbox/mod.rs
@@ -60,7 +60,12 @@ pub async fn get_sandbox_manager() -> SandboxResult<Arc<SandboxManager>> {
                 .arg("-u")
                 .output()
                 .map(|o| String::from_utf8_lossy(&o.stdout).trim() == "0")
-                .unwrap_or(false);
+                .unwrap_or_else(|e| {
+                    tracing::warn!(
+                        "[get_sandbox_manager] Failed to detect root via 'id -u': {e}; assuming non-root"
+                    );
+                    false
+                });
             config.preferred_backend = preferred_backend_for(is_root);
             if is_root {
                 tracing::info!(

--- a/crates/tools/src/catalog.rs
+++ b/crates/tools/src/catalog.rs
@@ -233,24 +233,13 @@ async fn install_pacman(entry: &CatalogEntry, progress: &ProgressSink) -> Result
         "Installing {} via pacman...",
         entry.display_name
     )));
-    let platform = get_platform();
     // package_name is keyed by binary in the catalog; look it up fresh from the
     // dependency to get the real package name.
     let pkg = pacman_package_for(&entry.binary_name).unwrap_or_else(|| entry.binary_name.clone());
     validate_package_name(&pkg)?;
-    let result = platform
-        .execute_command(
-            "pacman",
-            &["-S", "--noconfirm", &pkg],
-            Duration::from_secs(600),
-        )
-        .await?;
-    if result.exit_code != 0 {
-        return Err(Error::ToolExecution(format!(
-            "Failed to install {pkg}: {}",
-            result.stderr
-        )));
-    }
+    // -Sy refreshes the package DBs first; a bare -S fails on a rootfs whose
+    // sync DBs have gone stale (see installers::pacman).
+    crate::installers::pacman::install(&pkg, Duration::from_secs(600)).await?;
     progress(InstallEvent::step(format!(
         "{} installed",
         entry.display_name

--- a/crates/tools/src/catalog.rs
+++ b/crates/tools/src/catalog.rs
@@ -129,11 +129,22 @@ fn collect_dependencies() -> BTreeMap<String, (ExternalDependency, Vec<String>)>
     deps
 }
 
-/// Probe whether a single binary is present on PATH (cheap `which`).
+/// Probe whether a single binary is present on PATH.
+///
+/// Uses the POSIX `command -v` shell builtin, not the `which` binary: the
+/// minimal BlackArch sandbox rootfs does not ship `which`, so a `which` probe
+/// reports every tool as Missing even when installed (certipy/kerbrute landed
+/// in `/usr/sbin` but read as absent). `command -v` is a shell builtin and
+/// works in both the sandbox and on the host. The binary name is passed as a
+/// positional arg (`$1`), never interpolated, so no shell-escaping is needed.
 async fn binary_present(binary: &str) -> InstallState {
     let platform = get_platform();
     match platform
-        .execute_command("which", &[binary], Duration::from_secs(5))
+        .execute_command(
+            "sh",
+            &["-c", "command -v \"$1\" > /dev/null 2>&1", "sh", binary],
+            Duration::from_secs(5),
+        )
         .await
     {
         Ok(r) if r.exit_code == 0 => InstallState::Installed,

--- a/crates/tools/src/installers/bloodhound.rs
+++ b/crates/tools/src/installers/bloodhound.rs
@@ -65,21 +65,9 @@ impl ToolInstaller for BloodHoundInstaller {
         progress(InstallEvent::step(
             "Installing BloodHound collector via pacman (python-bloodhound)...",
         ));
-        let platform = get_platform();
-        let result = platform
-            .execute_command(
-                "pacman",
-                &["-S", "--noconfirm", "python-bloodhound"],
-                Duration::from_secs(600),
-            )
-            .await?;
-
-        if result.exit_code != 0 {
-            return Err(Error::ToolExecution(format!(
-                "Failed to install python-bloodhound: {}",
-                result.stderr
-            )));
-        }
+        // -Sy refreshes the package DBs first; a bare -S fails on a rootfs whose
+        // sync DBs have gone stale (see installers::pacman).
+        super::pacman::install("python-bloodhound", Duration::from_secs(600)).await?;
 
         if !Self::collector_present().await {
             return Err(Error::ToolExecution(

--- a/crates/tools/src/installers/bloodhound.rs
+++ b/crates/tools/src/installers/bloodhound.rs
@@ -10,15 +10,22 @@
 
 use super::{InstallEvent, ProgressSink, ToolInstaller};
 use pentest_core::error::{Error, Result};
-use pentest_platform::{get_platform, CommandExec};
 use std::time::Duration;
 
 use crate::installers::sandbox_enabled;
 
-const COLLECTOR_BINARY: &str = "bloodhound-python";
+/// Binary the collector package installs. The BlackArch package
+/// `bloodhound-ce-python` provides the `bloodhound-ce-python` collector (the
+/// v5/CE data collector). The old `python-bloodhound` / `bloodhound-python`
+/// names do not exist in the current repos — using them caused
+/// `error: target not found: python-bloodhound`.
+const COLLECTOR_BINARY: &str = "bloodhound-ce-python";
+
+/// BlackArch package that provides [`COLLECTOR_BINARY`].
+const COLLECTOR_PACKAGE: &str = "bloodhound-ce-python";
 
 const HOST_INSTRUCTIONS: &str =
-    "Install the collector on the host with: pipx install bloodhound  (provides `bloodhound-python`). \
+    "Install the collector on the host with: pipx install bloodhound-ce  (provides `bloodhound-ce-python`). \
      For the BloodHound CE UI + neo4j graph, run the official Docker Compose stack from \
      https://github.com/SpecterOps/BloodHound (docker compose up); that service is not auto-managed \
      by the connector.";
@@ -27,12 +34,7 @@ pub struct BloodHoundInstaller;
 
 impl BloodHoundInstaller {
     async fn collector_present() -> bool {
-        let platform = get_platform();
-        platform
-            .execute_command("which", &[COLLECTOR_BINARY], Duration::from_secs(5))
-            .await
-            .map(|r| r.exit_code == 0)
-            .unwrap_or(false)
+        super::binary_on_path(COLLECTOR_BINARY).await
     }
 }
 
@@ -52,27 +54,29 @@ impl ToolInstaller for BloodHoundInstaller {
 
     async fn install(&self, progress: &ProgressSink) -> Result<()> {
         if Self::collector_present().await {
-            progress(InstallEvent::step("bloodhound-python already installed"));
+            progress(InstallEvent::step(format!(
+                "{COLLECTOR_BINARY} already installed"
+            )));
             return Ok(());
         }
 
         if !sandbox_enabled() {
             return Err(Error::ToolExecution(format!(
-                "bloodhound-python is not installed and sandbox is disabled. {HOST_INSTRUCTIONS}"
+                "{COLLECTOR_BINARY} is not installed and sandbox is disabled. {HOST_INSTRUCTIONS}"
             )));
         }
 
-        progress(InstallEvent::step(
-            "Installing BloodHound collector via pacman (python-bloodhound)...",
-        ));
+        progress(InstallEvent::step(format!(
+            "Installing BloodHound collector via pacman ({COLLECTOR_PACKAGE})..."
+        )));
         // -Sy refreshes the package DBs first; a bare -S fails on a rootfs whose
         // sync DBs have gone stale (see installers::pacman).
-        super::pacman::install("python-bloodhound", Duration::from_secs(600)).await?;
+        super::pacman::install(COLLECTOR_PACKAGE, Duration::from_secs(600)).await?;
 
         if !Self::collector_present().await {
-            return Err(Error::ToolExecution(
-                "python-bloodhound installed but bloodhound-python is not on PATH".to_string(),
-            ));
+            return Err(Error::ToolExecution(format!(
+                "{COLLECTOR_PACKAGE} installed but {COLLECTOR_BINARY} is not on PATH"
+            )));
         }
 
         progress(InstallEvent::step("BloodHound collector installed"));
@@ -97,5 +101,15 @@ mod tests {
     fn manual_instructions_mention_neo4j_stack() {
         let instr = BloodHoundInstaller.manual_instructions().unwrap();
         assert!(instr.contains("Docker Compose") || instr.contains("docker compose"));
+    }
+
+    #[test]
+    fn collector_package_and_binary_are_the_real_repo_names() {
+        // Regression: the old `python-bloodhound` package name does not exist
+        // in the BlackArch repos and caused `target not found`. The real
+        // package/binary is `bloodhound-ce-python`.
+        assert_eq!(COLLECTOR_PACKAGE, "bloodhound-ce-python");
+        assert_eq!(COLLECTOR_BINARY, "bloodhound-ce-python");
+        assert_ne!(COLLECTOR_PACKAGE, "python-bloodhound");
     }
 }

--- a/crates/tools/src/installers/metasploit.rs
+++ b/crates/tools/src/installers/metasploit.rs
@@ -63,22 +63,10 @@ impl ToolInstaller for MetasploitInstaller {
         progress(InstallEvent::step(
             "Installing Metasploit via pacman (this is large, ~2GB)...",
         ));
-        let platform = get_platform();
-        let result = platform
-            .execute_command(
-                "pacman",
-                &["-S", "--noconfirm", "metasploit"],
-                // Metasploit is a large package; allow a generous timeout.
-                Duration::from_secs(1800),
-            )
-            .await?;
-
-        if result.exit_code != 0 {
-            return Err(Error::ToolExecution(format!(
-                "Failed to install metasploit: {}",
-                result.stderr
-            )));
-        }
+        // -Sy refreshes the package DBs first; a bare -S fails on a rootfs whose
+        // sync DBs have gone stale (see installers::pacman). Metasploit is a
+        // large package, so allow a generous timeout.
+        super::pacman::install("metasploit", Duration::from_secs(1800)).await?;
 
         if !Self::msfconsole_present().await {
             return Err(Error::ToolExecution(

--- a/crates/tools/src/installers/metasploit.rs
+++ b/crates/tools/src/installers/metasploit.rs
@@ -11,7 +11,6 @@
 
 use super::{InstallEvent, ProgressSink, ToolInstaller};
 use pentest_core::error::{Error, Result};
-use pentest_platform::{get_platform, CommandExec};
 use std::time::Duration;
 
 use crate::installers::sandbox_enabled;
@@ -25,12 +24,7 @@ pub struct MetasploitInstaller;
 
 impl MetasploitInstaller {
     async fn msfconsole_present() -> bool {
-        let platform = get_platform();
-        platform
-            .execute_command("which", &["msfconsole"], Duration::from_secs(5))
-            .await
-            .map(|r| r.exit_code == 0)
-            .unwrap_or(false)
+        super::binary_on_path("msfconsole").await
     }
 }
 

--- a/crates/tools/src/installers/mod.rs
+++ b/crates/tools/src/installers/mod.rs
@@ -74,6 +74,32 @@ pub(crate) fn sandbox_enabled() -> bool {
     false
 }
 
+/// Return true if `binary` resolves on PATH in the current execution
+/// environment (sandbox when enabled, host otherwise).
+///
+/// Uses the POSIX `command -v` shell builtin rather than the `which` binary:
+/// the minimal BlackArch sandbox rootfs does **not** ship `which`, so a
+/// `which <bin>` probe fails with "command not found" even for a tool that is
+/// correctly installed (e.g. certipy/kerbrute land in `/usr/sbin` but the
+/// post-install check reported them missing). `command -v` is a builtin of
+/// every POSIX shell, so it works in both the sandbox and on the host.
+///
+/// The binary name is passed as a positional shell argument (`sh -c '...' _ <bin>`
+/// referenced as `$1`), never interpolated into the script, so no shell-escaping
+/// of the name is required.
+pub(crate) async fn binary_on_path(binary: &str) -> bool {
+    let platform = pentest_platform::get_platform();
+    pentest_platform::CommandExec::execute_command(
+        &platform,
+        "sh",
+        &["-c", "command -v \"$1\" > /dev/null 2>&1", "sh", binary],
+        std::time::Duration::from_secs(5),
+    )
+    .await
+    .map(|r| r.exit_code == 0)
+    .unwrap_or(false)
+}
+
 /// A bespoke installer for one tool (or tool bundle) that cannot be installed
 /// by a single package-manager command.
 ///

--- a/crates/tools/src/installers/mod.rs
+++ b/crates/tools/src/installers/mod.rs
@@ -18,6 +18,7 @@
 mod bloodhound;
 mod metasploit;
 mod package;
+pub(crate) mod pacman;
 mod webwright;
 mod zap;
 

--- a/crates/tools/src/installers/package.rs
+++ b/crates/tools/src/installers/package.rs
@@ -105,21 +105,9 @@ impl ToolInstaller for PackageInstaller {
             self.display_name, self.pacman_package
         )));
 
-        let platform = get_platform();
-        let result = platform
-            .execute_command(
-                "pacman",
-                &["-S", "--noconfirm", self.pacman_package],
-                Duration::from_secs(600),
-            )
-            .await?;
-
-        if result.exit_code != 0 {
-            return Err(Error::ToolExecution(format!(
-                "Failed to install {}: {}",
-                self.pacman_package, result.stderr
-            )));
-        }
+        // -Sy refreshes the package DBs first; a bare -S fails on a rootfs whose
+        // sync DBs have gone stale (see installers::pacman).
+        super::pacman::install(self.pacman_package, Duration::from_secs(600)).await?;
 
         if !self.is_installed().await {
             return Err(Error::ToolExecution(format!(

--- a/crates/tools/src/installers/package.rs
+++ b/crates/tools/src/installers/package.rs
@@ -8,7 +8,6 @@
 
 use super::{InstallEvent, ProgressSink, ToolInstaller};
 use pentest_core::error::{Error, Result};
-use pentest_platform::{get_platform, CommandExec};
 use std::time::Duration;
 
 use crate::installers::sandbox_enabled;
@@ -74,12 +73,7 @@ impl ToolInstaller for PackageInstaller {
     }
 
     async fn is_installed(&self) -> bool {
-        let platform = get_platform();
-        platform
-            .execute_command("which", &[self.binary_name], Duration::from_secs(5))
-            .await
-            .map(|r| r.exit_code == 0)
-            .unwrap_or(false)
+        super::binary_on_path(self.binary_name).await
     }
 
     async fn install(&self, progress: &ProgressSink) -> Result<()> {

--- a/crates/tools/src/installers/pacman.rs
+++ b/crates/tools/src/installers/pacman.rs
@@ -1,0 +1,78 @@
+//! Shared pacman install helper for sandbox installers.
+//!
+//! Every sandbox tool install must refresh the package databases before
+//! installing. The rootfs setup syncs the DBs once ([`crate`]'s rootfs
+//! bootstrap runs `pacman -Syu`), but that sync is best-effort and goes stale:
+//! once the `core`/`extra`/`blackarch` sync DBs are missing or outdated, a bare
+//! `pacman -S <pkg>` fails with
+//! `database file for 'core' does not exist (use '-Sy' to download)`.
+//!
+//! Routing all sandbox installs through [`install`] guarantees the `-y` refresh
+//! happens first, mirroring what the Docker and WSL backends already do before
+//! their own installs.
+
+use pentest_core::error::{Error, Result};
+use pentest_platform::{get_platform, CommandExec};
+use std::time::Duration;
+
+/// Build the `pacman` argument vector for a sandbox package install.
+///
+/// The leading `-Sy` refreshes the package databases before resolving the
+/// target, which is the whole point: it prevents the "database file for 'core'
+/// does not exist" failure on a rootfs whose sync DBs have gone stale. This is
+/// a deliberate `-Sy` (not `-Syu`): the rootfs is fully upgraded once at setup,
+/// and a per-tool full-system upgrade would be slow and surprising. `--needed`
+/// makes re-runs idempotent (pacman skips an already-current package).
+pub(crate) fn install_args(pkg: &str) -> [&str; 4] {
+    ["-Sy", "--noconfirm", "--needed", pkg]
+}
+
+/// Install `pkg` inside the sandbox via `pacman -Sy --noconfirm --needed`.
+///
+/// Returns a `ToolExecution` error carrying pacman's stderr on non-zero exit.
+/// The caller is responsible for the pre-install "already present?" check and
+/// the post-install "binary on PATH?" verification — this helper owns only the
+/// database-refresh-and-install step that every sandbox installer shares.
+pub(crate) async fn install(pkg: &str, timeout: Duration) -> Result<()> {
+    let platform = get_platform();
+    let result = platform
+        .execute_command("pacman", &install_args(pkg), timeout)
+        .await?;
+
+    if result.exit_code != 0 {
+        return Err(Error::ToolExecution(format!(
+            "Failed to install {pkg}: {}",
+            result.stderr
+        )));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn install_args_refresh_db_before_installing() {
+        // The leading operation must be -Sy (refresh + sync), never a bare -S:
+        // a bare -S is exactly the bug that fails on a stale sync DB.
+        let args = install_args("python-bloodhound");
+        assert_eq!(args[0], "-Sy", "must refresh databases before install");
+        assert!(args.contains(&"--noconfirm"), "install must be unattended");
+        assert_eq!(
+            args.last().copied(),
+            Some("python-bloodhound"),
+            "package name must be the final argument"
+        );
+    }
+
+    #[test]
+    fn install_args_never_uses_bare_dash_s() {
+        let args = install_args("metasploit");
+        assert!(
+            !args.contains(&"-S"),
+            "bare -S skips the DB refresh and reintroduces the stale-DB failure"
+        );
+    }
+}

--- a/crates/tools/src/installers/webwright.rs
+++ b/crates/tools/src/installers/webwright.rs
@@ -58,11 +58,7 @@ impl ToolInstaller for WebwrightInstaller {
             "Installing webwright (Python package)...",
         ));
 
-        let uv_available = platform
-            .execute_command("which", &["uv"], Duration::from_secs(5))
-            .await
-            .map(|r| r.exit_code == 0)
-            .unwrap_or(false);
+        let uv_available = super::binary_on_path("uv").await;
 
         let git_spec = format!("git+{WEBWRIGHT_GIT_URL}");
 

--- a/crates/tools/src/installers/zap.rs
+++ b/crates/tools/src/installers/zap.rs
@@ -8,7 +8,6 @@
 
 use super::{InstallEvent, ProgressSink, ToolInstaller};
 use pentest_core::error::{Error, Result};
-use pentest_platform::{get_platform, CommandExec};
 use std::time::Duration;
 
 use crate::installers::sandbox_enabled;
@@ -25,14 +24,8 @@ pub struct ZapInstaller;
 
 impl ZapInstaller {
     async fn launcher_present() -> bool {
-        let platform = get_platform();
         for bin in ZAP_BINARIES {
-            if platform
-                .execute_command("which", &[bin], Duration::from_secs(5))
-                .await
-                .map(|r| r.exit_code == 0)
-                .unwrap_or(false)
-            {
+            if super::binary_on_path(bin).await {
                 return true;
             }
         }

--- a/crates/tools/src/installers/zap.rs
+++ b/crates/tools/src/installers/zap.rs
@@ -69,21 +69,9 @@ impl ToolInstaller for ZapInstaller {
         progress(InstallEvent::step(
             "Installing OWASP ZAP via pacman (zaproxy)...",
         ));
-        let platform = get_platform();
-        let result = platform
-            .execute_command(
-                "pacman",
-                &["-S", "--noconfirm", "zaproxy"],
-                Duration::from_secs(600),
-            )
-            .await?;
-
-        if result.exit_code != 0 {
-            return Err(Error::ToolExecution(format!(
-                "Failed to install zaproxy: {}",
-                result.stderr
-            )));
-        }
+        // -Sy refreshes the package DBs first; a bare -S fails on a rootfs whose
+        // sync DBs have gone stale (see installers::pacman).
+        super::pacman::install("zaproxy", Duration::from_secs(600)).await?;
 
         if !Self::launcher_present().await {
             return Err(Error::ToolExecution(

--- a/crates/ui/src/liveview_connector/mod.rs
+++ b/crates/ui/src/liveview_connector/mod.rs
@@ -769,12 +769,81 @@ impl LiveViewConnector {
         // once we see the first successful execute (or WS open). For now, emit
         // a best-effort Registered event after a short delay to indicate the
         // runner has started and is handling registration internally.
+        //
+        // We also probe the runner's `get_stats()` at that point and log a
+        // clear verdict (search: "[Connector]") so an operator can tell "the
+        // WS came up" from "still trying" without hunting for the SDK's own
+        // `Registered successfully` line in a fast-scrolling log. `running`
+        // plus a non-null `last_connected_at_ms` is the strongest cheap signal
+        // that the transport actually established; `reconnection_attempts` and
+        // `last_disconnect_reason` explain a stuck connector at a glance.
         let event_tx_clone = self.event_tx.clone();
+        let runner_probe = runner.clone();
         tokio::spawn(async move {
             // Give the runner time to connect and register
             tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
+            let stats = runner_probe.get_stats().await;
+            let running = stats
+                .get("running")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let ever_connected = stats
+                .get("last_connected_at_ms")
+                .map(|v| !v.is_null())
+                .unwrap_or(false);
+            if running && ever_connected {
+                tracing::info!(
+                    "[Connector] transport up 3s after startup: reconnects={} disconnects={} \
+                     heartbeat_rtt_last_ms={}",
+                    stats
+                        .get("reconnection_attempts")
+                        .cloned()
+                        .unwrap_or_default(),
+                    stats.get("total_disconnects").cloned().unwrap_or_default(),
+                    stats
+                        .get("heartbeat_rtt_last_ms")
+                        .cloned()
+                        .unwrap_or_default(),
+                );
+            } else {
+                tracing::warn!(
+                    "[Connector] transport NOT established 3s after startup \
+                     (running={} ever_connected={} last_disconnect_reason={}). Check host \
+                     reachability, TLS/cert settings, and auth token; the runner keeps retrying \
+                     with backoff.",
+                    running,
+                    ever_connected,
+                    stats
+                        .get("last_disconnect_reason")
+                        .cloned()
+                        .unwrap_or_default(),
+                );
+            }
             let _ = event_tx_clone.send(ConnectorEvent::StatusChanged(ConnectorStatus::Registered));
         });
+
+        // One-time startup summary. The SDK runner logs its registration/OTT/
+        // keepalive internals at debug and emits no user-facing events, so at
+        // `info` there is no single line confirming *what* this connector is
+        // trying to be. Emit a compact, greppable banner (search: "[Connector]")
+        // so an operator staring at a fast-scrolling poll log can confirm the
+        // host, tenant, identity, and whether an auth token is present without
+        // reconstructing it from a dozen debug lines.
+        tracing::info!(
+            "[Connector] starting: host={} tenant={} instance_id={} connector_name={} \
+             matrix_api_url={} auth_token={} aggression={:?}",
+            self.config.host,
+            self.config.tenant_id,
+            self.config.instance_id,
+            self.config.connector_name,
+            self.derive_matrix_api_url(),
+            if self.config.auth_token.is_empty() {
+                "absent"
+            } else {
+                "present"
+            },
+            self.config.aggression_level,
+        );
 
         // Run the connector — this blocks until shutdown or non-recoverable error
         match runner.run().await {

--- a/justfile
+++ b/justfile
@@ -47,7 +47,7 @@ matrix_api := env_var_or_default("MATRIX_API_URL", "https://studio.strike48.test
 matrix_tenant := env_var_or_default("MATRIX_TENANT_ID", "*")
 
 # Run headless agent in dev mode against studio.strike48.test
-dev STRIKE48_HOST="wss://studio.strike48.test" MATRIX_API_URL="https://studio.strike48.test" MATRIX_TENANT_ID="*" INSTANCE_ID="pick-dev" MATRIX_TLS_INSECURE="true" RUST_LOG="debug" STRIKE48_ACCEPT_INVALID_CERTS="true" *ARGS="":
+dev STRIKE48_HOST="wss://studio.strike48.test" MATRIX_API_URL="https://studio.strike48.test" MATRIX_TENANT_ID="*" INSTANCE_ID="pick-dev" MATRIX_TLS_INSECURE="true" RUST_LOG="debug,hyper_util=warn,hyper=warn" STRIKE48_ACCEPT_INVALID_CERTS="true" *ARGS="":
     #!/usr/bin/env bash
     set -euo pipefail
     export STRIKE48_HOST="{{STRIKE48_HOST}}"

--- a/run-pentest.sh
+++ b/run-pentest.sh
@@ -50,7 +50,7 @@ else
     # Set defaults
     export STRIKE48_HOST="${STRIKE48_HOST:-ws://localhost:3030}"
     export STRIKE48_TENANT="${STRIKE48_TENANT:-non-prod}"
-    export RUST_LOG="${RUST_LOG:-debug}"
+    export RUST_LOG="${RUST_LOG:-debug,hyper_util=warn,hyper=warn}"
 fi
 
 # STRIKE48_API_URL gates the SDK's OTT origin allowlist (see


### PR DESCRIPTION
## Summary

Fixes #238. On a non-root Linux desktop, launching the interactive sandboxed shell (and, it turned out, installing tools) failed. The original report was `Permission denied (os error 13)` from the PTY shell; investigating on an Ubuntu 24.04 host surfaced a chain of related backend-selection bugs, all fixed here.

**Root cause (deeper than first thought):** it is not "bwrap vs proot preference." On Ubuntu 24.04+, `bwrap::is_available()` reported bwrap as usable when it was not — it trusted `kernel.unprivileged_userns_clone=1` but never accounted for `kernel.apparmor_restrict_unprivileged_userns=1`, which separately denies the uid-map setup. So every backend-selection path picked bwrap, then bwrap failed at runtime ("setting up uid map: Permission denied"). The PTY shell surfaced it as a spawn/early-exit failure; the tool-install path surfaced it as raw install errors.

## What changed

**1. Truthful bwrap availability (`bwrap.rs`)** — `is_available()` now confirms with a real `bwrap --unshare-user --uid 0 --gid 0 ...` probe (the exact operation AppArmor blocks), not a sysctl read. Cached in a process-global `OnceCell` so "install all" doesn't re-probe per package. This is the central fix: with it, `detect_backend` selects a *working* backend for both the shell and tool installs.

**2. Backend order on Linux (`mod.rs`)** — `detect_backend` now tries `bwrap -> proot -> docker` on Linux (was `bwrap -> docker -> proot`). proot uses ptrace with no per-command container spin-up and works on desktops without Docker; Docker-per-command is slow and unrepresentative. Docker remains the last-resort Linux fallback and the primary sandbox on macOS (unchanged, cfg-gated).

**3. proot env injection (`pty_shell.rs`)** — `build_proot_cmd` set the guest env (`HOME=/root`, `PATH`, `TERM`) as host *process* env via `CommandBuilder::env()`. Under portable-pty that makes the spawn fail with EACCES (it resolves the child context against `HOME=/root`, which does not exist on the host). Now passed *inside* the guest via `/usr/bin/env KEY=VAL ...`, matching the WSL builder and bwrap's `--setenv`. Latent bug affecting every proot PTY shell.

**4. Symmetric spawn + early-exit fallback (`pty_shell.rs`)** — defense-in-depth for the interactive shell: if the selected namespace backend fails to spawn with EACCES, or spawns and dies immediately during init, retry the sibling backend (bwrap<->proot) on a fresh PTY rather than hard-failing. Pure decision functions (`namespace_sibling`, `fallback_backend_for`) are unit-tested; the live path has an ignored end-to-end test.

**5. Root detection hardening / H1 (`mod.rs`, `bwrap.rs`)** — replaced the PATH-spoofable `id -u` shell-out with `libc::geteuid()` via a shared `is_effective_root()`, used in both backend selection and the `--cap-add ALL` capability gate (the check that most needs to be non-spoofable). Root->bwrap preference gated to Linux.

## Verification

Verified end-to-end on an Ubuntu 24.04 host (`apparmor_restrict_unprivileged_userns=1`, bwrap present but unusable, proot available):

- `is_available()` correctly reports bwrap unusable; `detect_backend` selects **proot** (not bwrap, not Docker).
- The ignored end-to-end test `sandboxed_shell_is_alive_after_backend_fallback` produces a live, responsive shell.
- Interactive shell and tool-install paths both use proot.

Test plan:

- [x] `cargo fmt --all` clean
- [x] `cargo test --package pentest-platform --package pentest-core --lib --locked --features pentest-platform/desktop-pcap` (256 core + 38 platform, incl. new tests)
- [x] `cargo clippy --workspace --locked --features pentest-platform/desktop-pcap -- -D warnings` clean
- [x] `cargo check --workspace --locked --features pentest-platform/desktop-pcap` (incl. downstream pentest-ui)
- [x] Manual: sandboxed shell lands in BlackArch rootfs via proot on the affected host

## Acceptance criteria (from #238)

- [x] Non-root Linux desktop: sandboxed shell no longer fails with EACCES; a working backend is selected.
- [x] bwrap used only when actually usable; otherwise proot; Docker as last resort (macOS unchanged).
- [x] Backend selection covered by unit tests (root/non-root, sibling fallback, error kinds).
- [x] No public signature changes; downstream `pentest-ui` compiles unchanged.

## Follow-ups (filed, not blocking)

- #241 relabel the Native/Proot toggle to Sandboxed/Native (UI leaks an implementation detail)
- #242 surface backend fallback to the operator, not just logs
- #243 SandboxManager reports a stale backend after an EACCES fallback (config drift)
- #244 signal sandbox-disabled state in the Tools UI; reconcile DISABLE_SANDBOX vs shell_mode

Out of scope here (separate subsystem): the BlackArch rootfs pacman databases can be stale, so `pacman -S <pkg>` without `-Sy` fails with "database file for 'core' does not exist". That is tool-install provisioning, not sandbox selection; will file separately.


Update (review follow-up): the non-interactive tool path in `command.rs`
fail-opens to host execution when the sandbox errors (pre-existing, distinct
from the interactive PTY path which fails closed). Now tracked as #256.
