### PR TITLE
feat: default to sandboxed (proot) shell mode everywhere

### DIFF
--- a/apps/desktop/src/main.rs
+++ b/apps/desktop/src/main.rs
@@ -11,7 +11,7 @@ const DESKTOP_CONFIG: ConnectorAppConfig = ConnectorAppConfig {
     platform_name: "Desktop",
     container_class: "mobile-app",
     shell_route_mode: ShellMode::Native,
-    default_proot: false,
+    default_proot: true,
     start_liveview_server: true,
     inject_css: false,
     extra_init_messages: &[],

--- a/apps/web/src/main.rs
+++ b/apps/web/src/main.rs
@@ -12,7 +12,7 @@ const WEB_CONFIG: ConnectorAppConfig = ConnectorAppConfig {
     platform_name: "Web (Liveview)",
     container_class: "mobile-app",
     shell_route_mode: ShellMode::Native,
-    default_proot: false,
+    default_proot: true,
     start_liveview_server: false,
     inject_css: false,
     extra_init_messages: &["Tools execute on the server machine."],

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -9,9 +9,10 @@ use crate::aggression::AggressionLevel;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum ShellMode {
     /// Run commands directly on the host machine (native shell)
-    #[default]
     Native,
-    /// Run commands inside the proot BlackArch environment
+    /// Run commands inside the sandboxed BlackArch environment (bwrap/proot).
+    /// Default: the connector sandboxes tool execution out of the box.
+    #[default]
     Proot,
 }
 


### PR DESCRIPTION
## Summary

Make the sandboxed BlackArch environment (proot/bwrap) the **default** execution mode across all surfaces, so pentest tools are sandboxed out of the box instead of running on the host.

## Changes

- `ShellMode::default()`: `Native` -> `Proot`. This is the default for `AppSettings::default()` and any fresh/absent settings, so **headless** (which reads `shell_mode` straight from settings) also defaults to sandboxed.
- `apps/desktop` and `apps/web`: `default_proot` `false` -> `true`, matching `apps/mobile` (already `true`).

## Behavior

- **First-run only.** The per-app `default_proot` seed only applies when `last_config.is_none()`; it never overrides an existing user choice.
- **Existing users unaffected.** A persisted `shell_mode` deserializes to its stored value; only fresh installs pick up the new default.
- **User-reversible.** Native remains selectable in Settings.
- **On-demand rootfs download.** Selecting Proot triggers a BlackArch rootfs download the first time a shell/tool runs (`ensure_ready` -> `ensure_rootfs`). The UI already gates the Proot option behind `blackarch_downloaded` and downloads on demand — a known, handled path (mobile ships `default_proot=true`).

## Rationale

Sandboxing tool execution by default is the safer, higher-value posture for a pentest connector and matches the product intent. It also aligns desktop/web with mobile.

## Depends on / relates to

Builds on the #238/#239 sandbox-selection fixes (a working backend is now selected on AppArmor-restricted Linux hosts) and #245/#246 (tool installs sync the pacman DB). Those should land first so the default lands on a working sandbox.

Related follow-ups: #241 (relabel toggle), #244 (surface sandbox state / reconcile switches).

## Test plan

- [x] `cargo test -p pentest-core --lib` (256 pass)
- [x] `cargo clippy --workspace --locked --features pentest-platform/desktop-pcap -- -D warnings` clean
- [x] `cargo check --workspace` clean
- [ ] Manual: fresh install (no prior settings) starts in Proot; existing settings with Native are preserved
