### PR TITLE
fix(#245): sync pacman DB before installing tools (-Sy)

### DIFF
--- a/crates/tools/src/external/install.rs
+++ b/crates/tools/src/external/install.rs
@@ -70,10 +70,15 @@ pub async fn ensure_tool_installed(
         "Installing '{}' via pacman package '{}'...",
         binary_name, pacman_package
     );
+    // `-Sy` (refresh DB, then install) rather than a bare `-S`: a rootfs whose
+    // sync databases are stale or were never synced makes `-S` fail with
+    // "database file for 'core' does not exist ... target not found". `--needed`
+    // keeps re-runs idempotent. This mirrors the `installers::pacman` helper,
+    // which documents the full rationale for the sandbox installers.
     let install = platform
         .execute_command(
             "pacman",
-            &["-S", "--noconfirm", pacman_package],
+            &["-Sy", "--noconfirm", "--needed", pacman_package],
             Duration::from_secs(300),
         )
         .await?;
@@ -137,7 +142,9 @@ pub async fn install_tools_batch(platform: &impl CommandExec, packages: &[&str])
 
     info!("Batch installing {} packages...", packages.len());
 
-    let mut args = vec!["-S", "--noconfirm"];
+    // `-Sy` (refresh DB then install) so a stale/unsynced rootfs DB doesn't make
+    // the whole batch fail with "target not found" (see ensure_tool_installed).
+    let mut args = vec!["-Sy", "--noconfirm", "--needed"];
     args.extend_from_slice(packages);
 
     let install = platform


### PR DESCRIPTION
## Summary

Fixes #245. Installing a tool into the sandbox failed when the rootfs pacman databases were stale/unsynced:

```
warning: database file for 'core' does not exist (use '-Sy' to download)
error: target not found: python-bloodhound
```

The installers ran `pacman -S <pkg>` without refreshing the package DB, so a rootfs whose sync databases were not current had nothing to resolve against.

## Change

`crates/tools/src/external/install.rs` now uses `pacman -Sy --noconfirm --needed` (refresh DB, then install) instead of a bare `-S` in both install sites:

- `ensure_tool_installed` (single) — the path used by ~50 external tool wrappers (nmap, masscan, hydra, nikto, the network/web/specialized/postexploit/wireless families, ...)
- `install_tools_batch` (batch)

`--needed` keeps re-runs idempotent (pacman skips an already-current package).

## Scope note (rebased onto main)

This branch originally also patched the four sandbox installers (`bloodhound`, `metasploit`, `package`, `zap`). Since then, `main` (#239/#253) refactored those installers to route through a shared `installers::pacman::install` helper that already runs `pacman -Sy --noconfirm --needed`. Those changes are now redundant, so this branch has been rebased and reduced to the one remaining unfixed site: `external/install.rs`. Its flags and comment are aligned with that shared helper so the crate carries a single pacman-install convention.

## Why `-Sy` and not `-Syu`

`-Sy` fixes the missing-DB error and self-heals a stale rootfs without a full system upgrade on every install. It matches the shared `installers::pacman` helper and `RootfsManager::initial_pacman_sync` (`pacman -Sy`), and the rootfs already gets a `-Syu` at provisioning, so the partial-upgrade risk is acceptable for this ephemeral pentest sandbox. A full `-Syu` per install was explicitly ruled out (slow).

## Test plan

- [x] `cargo check -p pentest-tools --features desktop --lib` clean
- [x] `cargo clippy -p pentest-tools --features desktop --all-targets -- -D warnings` clean
- [x] `cargo test -p pentest-tools --features desktop --lib` — 293 pass
- [ ] Manual: install a tool (e.g. nmap) into a sandbox with a stale rootfs DB and confirm it succeeds
