### PR TITLE
fix(#184): fail-closed grounding guardrail — agent can no longer fabricate tool results

### DIFF
--- a/MANUAL_TEST_THREE_AGENT_PIPELINE.md
+++ b/MANUAL_TEST_THREE_AGENT_PIPELINE.md
@@ -12,11 +12,19 @@ git fetch fork feature/three-agent-pipeline
 git checkout feature/three-agent-pipeline
 
 # 2. Build
-cargo build
+#    The `inject_test_evidence` tool used below is a dev/test-only fabrication
+#    path (pick#184) and is NOT registered unless you opt in at build time.
+#    Enable the feature so the steps that call it work:
+cargo build --features pentest-tools/inject-test-evidence
 
 # 3. Verify environment
 cat .env | grep -E "STRIKE48_HOST|TENANT_ID"
 ```
+
+> **Note (pick#184):** `inject_test_evidence` is only registered when the
+> connector is built with the `inject-test-evidence` feature. A default/release
+> build will not expose it (the tool would reply "Unknown tool"). The real-tool
+> test suites below (nmap, service banner, whatweb) do not need the feature.
 
 ## Quick Smoke Test (5 minutes)
 

--- a/crates/core/src/orchestrator.rs
+++ b/crates/core/src/orchestrator.rs
@@ -168,6 +168,17 @@ pub enum GateError {
     /// highlight the offenders.
     #[error("{} evidence node(s) are still pending validation: {}", .pending_ids.len(), .pending_ids.join(", "))]
     PendingNodes { pending_ids: Vec<String> },
+
+    /// At least one publishable finding lacks [`Provenance`] tying it to real
+    /// tool output. The report must never present a finding the agent asserted
+    /// without a grounding tool result, so the gate fails closed (pick#184).
+    /// The offending node IDs are included so the UI can name them.
+    ///
+    /// The remedy is to ground the finding in a real tool run — never to
+    /// attach synthetic provenance to satisfy the gate, which would defeat the
+    /// guardrail.
+    #[error("{} finding(s) lack tool-output provenance and cannot be published (ungrounded): {}", .ids.len(), .ids.join(", "))]
+    UngroundedFindings { ids: Vec<String> },
 }
 
 /// Build a [`ValidatedFindingsManifest`] from the current evidence graph.
@@ -193,6 +204,24 @@ pub fn gate_for_report(
         .collect();
     if !pending_ids.is_empty() {
         return Err(GateError::PendingNodes { pending_ids });
+    }
+
+    // Fail closed on ungrounded findings (pick#184). A finding that will be
+    // published (Confirmed/Revised) must carry `Provenance` tying it to real
+    // tool output; otherwise it is a claim with no backing tool result and must
+    // never reach the report. We anchor on `is_publishable_finding()` rather
+    // than a `node_type` string (which is free-form) so this catches every
+    // finding headed for the report. InfoOnly / FalsePositive / context nodes
+    // are intentionally exempt — they are not published findings. This check
+    // follows the Pending gate: an un-adjudicated node is reported as Pending
+    // first, since its provenance is not yet the operator's concern.
+    let ungrounded: Vec<String> = nodes
+        .iter()
+        .filter(|n| n.is_publishable_finding() && n.provenance.is_none())
+        .map(|n| n.id.clone())
+        .collect();
+    if !ungrounded.is_empty() {
+        return Err(GateError::UngroundedFindings { ids: ungrounded });
     }
 
     let findings: Vec<ManifestFinding> = nodes
@@ -459,6 +488,19 @@ mod tests {
         EngagementInfo::new("10.0.0.0/24", ts()).with_completed_at(ts())
     }
 
+    /// Provenance a real finding-producing tool would attach. Every finding
+    /// node in production carries one (verified across all evidence producers),
+    /// so test fixtures for publishable findings attach it too — otherwise the
+    /// fail-closed grounding gate (pick#184) would reject them.
+    fn provenance() -> Provenance {
+        Provenance::new(
+            "nmap",
+            "7.95",
+            ProbeCommand::from_exact("nmap -sV 10.0.0.1"),
+            "Nmap scan report",
+        )
+    }
+
     fn confirmed_finding(id: &str, sev: Severity) -> EvidenceNode {
         let mut n = EvidenceNode::new(
             id,
@@ -468,7 +510,8 @@ mod tests {
             "10.0.0.1",
             sev,
             "initial rationale",
-        );
+        )
+        .with_provenance(provenance());
         n.apply_validator_decision(sev, "validator confirmed");
         n
     }
@@ -482,7 +525,8 @@ mod tests {
             "10.0.0.1",
             from,
             "initial rationale",
-        );
+        )
+        .with_provenance(provenance());
         n.apply_validator_decision(to, "severity adjusted after reproducing");
         n
     }
@@ -561,6 +605,7 @@ mod tests {
             GateError::PendingNodes { pending_ids } => {
                 assert_eq!(pending_ids, vec!["p1", "p2"]);
             }
+            other => panic!("expected PendingNodes, got {other:?}"),
         }
     }
 
@@ -636,19 +681,77 @@ mod tests {
 
     #[test]
     fn manifest_preserves_provenance_for_publishable_findings() {
-        let mut n = confirmed_finding("c1", Severity::High);
-        n.provenance = Some(Provenance::new(
-            "nmap",
-            "7.95",
-            ProbeCommand::from_exact("nmap -sV 10.0.0.1"),
-            "Nmap scan report",
-        ));
+        // confirmed_finding already carries provenance (as every real finding
+        // does); assert the gate passes it through into the manifest.
+        let n = confirmed_finding("c1", Severity::High);
         let manifest = gate_for_report(&[n], engagement()).unwrap();
         let prov = manifest.findings[0]
             .provenance
             .as_ref()
             .expect("provenance preserved in manifest");
         assert_eq!(prov.underlying_tool, "nmap");
+    }
+
+    // --- Fail-closed grounding gate (pick#184 Lever 3) --------------------
+
+    #[test]
+    fn gate_rejects_publishable_finding_without_provenance() {
+        // A Confirmed finding with no provenance is an ungrounded claim — the
+        // agent asserted it with no backing tool result. The gate must refuse.
+        let mut n = confirmed_finding("ungrounded", Severity::High);
+        n.provenance = None;
+        let err = gate_for_report(&[n], engagement()).unwrap_err();
+        match err {
+            GateError::UngroundedFindings { ids } => {
+                assert_eq!(ids, vec!["ungrounded".to_string()]);
+            }
+            other => panic!("expected UngroundedFindings, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn gate_rejects_revised_finding_without_provenance() {
+        // Revised is publishable too, so the grounding requirement applies.
+        let mut n = revised_finding("rev", Severity::High, Severity::Medium);
+        n.provenance = None;
+        let err = gate_for_report(&[n], engagement()).unwrap_err();
+        assert!(matches!(err, GateError::UngroundedFindings { .. }));
+    }
+
+    #[test]
+    fn gate_accepts_publishable_finding_with_provenance() {
+        // The happy path: a grounded, adjudicated finding publishes.
+        let manifest =
+            gate_for_report(&[confirmed_finding("c1", Severity::High)], engagement()).unwrap();
+        assert_eq!(manifest.findings.len(), 1);
+    }
+
+    #[test]
+    fn gate_ignores_missing_provenance_on_non_published_nodes() {
+        // InfoOnly and FalsePositive nodes are not published findings, so the
+        // grounding requirement does not apply — even without provenance the
+        // gate must not reject them (info_only/false_positive build no prov).
+        let nodes = [info_only("i1"), false_positive("fp1")];
+        let manifest =
+            gate_for_report(&nodes, engagement()).expect("non-published nodes need no provenance");
+        assert_eq!(manifest.findings.len(), 0);
+        assert_eq!(manifest.context_nodes.len(), 1);
+        assert_eq!(manifest.counts.false_positives, 1);
+    }
+
+    #[test]
+    fn gate_reports_pending_before_ungrounded() {
+        // A still-Pending node and an ungrounded published finding together:
+        // the Pending gate fires first (provenance is not yet the operator's
+        // concern for an un-adjudicated node).
+        let mut ungrounded = confirmed_finding("c1", Severity::High);
+        ungrounded.provenance = None;
+        let nodes = [pending("p1"), ungrounded];
+        let err = gate_for_report(&nodes, engagement()).unwrap_err();
+        assert!(
+            matches!(err, GateError::PendingNodes { .. }),
+            "Pending must be reported before UngroundedFindings, got {err:?}"
+        );
     }
 
     #[test]

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -459,6 +459,36 @@ impl ToolSchema {
     }
 }
 
+/// Whether a tool actually completed a probe, distinct from whether it
+/// "succeeded".
+///
+/// `success` is a legacy boolean that conflates two very different things: a
+/// tool that ran and legitimately found nothing (`success:true`, empty data)
+/// vs. one that failed to probe at all (which several wrappers *also* reported
+/// as `success:true`). That ambiguity is the fabrication substrate #184
+/// closes: the model cannot tell "ran, found nothing" from "never ran," so it
+/// fills the gap. `ToolOutcome` makes the distinction explicit and trustworthy.
+///
+/// Serialized `snake_case` and defaulted to [`ToolOutcome::Ran`] so payloads
+/// from older connectors (which omit the field) deserialize unchanged over the
+/// Matrix wire — no lockstep backend deploy required.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolOutcome {
+    /// The tool ran to completion; `data` is trustworthy. A zero-finding scan
+    /// that genuinely ran is still `Ran` (a truthful empty result).
+    #[default]
+    Ran,
+    /// The tool did not complete a real probe (nonzero exit, timeout,
+    /// unparseable output, crash). `data` is NOT trustworthy — the model and
+    /// the report gate must treat it as "no data," never as a finding.
+    Failed,
+    /// A precondition was not met (missing dependency, unsupported platform),
+    /// so the probe never started. Distinct from `Failed`: nothing went wrong,
+    /// the work simply did not run.
+    Skipped,
+}
+
 /// Result from a tool execution.
 ///
 /// `provenance` is `Option` because not every tool produces a finding —
@@ -466,6 +496,11 @@ impl ToolSchema {
 /// Tools that produce findings (scanners, probes, exploits) must attach a
 /// `Provenance` so the Report Agent can render a reproducible evidence
 /// block. See [`crate::provenance`] and GitHub issue #52.
+///
+/// `outcome` distinguishes "ran" from "failed"/"skipped" so a functional
+/// failure can never masquerade as a legitimate empty result (#184). It is
+/// additive and defaulted for wire compatibility; `success` is retained
+/// unchanged.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ToolResult {
     pub success: bool,
@@ -474,6 +509,9 @@ pub struct ToolResult {
     pub duration_ms: u64,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provenance: Option<Provenance>,
+    /// Whether the tool actually completed a probe. See [`ToolOutcome`].
+    #[serde(default)]
+    pub outcome: ToolOutcome,
 }
 
 impl ToolResult {
@@ -485,6 +523,7 @@ impl ToolResult {
             error: None,
             duration_ms: 0,
             provenance: None,
+            outcome: ToolOutcome::Ran,
         }
     }
 
@@ -496,10 +535,15 @@ impl ToolResult {
             error: None,
             duration_ms,
             provenance: None,
+            outcome: ToolOutcome::Ran,
         }
     }
 
-    /// Create an error result
+    /// Create an error result.
+    ///
+    /// An error means the tool did not complete a real probe, so the outcome
+    /// is [`ToolOutcome::Failed`] — the structured "this did not run" signal
+    /// the model and report gate rely on (#184).
     pub fn error(message: impl Into<String>) -> Self {
         Self {
             success: false,
@@ -507,6 +551,7 @@ impl ToolResult {
             error: Some(message.into()),
             duration_ms: 0,
             provenance: None,
+            outcome: ToolOutcome::Failed,
         }
     }
 
@@ -518,6 +563,21 @@ impl ToolResult {
             error: Some(message.into()),
             duration_ms,
             provenance: None,
+            outcome: ToolOutcome::Failed,
+        }
+    }
+
+    /// Create a skipped result: a precondition was not met (missing
+    /// dependency, unsupported platform) so the probe never started. Distinct
+    /// from an error — nothing went wrong, the work simply did not run (#184).
+    pub fn skipped(message: impl Into<String>) -> Self {
+        Self {
+            success: false,
+            data: Value::Null,
+            error: Some(message.into()),
+            duration_ms: 0,
+            provenance: None,
+            outcome: ToolOutcome::Skipped,
         }
     }
 
@@ -525,6 +585,28 @@ impl ToolResult {
     /// this before returning.
     pub fn with_provenance(mut self, provenance: Provenance) -> Self {
         self.provenance = Some(provenance);
+        self
+    }
+
+    /// Override the outcome classification.
+    ///
+    /// Use when a tool ran the subprocess but the run was not a completed
+    /// probe — e.g. `execute_command` with a nonzero exit or a timeout — so it
+    /// can keep the captured stdout/stderr in `data` while still telling the
+    /// model and the report gate the probe did not complete (`Failed`). See
+    /// [`ToolOutcome`] and #184.
+    ///
+    /// Enforces the `success`/`outcome` invariant: a `Failed` or `Skipped`
+    /// probe is never a success. `success = true, outcome = Failed` is a
+    /// contradiction and exactly the ambiguity #184 exists to remove, so it is
+    /// unrepresentable through this builder. Setting `Ran` leaves `success`
+    /// untouched.
+    #[must_use = "with_outcome consumes self; assign the returned result or the outcome is lost"]
+    pub fn with_outcome(mut self, outcome: ToolOutcome) -> Self {
+        self.outcome = outcome;
+        if matches!(outcome, ToolOutcome::Failed | ToolOutcome::Skipped) {
+            self.success = false;
+        }
         self
     }
 }
@@ -868,6 +950,101 @@ fn levenshtein_distance(s1: &str, s2: &str) -> usize {
     }
 
     matrix[len1][len2]
+}
+
+#[cfg(test)]
+mod tool_outcome_tests {
+    //! pick#184 Lever 2: `ToolOutcome` must distinguish a completed probe from
+    //! a failed/skipped one, and the field must be additive + wire-compatible
+    //! so older connector payloads (which omit it) still deserialize.
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn success_constructors_are_ran() {
+        assert_eq!(ToolResult::success(json!({})).outcome, ToolOutcome::Ran);
+        assert_eq!(
+            ToolResult::success_with_duration(json!({}), 5).outcome,
+            ToolOutcome::Ran
+        );
+    }
+
+    #[test]
+    fn error_constructors_are_failed() {
+        // An error is the structured "did not complete a probe" signal (#184).
+        assert_eq!(ToolResult::error("boom").outcome, ToolOutcome::Failed);
+        assert_eq!(
+            ToolResult::error_with_duration("boom", 5).outcome,
+            ToolOutcome::Failed
+        );
+    }
+
+    #[test]
+    fn skipped_constructor_is_skipped_and_not_success() {
+        let r = ToolResult::skipped("dependency missing");
+        assert_eq!(r.outcome, ToolOutcome::Skipped);
+        assert!(!r.success);
+    }
+
+    #[test]
+    fn with_outcome_overrides() {
+        let r = ToolResult::success(json!({})).with_outcome(ToolOutcome::Failed);
+        assert_eq!(r.outcome, ToolOutcome::Failed);
+    }
+
+    #[test]
+    fn with_outcome_failed_or_skipped_forces_success_false() {
+        // `success=true, outcome=Failed` is the exact ambiguity #184 removes;
+        // the builder must make it unrepresentable.
+        let failed = ToolResult::success(json!({})).with_outcome(ToolOutcome::Failed);
+        assert!(!failed.success);
+        let skipped = ToolResult::success(json!({})).with_outcome(ToolOutcome::Skipped);
+        assert!(!skipped.success);
+        // Ran leaves success untouched.
+        let ran = ToolResult::success(json!({})).with_outcome(ToolOutcome::Ran);
+        assert!(ran.success);
+    }
+
+    #[test]
+    fn legacy_json_without_outcome_deserializes_as_ran() {
+        // A payload from an older connector omits `outcome` entirely. It must
+        // deserialize as `Ran` (the pre-#184 implicit contract), not error.
+        let legacy = json!({
+            "success": true,
+            "data": {"ports": []},
+            "error": null,
+            "duration_ms": 12
+        });
+        let r: ToolResult = serde_json::from_value(legacy).unwrap();
+        assert_eq!(r.outcome, ToolOutcome::Ran);
+        assert!(r.success);
+    }
+
+    #[test]
+    fn outcome_round_trips_snake_case() {
+        for (oc, wire) in [
+            (ToolOutcome::Ran, "\"ran\""),
+            (ToolOutcome::Failed, "\"failed\""),
+            (ToolOutcome::Skipped, "\"skipped\""),
+        ] {
+            assert_eq!(serde_json::to_string(&oc).unwrap(), wire);
+            let back: ToolOutcome = serde_json::from_str(wire).unwrap();
+            assert_eq!(back, oc);
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_timed_err_arm_yields_failed_outcome() {
+        // The Err branch of execute_timed is the shared path scanner wrappers
+        // now flow through on a nonzero exit; it must stamp Failed.
+        let r = execute_timed(|| async {
+            Err::<serde_json::Value, _>(crate::error::Error::ToolExecution("nonzero exit".into()))
+        })
+        .await
+        .unwrap();
+        assert_eq!(r.outcome, ToolOutcome::Failed);
+        assert!(!r.success);
+    }
 }
 
 #[cfg(test)]

--- a/crates/tools/Cargo.toml
+++ b/crates/tools/Cargo.toml
@@ -10,6 +10,11 @@ default = ["desktop"]
 desktop = ["pentest-platform/desktop"]
 android = ["pentest-platform/android"]
 ios = ["pentest-platform/ios"]
+# Dev/test only: registers `inject_test_evidence`, which pushes arbitrary
+# fabricated findings into the evidence graph. NEVER enable in release builds —
+# it is a grounding-guardrail bypass (pick#184). Off by default so production
+# connectors never advertise or expose the tool.
+inject-test-evidence = []
 
 [dependencies]
 # Core

--- a/crates/tools/src/execute_command.rs
+++ b/crates/tools/src/execute_command.rs
@@ -4,8 +4,8 @@ use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::provenance::{truncate_excerpt, ProbeCommand, Provenance};
 use pentest_core::tools::{
-    execute_timed_with_provenance, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed_with_provenance, ParamType, PentestTool, Platform, ToolContext, ToolOutcome,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -61,15 +61,22 @@ impl PentestTool for ExecuteCommandTool {
     async fn execute(&self, params: Value, ctx: &ToolContext) -> Result<ToolResult> {
         let workspace_path = ctx.workspace_path.clone();
 
-        execute_timed_with_provenance(|| async move {
-            let platform = get_platform();
+        // Command execution unsupported here → the probe never ran. Return
+        // Skipped directly (precondition unmet), before timing, so we never
+        // have to string-match an error message to recover this case (#184).
+        if !get_platform().is_command_exec_supported() {
+            return Ok(ToolResult::skipped(
+                "Command execution not supported on this platform",
+            ));
+        }
 
-            // Check if command execution is supported
-            if !platform.is_command_exec_supported() {
-                return Err(pentest_core::error::Error::PlatformNotSupported(
-                    "Command execution not supported on this platform".into(),
-                ));
-            }
+        // Build the run future via the provenance-timed helper so timing and
+        // the error→Failed mapping stay consistent with every other tool. On
+        // success we then reclassify the outcome from the process exit status
+        // (see below) — a completed subprocess is not necessarily a completed
+        // probe (#184).
+        let run = execute_timed_with_provenance(|| async move {
+            let platform = get_platform();
 
             let command = params
                 .get("command")
@@ -127,7 +134,58 @@ impl PentestTool for ExecuteCommandTool {
 
             Ok((data, provenance))
         })
-        .await
+        .await?;
+
+        Ok(classify_command_outcome(run))
+    }
+}
+
+/// Reclassify a completed `execute_command` run's outcome from its process
+/// exit status (#184).
+///
+/// A subprocess that *ran* is not necessarily a *completed probe*. Applied only
+/// to a `Ran` result (an already-`Failed` result from the tool body — bad
+/// params, spawn failure — passes through unchanged; the unsupported-platform
+/// `Skipped` case is handled before this is reached). We downgrade to
+/// [`ToolOutcome::Failed`] — `with_outcome` also clears `success` — when:
+/// * the command timed out (never finished), or
+/// * it exited nonzero **and produced no stdout** (errored with nothing to show), or
+/// * the exit status is unreadable (fail closed — never assume success).
+///
+/// We deliberately do NOT fail a nonzero exit that still produced stdout: many
+/// legitimate tools use nonzero exit codes as signal (`grep` with no match,
+/// `diff`, `test`), and their stdout is real output the model may need. A zero
+/// exit with empty stdout stays [`ToolOutcome::Ran`] — a truthful empty result.
+///
+/// The captured stdout/stderr/exit_code stay in `data` in every case, for the
+/// model's diagnostic use.
+fn classify_command_outcome(result: ToolResult) -> ToolResult {
+    // Only a `Ran` result needs reclassification from exit status. Anything
+    // already Failed/Skipped (the tool body returned Err, or the platform was
+    // unsupported) is left as-is.
+    if result.outcome != ToolOutcome::Ran {
+        return result;
+    }
+
+    let timed_out = result.data.get("timed_out").and_then(Value::as_bool) == Some(true);
+    let exit_code = result.data.get("exit_code").and_then(Value::as_i64);
+    let stdout_empty = result
+        .data
+        .get("stdout")
+        .and_then(Value::as_str)
+        .map(str::is_empty)
+        .unwrap_or(true);
+
+    // Fail closed: a run whose exit status we cannot read is not a trustworthy
+    // completed probe. The tool body always writes `exit_code`, so `None` here
+    // means an unexpected data shape — treat it as Failed, never assume success.
+    let failed =
+        timed_out || exit_code.is_none() || (exit_code.is_some_and(|c| c != 0) && stdout_empty);
+
+    if failed {
+        result.with_outcome(ToolOutcome::Failed)
+    } else {
+        result
     }
 }
 
@@ -252,5 +310,95 @@ mod tests {
         assert!(eff.contains("<REDACTED>"));
         // The exact command must retain the secret for internal traceability.
         assert!(prov.probe_commands[0].command.contains("hunter2"));
+    }
+
+    // --- classify_command_outcome (pick#184 Lever 2) ----------------------
+    //
+    // A completed subprocess is not necessarily a completed probe. These pin
+    // the exit-status → ToolOutcome mapping directly on the pure classifier so
+    // they are deterministic (no live subprocess needed).
+
+    /// Build a success-path ToolResult carrying the given process status, as
+    /// the tool body produces before classification.
+    fn ran(exit_code: i64, stdout: &str, timed_out: bool) -> ToolResult {
+        ToolResult::success(json!({
+            "stdout": stdout,
+            "stderr": "",
+            "exit_code": exit_code,
+            "timed_out": timed_out,
+            "duration_ms": 1,
+        }))
+    }
+
+    #[test]
+    fn zero_exit_with_output_is_ran() {
+        let r = classify_command_outcome(ran(0, "hello\n", false));
+        assert_eq!(r.outcome, ToolOutcome::Ran);
+        assert!(r.success);
+    }
+
+    #[test]
+    fn zero_exit_empty_stdout_is_ran_truthful_empty() {
+        // A command that ran cleanly and simply produced nothing is a truthful
+        // empty result — must stay trustworthy, not be downgraded.
+        let r = classify_command_outcome(ran(0, "", false));
+        assert_eq!(r.outcome, ToolOutcome::Ran);
+        assert!(r.success);
+    }
+
+    #[test]
+    fn nonzero_exit_empty_stdout_is_failed() {
+        // Errored and produced nothing — the fabrication substrate. Fail closed.
+        let r = classify_command_outcome(ran(1, "", false));
+        assert_eq!(r.outcome, ToolOutcome::Failed);
+        assert!(!r.success);
+    }
+
+    #[test]
+    fn nonzero_exit_with_stdout_stays_ran() {
+        // Many legit tools exit nonzero yet produce real output (`grep` no
+        // match, `diff`, `test`). Their stdout is real data — do NOT discard.
+        let r = classify_command_outcome(ran(1, "line-of-real-output\n", false));
+        assert_eq!(r.outcome, ToolOutcome::Ran);
+        assert!(r.success);
+    }
+
+    #[test]
+    fn timed_out_is_failed_even_with_partial_stdout() {
+        // A timeout never finished, so even partial stdout is untrustworthy.
+        let r = classify_command_outcome(ran(0, "partial output", true));
+        assert_eq!(r.outcome, ToolOutcome::Failed);
+        assert!(!r.success);
+    }
+
+    #[test]
+    fn missing_exit_code_fails_closed() {
+        // The tool body always writes exit_code; a missing one means an
+        // unexpected data shape. Never assume success — fail closed (#184).
+        let r = classify_command_outcome(ToolResult::success(json!({
+            "stdout": "",
+            "stderr": "something broke",
+            "timed_out": false,
+            // exit_code deliberately absent
+        })));
+        assert_eq!(r.outcome, ToolOutcome::Failed);
+        assert!(!r.success);
+    }
+
+    #[test]
+    fn already_failed_result_passes_through_unchanged() {
+        // A tool body that returned Err (bad params, spawn failure) is already
+        // Failed; classification must not touch it.
+        let r = classify_command_outcome(ToolResult::error("bad params"));
+        assert_eq!(r.outcome, ToolOutcome::Failed);
+        assert!(!r.success);
+    }
+
+    #[test]
+    fn skipped_result_passes_through_unchanged() {
+        // The unsupported-platform Skipped case is produced upstream in
+        // execute(); if one reaches the classifier it must survive.
+        let r = classify_command_outcome(ToolResult::skipped("unsupported platform"));
+        assert_eq!(r.outcome, ToolOutcome::Skipped);
     }
 }

--- a/crates/tools/src/external/ffuf.rs
+++ b/crates/tools/src/external/ffuf.rs
@@ -183,10 +183,15 @@ impl PentestTool for FfufTool {
                 .execute_command("ffuf", &args_refs, overall_timeout)
                 .await?;
 
-            if result.exit_code != 0 && result.stdout.is_empty() {
+            // Any nonzero exit means the fuzz run did not complete cleanly. A
+            // crashed/partial run cannot be trusted to have exhausted the
+            // wordlist, so we fail closed (Err → outcome=Failed) rather than
+            // parse partial output as a full result (#184). A genuine
+            // zero-finding run exits 0 and yields an empty (truthful) result set.
+            if result.exit_code != 0 {
                 return Err(pentest_core::error::Error::ToolExecution(format!(
-                    "ffuf failed: {}",
-                    result.stderr
+                    "ffuf failed (exit {}): {}",
+                    result.exit_code, result.stderr
                 )));
             }
 

--- a/crates/tools/src/external/masscan.rs
+++ b/crates/tools/src/external/masscan.rs
@@ -146,10 +146,15 @@ impl PentestTool for MasscanTool {
                 .execute_command("masscan", &args_refs, timeout)
                 .await?;
 
-            if result.exit_code != 0 && result.stdout.is_empty() {
+            // Any nonzero exit means the scan did not complete cleanly. A
+            // crashed/partial port scan cannot be trusted to enumerate *all*
+            // open ports, so we fail closed (Err → outcome=Failed) rather than
+            // parse partial output as a full result (#184). A genuine
+            // zero-finding scan exits 0 and parses to an empty (truthful) list.
+            if result.exit_code != 0 {
                 return Err(pentest_core::error::Error::ToolExecution(format!(
-                    "masscan failed: {}",
-                    result.stderr
+                    "masscan failed (exit {}): {}",
+                    result.exit_code, result.stderr
                 )));
             }
 

--- a/crates/tools/src/external/rustscan.rs
+++ b/crates/tools/src/external/rustscan.rs
@@ -132,10 +132,16 @@ impl PentestTool for RustScanTool {
                 .execute_command("rustscan", &args_refs, Duration::from_secs(300))
                 .await?;
 
-            if result.exit_code != 0 && result.stdout.is_empty() {
+            // Any nonzero exit means the scan did not complete cleanly. A
+            // crashed/partial port scan cannot be trusted to enumerate *all*
+            // open ports, so we fail closed (Err → outcome=Failed) rather than
+            // parse whatever partial stdout exists as if it were a full result
+            // (#184). A genuine zero-finding scan exits 0 and parses to an
+            // empty (but truthful) port list below.
+            if result.exit_code != 0 {
                 return Err(pentest_core::error::Error::ToolExecution(format!(
-                    "rustscan failed: {}",
-                    result.stderr
+                    "rustscan failed (exit {}): {}",
+                    result.exit_code, result.stderr
                 )));
             }
 

--- a/crates/tools/src/inject_test_evidence.rs
+++ b/crates/tools/src/inject_test_evidence.rs
@@ -2,6 +2,16 @@
 //!
 //! This tool allows manual testing of the Validator → Report pipeline
 //! by creating sample evidence nodes with various severities and types.
+//!
+//! # Dev/test only — never ships in release (pick#184)
+//!
+//! This tool pushes arbitrary, caller-supplied findings (with fabricated
+//! provenance) straight into the evidence graph, bypassing the grounding
+//! guardrail. It is registered in [`crate::create_tool_registry`] **only**
+//! under the opt-in `inject-test-evidence` cargo feature, which must never be
+//! enabled in a release build. The module stays compiled unconditionally so
+//! its own unit test builds under `cargo test`; only the registry registration
+//! and the `InjectTestEvidenceTool` re-export are feature-gated.
 
 use async_trait::async_trait;
 use pentest_core::error::Result;

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -67,6 +67,12 @@ pub use external::{
     TheHarvesterTool, TsharkTool, UnicornscanTool, Wafw00fTool, WaybackurlsTool, WfuzzTool,
     WhatwebTool, WhoisTool, WpscanTool, XsstrikeTool, ZapTool,
 }; // External tools
+
+// Only re-exported when the opt-in dev/test feature is on (pick#184). The
+// module itself stays compiled so its own `#[cfg(test)]` unit test builds under
+// `cargo test`; the tool is just not surfaced to callers of the registry in
+// release builds.
+#[cfg(feature = "inject-test-evidence")]
 pub use inject_test_evidence::InjectTestEvidenceTool;
 pub use lateral_movement::LateralMovementTool;
 pub use list_files::ListFilesTool;
@@ -237,7 +243,11 @@ pub fn create_tool_registry() -> ToolRegistry {
     registry.register(WriteFileTool);
     registry.register(ListFilesTool);
 
-    // Testing tools
+    // Testing tools — `inject_test_evidence` pushes arbitrary fabricated
+    // findings into the evidence graph, so it is a grounding-guardrail bypass
+    // (pick#184). Gate it behind an opt-in feature so release builds never
+    // register or advertise it; dev/test builds enable it explicitly.
+    #[cfg(feature = "inject-test-evidence")]
     registry.register(InjectTestEvidenceTool);
 
     // Data transformation and analysis
@@ -310,5 +320,43 @@ mod webwright_tests {
         assert_eq!(json_schema["name"], "webwright");
         assert!(json_schema["parameters"]["properties"]["mode"].is_object());
         assert!(json_schema["parameters"]["properties"]["start_url"].is_object());
+    }
+}
+
+#[cfg(test)]
+mod inject_test_evidence_gating {
+    //! pick#184 Lever 1: `inject_test_evidence` injects arbitrary fabricated
+    //! findings into the evidence graph, so it must never ship in release
+    //! builds. It is gated behind the opt-in `inject-test-evidence` feature.
+    //! These two tests pin both sides of that gate; each runs only in the build
+    //! configuration where its assertion is true.
+    use super::*;
+
+    /// Default/release build (the configuration CI's `cargo test` uses): the
+    /// tool must be absent from the registry. This is the security-critical
+    /// assertion — if it fails, a fabrication path shipped.
+    #[cfg(not(feature = "inject-test-evidence"))]
+    #[test]
+    fn inject_test_evidence_absent_from_default_registry() {
+        let registry = create_tool_registry();
+        assert!(
+            registry.get("inject_test_evidence").is_none(),
+            "inject_test_evidence must NOT be registered without the \
+             `inject-test-evidence` feature — it is a grounding-guardrail \
+             bypass and must never ship in release builds (pick#184)"
+        );
+    }
+
+    /// With the opt-in feature enabled (dev/test), the tool is available.
+    /// Run via `cargo test -p pentest-tools --features inject-test-evidence`.
+    #[cfg(feature = "inject-test-evidence")]
+    #[test]
+    fn inject_test_evidence_present_when_feature_enabled() {
+        let registry = create_tool_registry();
+        assert!(
+            registry.get("inject_test_evidence").is_some(),
+            "inject_test_evidence should be registered when the \
+             `inject-test-evidence` feature is enabled"
+        );
     }
 }

--- a/crates/ui/src/components/chat_panel/constants.rs
+++ b/crates/ui/src/components/chat_panel/constants.rs
@@ -250,6 +250,8 @@ For every finding:
 - Describe reproduction steps clearly
 - Note affected target and impact assessment
 
+**Grounding rule (non-negotiable):** Every tool result carries an `outcome` field. Only `outcome: "ran"` results are grounded data you may act on. A result with `outcome: "failed"` (the tool crashed, timed out, or errored) or `outcome: "skipped"` (a dependency or platform precondition was not met) means **the probe did not run** — treat it as *no data*, exactly as if the tool had never been called. Never create an EvidenceNode, assert a finding, or narrate a result from a `failed` or `skipped` tool call. If a probe you needed came back `failed`/`skipped`, either retry it, try a different tool, or state plainly that the check could not be completed — do not fill the gap with an assumed result. A finding must always trace to a real `ran` tool result.
+
 The Validator Agent will review your findings. The Report Agent will compile validated evidence into the final penetration test report.
 
 ## Operational Framework

--- a/crates/ui/tests/evidence_pipeline.rs
+++ b/crates/ui/tests/evidence_pipeline.rs
@@ -20,12 +20,16 @@
 //! drained node never reached it), so the finding could never appear in a
 //! report. This test fails closed if any of those seams regress.
 
+use pentest_core::evidence::EvidenceNode;
+use pentest_core::export::Severity;
 use pentest_core::orchestrator::{
     build_pending_evidence_manifest, gate_for_report, parse_validator_verdicts, EngagementInfo,
     GateError,
 };
 use pentest_core::provenance::{ProbeCommand, Provenance};
+use pentest_core::tools::{PentestTool, ToolContext, ToolOutcome};
 use pentest_tools::evidence_producer::{evidence_from_nmap, push_evidence};
+use pentest_tools::ExecuteCommandTool;
 use pentest_ui::session;
 use serde_json::{json, Value};
 use std::sync::{Mutex, MutexGuard};
@@ -324,6 +328,86 @@ fn drain_is_safe_under_concurrent_tool_execution() {
         total_pushed,
         "the graph must contain every forwarded node with no duplicates"
     );
+
+    session::clear_evidence();
+}
+
+/// pick#184 fail-closed grounding, on the production path. Two guarantees, end
+/// to end without a network or a live agent:
+///
+/// 1. A tool that fails to complete a probe surfaces a structured `Failed`
+///    outcome the model can trust — proven by running the real
+///    `ExecuteCommandTool` with a command that exits nonzero and prints
+///    nothing.
+/// 2. A finding with no tool-output provenance cannot reach the report — proven
+///    by adjudicating an ungrounded node to Confirmed and asserting the real
+///    `gate_for_report` refuses it with `UngroundedFindings`.
+///
+/// Before #184 the first was an indistinguishable `success:true` empty and the
+/// second passed the gate silently.
+#[tokio::test]
+async fn failed_tool_is_flagged_and_ungrounded_finding_cannot_reach_report() {
+    // (1) Run a real command that exits nonzero with empty stdout. On a host
+    // without command exec this returns Skipped; either way the outcome must
+    // NOT be a trustworthy `Ran`, and `success` must be false. This half
+    // touches no shared global evidence state, so it needs no serial guard —
+    // which also keeps us from holding a std Mutex across the `.await`.
+    let result = ExecuteCommandTool
+        .execute(
+            json!({ "command": "false", "args": [], "timeout_seconds": 10 }),
+            &ToolContext::default(),
+        )
+        .await
+        .expect("execute_command returns Ok(ToolResult) even on failure");
+    // Assert `!= Ran` rather than `== Failed` on purpose: both outcomes are
+    // correct depending on the host. With command exec available, "false"
+    // exits nonzero with empty stdout → Failed; without it, the tool returns
+    // Skipped before running. Either way it is not a trustworthy completed
+    // probe, which is all #184 requires here.
+    assert_ne!(
+        result.outcome,
+        ToolOutcome::Ran,
+        "a nonzero-exit empty command must not be reported as a completed probe"
+    );
+    assert!(
+        !result.success,
+        "a failed/skipped probe must not be a success"
+    );
+
+    // (2) An ungrounded finding must never reach the report. This half touches
+    // the shared evidence graph, so take the serial guard now — after the await
+    // above, so no lock is held across it.
+    let _guard = serial();
+    session::clear_evidence();
+
+    // Simulate the Red Team asserting a finding with no backing tool result: a
+    // node with no provenance. It is validated to Confirmed (clearing the
+    // Pending gate) so the ONLY thing between it and the report is grounding.
+    let mut ungrounded = EvidenceNode::new(
+        "ungrounded-claim",
+        "finding",
+        "Fabricated admin panel",
+        "Model asserted this with no tool output backing it.",
+        "10.0.0.9",
+        Severity::High,
+        "no grounding",
+    );
+    // No `.with_provenance(...)` — this is the whole point.
+    ungrounded.apply_validator_decision(Severity::High, "validator waved it through");
+    assert!(ungrounded.is_publishable_finding());
+    push_evidence(ungrounded).expect("push to buffer");
+    session::drain_tool_evidence_into_graph();
+
+    let snapshot = session::evidence_snapshot();
+    match gate_for_report(&snapshot, engagement()) {
+        Err(GateError::UngroundedFindings { ids }) => {
+            assert!(
+                ids.contains(&"ungrounded-claim".to_string()),
+                "the ungrounded finding must be named as the blocker, got {ids:?}"
+            );
+        }
+        other => panic!("gate must fail closed on an ungrounded finding, got {other:?}"),
+    }
 
     session::clear_evidence();
 }

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -239,7 +239,7 @@ Complete reference of all penetration testing tools available in Pick.
 |------|------|-------------|---------------|
 | `screenshot` | Native | Screen capture (base64 PNG) | No |
 | `traffic_capture` | Native | Network packet capture (PCAP) | Yes |
-| `inject_test_evidence` | Native | Test tool for three-agent pipeline | No |
+| `inject_test_evidence` | Native | Test tool for three-agent pipeline (dev/test only — requires the `inject-test-evidence` build feature; never registered in release, pick#184) | No |
 | `tshark` | External | Network protocol analyzer | Yes |
 
 ### Session Management


### PR DESCRIPTION
## Summary

Fixes #184. For a pentest platform whose premise is "no hallucinations — ground every claim in real tool output," the agent could present findings that never happened. Three independent code weaknesses combined to allow it; this PR closes each with a code-level backstop. Prompt anti-fabrication text stays, but is no longer the only defense.

Delivered as three reviewable commits (one per lever).

## The three levers

### Lever 1 — remove the production fabrication path (`1e63bd5`)
`inject_test_evidence` pushes arbitrary, caller-supplied findings (with fabricated provenance) straight into the evidence graph, and it shipped registered in every build. Gated behind a new off-by-default `inject-test-evidence` cargo feature, so release/default builds never register or advertise it. The module stays compiled (its own unit test still builds); only the registry registration and re-export are gated.

A cargo feature (not `cfg(debug_assertions)`) is deliberate: it is deterministically testable in both directions and decoupled from the build profile. The security-critical assertion — tool absent from the default registry — runs in normal CI.

### Lever 2 — distinguish "failed" from "empty" (`608e5db`)
A degraded/failed tool run was indistinguishable from a genuine zero-finding run: only a `success` bool separated them, and several tools set `success:true` on functional failure. That ambiguity is the fabrication substrate — the model can't tell "ran, found nothing" from "never ran," so it fills the gap.

- Additive, wire-compatible `ToolOutcome { Ran, Failed, Skipped }` on `ToolResult` (`#[serde(default)]` → older connector payloads without the field deserialize as `Ran`; `success` unchanged). `with_outcome` enforces the invariant that Failed/Skipped is never a success.
- `execute_command`: marks a run `Failed` on timeout, on nonzero exit **with empty stdout**, or on unreadable exit status (fail closed) — while deliberately keeping a nonzero exit that produced stdout as `Ran` (grep/diff/test exit nonzero legitimately). Unsupported platform → `Skipped`. stdout/stderr/exit_code stay in `data`.
- Scanner wrappers (rustscan, ffuf, masscan): any nonzero exit fails closed instead of parsing partial/empty output as a full result. A genuine zero-finding scan still exits 0 and yields a truthful empty set.
- Red-team prompt: a non-negotiable grounding rule — `failed`/`skipped` results are "no data"; never create a node or narrate a finding from one. (The schema field is inert without this clause.)

### Lever 3 — require grounding at the report gate (`e31b55d`)
`gate_for_report` refused Pending nodes but did not require provenance; `EvidenceNode.provenance` is `Option` and `None` passed. It now fails closed on any publishable finding (Confirmed/Revised) whose provenance is `None`, via a new `GateError::UngroundedFindings { ids }`. Anchored on `is_publishable_finding()` (not a free-form `node_type` string); InfoOnly/FalsePositive/context nodes are exempt. Ordered after the Pending gate. **Never** auto-attaches synthetic provenance — it blocks, per the issue guardrail.

## Why this is safe (verified preconditions)

- The #172/#174 Validator round-trip is live on `main` (PR #190), so a real node can be cleared from `Pending` — Lever 3 does not weld a deadlock shut.
- Every finding-producing tool already attaches provenance (verified across all 8 evidence-producer sites), so the gate passes legitimate findings and blocks only ungrounded ones. Fixtures updated to match production reality.

## Scope limit (please note)

These levers make the **report** trustworthy (report ← manifest ← gated graph ← provenance-bearing tool pushes). They do **not** fully close the **chat-narration** path: the red-team agent's free-text reply can still *claim* a finding that never entered the graph — there is no code seam between LLM conversational text and the operator. Post-fix the *report* is grounded; the *transcript* remains prompt-governed. A follow-up (surface `outcome=Failed` in the transcript, or a narration grounding cross-check) should track that. This PR does not claim fabrication is now impossible everywhere — it closes the report path and the three named code weaknesses.

## Test plan

- [x] `cargo clippy -p pentest-core -p pentest-tools -p pentest-ui --features connector,desktop --all-targets -- -D warnings` — clean (both `inject-test-evidence` on and off)
- [x] `cargo fmt --all -- --check` — clean
- [x] Lever 1: `inject_test_evidence` absent from default registry, present under the feature (both states tested)
- [x] Lever 2: `ToolOutcome` constructor mapping, `with_outcome` invariant, snake_case + legacy-JSON wire compat, `execute_timed` Err→Failed, full `classify_command_outcome` truth table (incl. fail-closed on missing exit_code)
- [x] Lever 3: gate rejects ungrounded Confirmed/Revised, accepts grounded, exempts non-published nodes, reports Pending before Ungrounded
- [x] Production-path integration test (`evidence_pipeline.rs`): a real failed `execute_command` surfaces `outcome=Failed`, and an ungrounded finding cannot pass `gate_for_report` — both halves of #184 proven on the non-test path
- [x] Full `pentest-core` + `pentest-tools` + `pentest-ui` suites green; existing tests unchanged

## Deferred (by design, follow-ups)

- Lever 2 applied to `execute_command` + rustscan/ffuf/masscan (the port/dir-scan finding vectors). The remaining ~20 scanner/OSINT wrappers should get the same treatment in a follow-up — kept out of this PR to stay reviewable.
- Chat-narration grounding (the scope limit above).