### PR TITLE
chore: gitignore .env backup copies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ logs/
 .env
 .env.local
 .env.*.local
+# Backups/copies of .env - secret-bearing, never commit (e.g. .env.bak-238).
+.env.bak
+.env.bak-*
+.env.*.bak
 
 # AI tooling local overlays — private, operator-specific, never committed.
 # See CLAUDE.md "Local Overrides" section.


### PR DESCRIPTION
## Summary

`.env` is gitignored, but ad-hoc backup copies like `.env.bak-238` are not, so a `git add -A` (or an editor's autosave copy) could commit a secret-bearing copy of `.env`. Those slip past the `.env` rule and would only be caught by the gitleaks full-history scan, after which a history rewrite is needed to remove them.

This adds `.env.bak`, `.env.bak-*`, and `.env.*.bak` to the tracked `.gitignore` so the protection is shared across all clones rather than living in each operator's local `.git/info/exclude`.

Scoped intentionally to env-backup patterns only. Personal build dirs (`target-check/`) and `.claude/` scratch stay clone-local, since `/target/` and `.claude/settings.local.json` are already the repo convention.

## Test plan

- [x] `git check-ignore` confirms `.env.bak-238`, `.env.bak`, `.env.production.bak` are now ignored
- [x] `.env`, `.env.local`, `.env.*.local` still ignored (unchanged behavior)
- [x] No tracked files are newly ignored (diff is additive, 4 lines)