### PR TITLE
fix: exclude AD suite from default installs; show install time estimate

### DIFF
--- a/crates/tools/src/catalog.rs
+++ b/crates/tools/src/catalog.rs
@@ -66,7 +66,48 @@ pub struct CatalogEntry {
     pub state: InstallState,
 }
 
+/// Rough expected install duration, in seconds, for a dependency. Used only to
+/// drive the UI's elapsed-vs-estimate progress bar — it is a soft hint, never a
+/// guarantee. The command layer runs installs to completion without streaming
+/// byte-level progress, so a true percentage is not available; a labeled
+/// estimate is the honest signal we can give.
+///
+/// Values are deliberately generous (a bar that fills slightly slow reads
+/// better than one that pins at 100% and keeps spinning). The default covers a
+/// single `pacman`/`apt` package fetch on a warm mirror; heavyweight custom
+/// installers override by `id`.
+pub fn estimated_install_secs(method: &InstallMethod, binary_name: &str) -> u32 {
+    // Sensible per-mechanism defaults.
+    let base = match method {
+        // Manual installs are operator-driven; no automated timer applies.
+        InstallMethod::Manual { .. } => 0,
+        // A single package plus the -Sy DB refresh on the sandbox rootfs.
+        InstallMethod::Pacman => 90,
+        InstallMethod::AptHost => 60,
+        // Bespoke installers vary widely; refined by binary below.
+        InstallMethod::Custom { .. } => 120,
+    };
+
+    // Per-tool overrides for the installers whose real-world duration is far
+    // from the mechanism default. Keyed by the catalog binary name.
+    match binary_name {
+        // Metasploit pulls a very large package set + Ruby gems.
+        "msfconsole" => 360,
+        // ZAP downloads a sizable Java app bundle.
+        "zaproxy" | "zap" => 150,
+        // webwright installs a Python env plus a Playwright Chromium download.
+        "webwright" => 180,
+        _ => base,
+    }
+}
+
 impl CatalogEntry {
+    /// Rough expected install duration in seconds. See
+    /// [`estimated_install_secs`]. `0` means no automated install (manual).
+    pub fn estimated_install_secs(&self) -> u32 {
+        estimated_install_secs(&self.install_method, &self.binary_name)
+    }
+
     /// Whether this entry can be installed automatically in the current mode.
     pub fn is_auto_installable(&self) -> bool {
         match &self.install_method {
@@ -357,6 +398,10 @@ pub struct CatalogItem {
     pub manual_instructions: Option<String>,
     /// Tools that declared this dependency.
     pub used_by: Vec<String>,
+    /// Rough expected install duration in seconds, for the UI's
+    /// elapsed-vs-estimate progress bar. `0` for manual-only entries. Soft hint.
+    #[serde(default)]
+    pub estimated_secs: u32,
 }
 
 impl From<&CatalogEntry> for CatalogItem {
@@ -381,6 +426,7 @@ impl From<&CatalogEntry> for CatalogItem {
             auto_installable: e.is_auto_installable(),
             manual_instructions: e.manual_instructions(),
             used_by: e.used_by.clone(),
+            estimated_secs: e.estimated_install_secs(),
         }
     }
 }
@@ -633,6 +679,7 @@ mod tests {
             auto_installable: true,
             manual_instructions: None,
             used_by: vec!["zap".into()],
+            estimated_secs: 150,
         };
         let json = serde_json::to_string(&item).unwrap();
         let back: CatalogItem = serde_json::from_str(&json).unwrap();
@@ -685,6 +732,75 @@ mod tests {
         deduped.dedup();
         assert_eq!(cats.len(), deduped.len(), "categories must be distinct");
         assert!(cats.iter().any(|c| c == "active_directory"));
+    }
+
+    #[test]
+    fn estimated_secs_defaults_by_method_and_overrides_by_binary() {
+        // Mechanism defaults.
+        assert_eq!(
+            estimated_install_secs(&InstallMethod::Pacman, "nmap"),
+            90,
+            "pacman default"
+        );
+        assert_eq!(
+            estimated_install_secs(&InstallMethod::AptHost, "some-apt-tool"),
+            60,
+            "apt default"
+        );
+        assert_eq!(
+            estimated_install_secs(
+                &InstallMethod::Custom {
+                    id: "certipy".into()
+                },
+                "certipy"
+            ),
+            120,
+            "custom default"
+        );
+        // Manual has no automated timer.
+        assert_eq!(
+            estimated_install_secs(
+                &InstallMethod::Manual {
+                    url: None,
+                    instructions: "x".into()
+                },
+                "burpsuite"
+            ),
+            0,
+            "manual = 0"
+        );
+        // Heavyweight per-binary overrides beat the mechanism default.
+        assert_eq!(
+            estimated_install_secs(
+                &InstallMethod::Custom {
+                    id: "metasploit".into()
+                },
+                "msfconsole"
+            ),
+            360,
+            "metasploit override"
+        );
+        assert!(
+            estimated_install_secs(&InstallMethod::Custom { id: "zap".into() }, "zaproxy")
+                > estimated_install_secs(&InstallMethod::Pacman, "nmap"),
+            "zap should estimate longer than a plain pacman package"
+        );
+    }
+
+    #[tokio::test]
+    async fn ad_suite_is_not_in_recommended_default_set() {
+        // Specialized AD-engagement tooling must not be swept in by the bulk
+        // "install all recommended" action (the operator installs it on demand).
+        let catalog = build_catalog().await;
+        for bin in ["bloodhound-python", "certipy", "kerbrute", "nxc"] {
+            let entry = catalog.iter().find(|e| e.binary_name == bin);
+            if let Some(entry) = entry {
+                assert!(
+                    !entry.recommended,
+                    "{bin} must be opt-in, not part of the recommended default set"
+                );
+            }
+        }
     }
 
     #[tokio::test]

--- a/crates/tools/src/external/ad/bloodhound.rs
+++ b/crates/tools/src/external/ad/bloodhound.rs
@@ -63,7 +63,10 @@ impl PentestTool for BloodHoundTool {
                     "BloodHound AD data collector (bloodhound-python ingestor)",
                 )
                 .custom_installer("bloodhound")
-                .category(ToolCategory::ActiveDirectory),
+                .category(ToolCategory::ActiveDirectory)
+                // Specialized AD-engagement tooling: installed on explicit
+                // operator action, not swept in by "install all recommended".
+                .recommended(false),
             )
             .param(ToolParam::required(
                 "domain",

--- a/crates/tools/src/external/ad/certipy.rs
+++ b/crates/tools/src/external/ad/certipy.rs
@@ -52,7 +52,10 @@ impl PentestTool for CertipyTool {
                     "Certipy - Active Directory Certificate Services (AD CS) attack tool",
                 )
                 .custom_installer("certipy")
-                .category(ToolCategory::ActiveDirectory),
+                .category(ToolCategory::ActiveDirectory)
+                // Specialized AD-engagement tooling: installed on explicit
+                // operator action, not swept in by "install all recommended".
+                .recommended(false),
             )
             .param(ToolParam::required(
                 "target",

--- a/crates/tools/src/external/ad/kerbrute.rs
+++ b/crates/tools/src/external/ad/kerbrute.rs
@@ -50,7 +50,10 @@ impl PentestTool for KerbruteTool {
                     "Kerbrute - Kerberos pre-auth username enumeration and password spraying",
                 )
                 .custom_installer("kerbrute")
-                .category(ToolCategory::ActiveDirectory),
+                .category(ToolCategory::ActiveDirectory)
+                // Specialized AD-engagement tooling: installed on explicit
+                // operator action, not swept in by "install all recommended".
+                .recommended(false),
             )
             .param(ToolParam::required(
                 "mode",

--- a/crates/tools/src/external/ad/netexec.rs
+++ b/crates/tools/src/external/ad/netexec.rs
@@ -52,7 +52,10 @@ impl PentestTool for NetExecTool {
                     "NetExec (nxc) - network service exploitation across SMB/WinRM/LDAP/MSSQL/SSH",
                 )
                 .custom_installer("netexec")
-                .category(ToolCategory::ActiveDirectory),
+                .category(ToolCategory::ActiveDirectory)
+                // Specialized AD-engagement tooling: installed on explicit
+                // operator action, not swept in by "install all recommended".
+                .recommended(false),
             )
             .param(ToolParam::required(
                 "protocol",

--- a/crates/ui/src/components/settings_page.rs
+++ b/crates/ui/src/components/settings_page.rs
@@ -82,6 +82,12 @@ pub fn SettingsPage(
     let mut installing = use_signal(|| None::<String>);
     let mut install_message = use_signal(String::new);
     let mut install_error = use_signal(|| None::<String>);
+    // Seconds elapsed since the current install began, ticked once a second by a
+    // background task while `installing` is Some. Drives the elapsed-vs-estimate
+    // progress bar so the operator can see how long an install is taking.
+    let mut install_elapsed = use_signal(|| 0u32);
+    // Expected duration (seconds) for the current install; 0 hides the estimate.
+    let mut install_estimate = use_signal(|| 0u32);
 
     // Load seed status on mount
     use_effect(move || {
@@ -99,6 +105,28 @@ pub fn SettingsPage(
             let items = pentest_tools::catalog::build_catalog_items().await;
             catalog_items.set(Some(items));
             catalog_loading.set(false);
+        });
+    });
+
+    // Tick the install elapsed clock once a second while an install is running.
+    // Reads `installing` reactively: the effect re-runs whenever an install
+    // starts or stops. The spawned loop exits as soon as `installing` clears (or
+    // changes), so at most one ticker is active at a time.
+    use_effect(move || {
+        let active = installing().is_some();
+        if !active {
+            return;
+        }
+        let started_for = installing();
+        spawn(async move {
+            loop {
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                // Stop if the install finished or a different one started.
+                if installing() != started_for {
+                    break;
+                }
+                install_elapsed.set(install_elapsed() + 1);
+            }
         });
     });
 
@@ -273,10 +301,23 @@ pub fn SettingsPage(
 
                     // Install all recommended (bulk) action
                     if installing() == Some("__all__".to_string()) {
-                        div { class: "sidebar-download-status",
-                            span { "Installing recommended tools... {install_message}" }
-                            div { class: "download-progress",
-                                div { class: "download-progress-fill indeterminate" }
+                        {
+                            let (fraction, label) = install_progress(install_elapsed(), install_estimate());
+                            rsx! {
+                                div { class: "sidebar-download-status",
+                                    span { "Installing recommended tools... {install_message}" }
+                                    div { class: "download-progress",
+                                        if install_estimate() > 0 {
+                                            div {
+                                                class: "download-progress-fill",
+                                                style: "width: {fraction * 100.0}%",
+                                            }
+                                        } else {
+                                            div { class: "download-progress-fill indeterminate" }
+                                        }
+                                    }
+                                    div { class: "text-dim-xs", "{label}" }
+                                }
                             }
                         }
                     } else {
@@ -284,8 +325,25 @@ pub fn SettingsPage(
                             class: "sidebar-download-btn",
                             disabled: installing().is_some(),
                             onclick: move |_| {
+                                // Estimate the bulk install as the sum of the
+                                // pending recommended, auto-installable entries.
+                                let estimate = catalog_items()
+                                    .map(|items| {
+                                        items
+                                            .iter()
+                                            .filter(|i| {
+                                                i.recommended
+                                                    && i.auto_installable
+                                                    && i.state != "installed"
+                                            })
+                                            .map(|i| i.estimated_secs)
+                                            .sum::<u32>()
+                                    })
+                                    .unwrap_or(0);
                                 spawn(async move {
                                     use tokio::sync::mpsc;
+                                    install_elapsed.set(0);
+                                    install_estimate.set(estimate);
                                     installing.set(Some("__all__".to_string()));
                                     install_error.set(None);
                                     install_message.set(String::new());
@@ -350,12 +408,25 @@ pub fn SettingsPage(
                                             // No action; chip shown above.
                                         } else if item.auto_installable {
                                             if installing() == Some(item.binary_name.clone()) {
-                                                div { style: "flex: 1; max-width: 240px;",
-                                                    div { class: "text-dim-xs",
-                                                        "Installing... {install_message}"
-                                                    }
-                                                    div { class: "download-progress",
-                                                        div { class: "download-progress-fill indeterminate" }
+                                                {
+                                                    let (fraction, label) = install_progress(install_elapsed(), install_estimate());
+                                                    rsx! {
+                                                        div { style: "flex: 1; max-width: 240px;",
+                                                            div { class: "text-dim-xs",
+                                                                "Installing... {install_message}"
+                                                            }
+                                                            div { class: "download-progress",
+                                                                if install_estimate() > 0 {
+                                                                    div {
+                                                                        class: "download-progress-fill",
+                                                                        style: "width: {fraction * 100.0}%",
+                                                                    }
+                                                                } else {
+                                                                    div { class: "download-progress-fill indeterminate" }
+                                                                }
+                                                            }
+                                                            div { class: "text-dim-xs", "{label}" }
+                                                        }
                                                     }
                                                 }
                                             } else {
@@ -364,10 +435,13 @@ pub fn SettingsPage(
                                                     disabled: installing().is_some(),
                                                     onclick: {
                                                         let bin = item.binary_name.clone();
+                                                        let estimate = item.estimated_secs;
                                                         move |_| {
                                                             let bin = bin.clone();
                                                             spawn(async move {
                                                                 use tokio::sync::mpsc;
+                                                                install_elapsed.set(0);
+                                                                install_estimate.set(estimate);
                                                                 installing.set(Some(bin.clone()));
                                                                 install_error.set(None);
                                                                 install_message.set(String::new());
@@ -1368,6 +1442,39 @@ pub fn SettingsPage(
     }
 }
 
+/// Turn elapsed and estimated install seconds into a progress fraction
+/// (`0.0..=0.95`) and a human label like `"0:42 elapsed · ~2:00 expected"`.
+///
+/// The fraction is capped below `1.0` while an install is running so the bar
+/// never claims completion before the install actually finishes; if the install
+/// overruns its estimate the bar holds near-full rather than resetting or
+/// looking stuck. When no estimate is available the fraction is `0.0` (callers
+/// render an indeterminate bar) and the label shows elapsed time only.
+fn install_progress(elapsed_secs: u32, estimate_secs: u32) -> (f64, String) {
+    let elapsed_label = format_duration(elapsed_secs);
+    if estimate_secs == 0 {
+        return (0.0, format!("{elapsed_label} elapsed"));
+    }
+    let fraction = (elapsed_secs as f64 / estimate_secs as f64).min(0.95);
+    let label = format!(
+        "{elapsed_label} elapsed \u{00b7} ~{} expected",
+        format_duration(estimate_secs)
+    );
+    (fraction, label)
+}
+
+/// Format a whole-second duration as `M:SS` (or `H:MM:SS` once past an hour).
+fn format_duration(secs: u32) -> String {
+    let h = secs / 3600;
+    let m = (secs % 3600) / 60;
+    let s = secs % 60;
+    if h > 0 {
+        format!("{h}:{m:02}:{s:02}")
+    } else {
+        format!("{m}:{s:02}")
+    }
+}
+
 /// Helper function to count how many resources in a tier are already seeded
 fn count_seeded_in_tier(status: &[(String, bool)], tier_resources: &[&str]) -> String {
     let seeded = tier_resources
@@ -1422,5 +1529,43 @@ fn humanize_category(category: &str) -> String {
             })
             .collect::<Vec<_>>()
             .join(" "),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_duration_renders_minutes_and_hours() {
+        assert_eq!(format_duration(0), "0:00");
+        assert_eq!(format_duration(9), "0:09");
+        assert_eq!(format_duration(75), "1:15");
+        assert_eq!(format_duration(600), "10:00");
+        assert_eq!(format_duration(3661), "1:01:01");
+    }
+
+    #[test]
+    fn install_progress_with_no_estimate_is_indeterminate() {
+        let (fraction, label) = install_progress(42, 0);
+        assert_eq!(fraction, 0.0, "no estimate => indeterminate (0.0)");
+        assert_eq!(label, "0:42 elapsed");
+    }
+
+    #[test]
+    fn install_progress_fills_toward_estimate() {
+        let (fraction, label) = install_progress(30, 120);
+        assert!((fraction - 0.25).abs() < 1e-9, "30/120 = 0.25");
+        assert_eq!(label, "0:30 elapsed \u{00b7} ~2:00 expected");
+    }
+
+    #[test]
+    fn install_progress_caps_below_full_when_overrunning() {
+        // Elapsed past the estimate must not claim 100% (or overflow past it).
+        let (fraction, _) = install_progress(600, 120);
+        assert!(
+            (fraction - 0.95).abs() < 1e-9,
+            "overrun must cap at 0.95, got {fraction}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Two related fixes to the Settings -> Tools install flow.

**1. AD suite no longer installed by a default install.**
"Install all recommended" sweeps every dependency whose `recommended` flag is
true. That flag defaults to `true`, so `bloodhound`, `certipy`, `kerbrute`, and
`netexec` were being installed by a plain default install despite being
specialized AD-engagement tooling. They now carry `.recommended(false)`,
matching the existing Metasploit/Burp precedent. Per-tool Install still installs
them on demand (`install_by_binary` deliberately ignores `recommended`).

**2. Install progress now shows how long it will take.**
The install UI previously rendered only an indeterminate animated bar. The
command layer runs installs to completion without streaming byte-level progress,
so a true percentage is not feasible; instead we surface a labeled time
estimate:

- `catalog::estimated_install_secs(method, binary)` returns a soft per-mechanism
  default (pacman 90s, apt 60s, custom 120s) with per-binary overrides for
  heavyweight installers (metasploit 360s, zap 150s, webwright 180s), exposed as
  `CatalogItem::estimated_secs`.
- A 1s ticker fills a determinate bar toward the estimate, capped at 95% until
  the install actually completes, with a `0:42 elapsed - ~2:00 expected` label.
  Bulk install estimates the sum of pending recommended entries. Tools without
  an estimate keep the indeterminate bar.

Estimates are deliberately soft hints (mirror speed / package size vary); the
bar is tuned to read slightly slow rather than pin at 100% and spin.

## Test plan

- [x] `cargo test --workspace --locked --features pentest-platform/desktop-pcap`
      - catalog 14/14 (incl. new `estimated_secs_defaults_by_method_and_overrides_by_binary`,
        `ad_suite_is_not_in_recommended_default_set`)
      - settings_page 4/4 (`format_duration`, three `install_progress` cases)
- [x] `cargo clippy --workspace --locked --features pentest-platform/desktop-pcap -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Live-verified in the web (liveview) app against a local Strike48 studio:
      AD suite shows individual Install buttons (not auto-installed); a BloodHound
      install showed the elapsed clock advancing 0:01 -> 0:02 against "~2:00 expected"
      with the determinate bar filling.

## Screenshot

Install in progress, showing the elapsed clock and estimate (and the AD suite now offered as individual opt-in installs rather than swept into the default set):

![install progress bar](https://raw.githubusercontent.com/Strike48-public/pick/pr-253-assets/.pr-assets/install-progress.png)
