### PR TITLE
fix: harden install-progress ticker and strengthen catalog tests

### DIFF
--- a/crates/tools/src/catalog.rs
+++ b/crates/tools/src/catalog.rs
@@ -836,6 +836,16 @@ mod tests {
             360,
             "metasploit override"
         );
+        assert_eq!(
+            estimated_install_secs(
+                &InstallMethod::Custom {
+                    id: "webwright".into()
+                },
+                "webwright"
+            ),
+            180,
+            "webwright override (Python env + Playwright Chromium download)"
+        );
         assert!(
             estimated_install_secs(&InstallMethod::Custom { id: "zap".into() }, "zaproxy")
                 > estimated_install_secs(&InstallMethod::Pacman, "nmap"),
@@ -849,13 +859,17 @@ mod tests {
         // "install all recommended" action (the operator installs it on demand).
         let catalog = build_catalog().await;
         for bin in ["bloodhound-python", "certipy", "kerbrute", "nxc"] {
-            let entry = catalog.iter().find(|e| e.binary_name == bin);
-            if let Some(entry) = entry {
-                assert!(
-                    !entry.recommended,
-                    "{bin} must be opt-in, not part of the recommended default set"
-                );
-            }
+            // Assert the entry EXISTS before checking its flag: without this the
+            // test would pass vacuously if a rename/refactor dropped the binary
+            // from the catalog, silently retiring the regression guard.
+            let entry = catalog
+                .iter()
+                .find(|e| e.binary_name == bin)
+                .unwrap_or_else(|| panic!("{bin} should be present in the catalog"));
+            assert!(
+                !entry.recommended,
+                "{bin} must be opt-in, not part of the recommended default set"
+            );
         }
     }
 

--- a/crates/ui/src/components/settings_page.rs
+++ b/crates/ui/src/components/settings_page.rs
@@ -89,6 +89,12 @@ pub fn SettingsPage(
     let mut install_elapsed = use_signal(|| 0u32);
     // Expected duration (seconds) for the current install; 0 hides the estimate.
     let mut install_estimate = use_signal(|| 0u32);
+    // Monotonic id for the current install session, bumped each time an install
+    // starts. A ticker captures the generation it was spawned for and stops as
+    // soon as a newer session begins, so a stale ticker can't advance the clock
+    // for a later install — even a restart of the same tool, where `installing`
+    // would otherwise look unchanged.
+    let mut install_generation = use_signal(|| 0u64);
 
     // Load seed status on mount
     use_effect(move || {
@@ -110,20 +116,24 @@ pub fn SettingsPage(
     });
 
     // Tick the install elapsed clock once a second while an install is running.
-    // Reads `installing` reactively: the effect re-runs whenever an install
-    // starts or stops. The spawned loop exits as soon as `installing` clears (or
-    // changes), so at most one ticker is active at a time.
+    // Reads `installing`/`install_generation` reactively, so the effect re-runs
+    // whenever an install starts, stops, or is replaced. The spawned loop
+    // captures the generation it was started for and exits as soon as a newer
+    // session begins; because a fresh session always bumps the generation, a
+    // stale ticker cannot advance the clock for a later install (including a
+    // restart of the same tool). The clock is reset here so the reset is atomic
+    // with the ticker spawn rather than racing the onclick handlers.
     use_effect(move || {
-        let active = installing().is_some();
-        if !active {
+        if installing().is_none() {
             return;
         }
-        let started_for = installing();
+        let generation = install_generation();
+        install_elapsed.set(0);
         spawn(async move {
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-                // Stop if the install finished or a different one started.
-                if installing() != started_for {
+                // Stop if this session was superseded or the install finished.
+                if install_generation() != generation || installing().is_none() {
                     break;
                 }
                 install_elapsed.set(install_elapsed() + 1);
@@ -343,7 +353,9 @@ pub fn SettingsPage(
                                     .unwrap_or(0);
                                 spawn(async move {
                                     use tokio::sync::mpsc;
-                                    install_elapsed.set(0);
+                                    // Bump the session id so any stale ticker
+                                    // stops; the ticker effect resets the clock.
+                                    install_generation.set(install_generation() + 1);
                                     install_estimate.set(estimate);
                                     installing.set(Some("__all__".to_string()));
                                     install_error.set(None);
@@ -427,7 +439,10 @@ pub fn SettingsPage(
                                                         let bin = bin.clone();
                                                         spawn(async move {
                                                             use tokio::sync::mpsc;
-                                                            install_elapsed.set(0);
+                                                            // Bump the session id so any stale
+                                                            // ticker stops; the ticker effect
+                                                            // resets the clock.
+                                                            install_generation.set(install_generation() + 1);
                                                             install_estimate.set(estimate);
                                                             installing.set(Some(bin.clone()));
                                                             install_error.set(None);


### PR DESCRIPTION
## Summary

Follow-up to #253 (merged), applying three fixes surfaced by a post-merge multi-agent review pass. #253 was squash-merged while the review was in flight, so these hardening changes land as a separate PR.

**1. Install-progress ticker race (settings_page.rs).**
The elapsed-clock ticker compared a captured `installing()` snapshot, leaving a narrow window where restarting an install within ~1s of the previous one could let a stale ticker advance the clock. Added a monotonic `install_generation` bumped on each install start; the ticker captures its generation and exits as soon as a newer session begins. The clock reset now lives in the ticker effect so it is atomic with the spawn rather than racing the onclick handlers. Impact was cosmetic (clock ticking slightly fast in a rare transition), never a crash or stuck state — this removes the window entirely and corrects the stale comment.

**2. AD-suite guard test could pass vacuously (catalog.rs).**
`ad_suite_is_not_in_recommended_default_set` used `if let Some(entry)` with no existence assertion, so a rename/refactor dropping a binary from the catalog would silently retire the regression guard for the primary #253 fix. Now asserts each binary is present before checking its `recommended` flag.

**3. Missing `webwright` estimate-override test (catalog.rs).**
The estimator test covered the metasploit (360s) and zap (150s) overrides but not webwright (180s), so a refactor could regress it to the Custom default undetected. Added the assertion.

## Test plan

- [x] `cargo test --workspace --locked --features pentest-platform/desktop-pcap` — catalog 14/14, settings_page 4/4
- [x] `cargo clippy --workspace --locked --features pentest-platform/desktop-pcap -- -D warnings` clean
- [x] `cargo fmt --all --check` clean