### PR TITLE
feat(ui): redesign Settings Tools panel as category-grouped status grid

### DIFF
--- a/crates/ui/src/components/css/settings_page.css
+++ b/crates/ui/src/components/css/settings_page.css
@@ -480,6 +480,146 @@
 }
 
 /* ==========================================================================
+   Tools grid (category-grouped status cards)
+   ========================================================================== */
+
+.settings-tools-section {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-top: 12px;
+}
+
+.settings-tools-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.settings-tools-icon {
+    display: flex;
+    align-items: center;
+    width: 16px;
+    height: 16px;
+    line-height: 0;
+    color: var(--muted-foreground);
+}
+
+.settings-tools-icon svg {
+    width: 14px;
+    height: 14px;
+}
+
+.settings-tools-title {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--muted-foreground);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin: 0;
+}
+
+.settings-page .tools-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 8px;
+}
+
+/* One tool as a compact status card. Rendered either as a <div> (installed /
+   manual) or a <button> (missing + auto-installable, click-to-install). Reset
+   button chrome so both render identically. */
+.tool-status-card {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    padding: 10px 12px;
+    border: 1px solid var(--border);
+    border-left-width: 3px;
+    border-radius: 6px;
+    background: var(--background);
+    text-align: left;
+    font: inherit;
+    color: var(--foreground);
+    width: 100%;
+    min-width: 0;
+}
+
+/* Color-coded install state via the left border + status text. */
+.tool-status-card.installed {
+    border-left-color: #10b981;
+}
+
+.tool-status-card.missing {
+    border-left-color: var(--muted-foreground);
+    cursor: pointer;
+    transition: border-color 0.15s, background-color 0.15s;
+}
+
+.tool-status-card.missing:hover:not(:disabled) {
+    border-left-color: var(--primary);
+    background: var(--secondary);
+}
+
+.tool-status-card.missing:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.tool-status-card.manual {
+    border-left-color: var(--border);
+}
+
+.tool-status-card-name {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--foreground);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.tool-status-card-desc {
+    font-size: 11px;
+    color: var(--muted-foreground);
+    line-height: 1.35;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.tool-status-card-status {
+    font-size: 11px;
+    font-family: var(--font-mono);
+}
+
+.tool-status-card-status.installed {
+    color: #10b981;
+}
+
+.tool-status-card-status.action {
+    color: var(--primary);
+    font-weight: 600;
+}
+
+.tool-status-card-status.muted {
+    color: var(--muted-foreground);
+}
+
+.tool-status-card-instructions {
+    font-size: 10px;
+    font-family: var(--font-mono);
+    color: var(--muted-foreground);
+    line-height: 1.35;
+    white-space: pre-wrap;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+/* ==========================================================================
    Seed Resources
    ========================================================================== */
 

--- a/crates/ui/src/components/css/settings_page.css
+++ b/crates/ui/src/components/css/settings_page.css
@@ -555,14 +555,21 @@
     transition: border-color 0.15s, background-color 0.15s;
 }
 
-.tool-status-card.missing:hover:not(:disabled) {
+.tool-status-card.missing:hover:not([aria-disabled="true"]) {
     border-left-color: var(--primary);
     background: var(--secondary);
 }
 
-.tool-status-card.missing:disabled {
+/* Keyboard focus ring for the div[role=button] card. */
+.tool-status-card.missing:focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
+}
+
+.tool-status-card.missing[aria-disabled="true"] {
     opacity: 0.5;
     cursor: not-allowed;
+    pointer-events: none;
 }
 
 .tool-status-card.manual {

--- a/crates/ui/src/components/mod.rs
+++ b/crates/ui/src/components/mod.rs
@@ -36,6 +36,7 @@ pub mod status_bar;
 mod terminal;
 pub mod text_input;
 mod toast;
+mod tool_category;
 pub mod tools_page;
 mod wifi_warning_dialog;
 #[cfg(feature = "liveview")]

--- a/crates/ui/src/components/settings_page.rs
+++ b/crates/ui/src/components/settings_page.rs
@@ -404,44 +404,75 @@ pub fn SettingsPage(
                                                     }
                                                 }
                                             } else if item.auto_installable {
-                                                // Missing but installable: the whole card is a
-                                                // button so click-to-install is keyboard- and
-                                                // screen-reader-accessible without extra wiring.
+                                                // Missing but installable. The card is a
+                                                // div[role=button] (not a <button>) because it
+                                                // holds block-level children — a <button> may only
+                                                // contain phrasing content. tabindex + onkeydown
+                                                // restore the keyboard/AT affordances a native
+                                                // button would provide.
                                                 let installing_this =
                                                     installing() == Some(item.binary_name.clone());
-                                                let bin = item.binary_name.clone();
-                                                let estimate = item.estimated_secs;
-                                                rsx! {
-                                                    button {
-                                                        class: "tool-status-card missing",
-                                                        disabled: installing().is_some(),
-                                                        onclick: move |_| {
-                                                            let bin = bin.clone();
+                                                let disabled = installing().is_some();
+                                                // Shared install action, invoked from both click
+                                                // and Enter/Space. Guards on `installing` so only
+                                                // one install runs at a time (mirrors the old
+                                                // `disabled` on every button).
+                                                let start_install = {
+                                                    let bin = item.binary_name.clone();
+                                                    let estimate = item.estimated_secs;
+                                                    move || {
+                                                        if installing().is_some() {
+                                                            return;
+                                                        }
+                                                        let bin = bin.clone();
+                                                        spawn(async move {
+                                                            use tokio::sync::mpsc;
+                                                            install_elapsed.set(0);
+                                                            install_estimate.set(estimate);
+                                                            installing.set(Some(bin.clone()));
+                                                            install_error.set(None);
+                                                            install_message.set(String::new());
+                                                            let (tx, mut rx) = mpsc::unbounded_channel();
                                                             spawn(async move {
-                                                                use tokio::sync::mpsc;
-                                                                install_elapsed.set(0);
-                                                                install_estimate.set(estimate);
-                                                                installing.set(Some(bin.clone()));
-                                                                install_error.set(None);
-                                                                install_message.set(String::new());
-                                                                let (tx, mut rx) = mpsc::unbounded_channel();
-                                                                spawn(async move {
-                                                                    while let Some(msg) = rx.recv().await {
-                                                                        install_message.set(msg);
-                                                                    }
-                                                                });
-                                                                let progress = move |evt: pentest_tools::installers::InstallEvent| {
-                                                                    let _ = tx.send(evt.message);
-                                                                };
-                                                                match pentest_tools::catalog::install_by_binary(&bin, &progress).await {
-                                                                    Ok(()) => {
-                                                                        let items = pentest_tools::catalog::build_catalog_items().await;
-                                                                        catalog_items.set(Some(items));
-                                                                    }
-                                                                    Err(e) => install_error.set(Some(e.to_string())),
+                                                                while let Some(msg) = rx.recv().await {
+                                                                    install_message.set(msg);
                                                                 }
-                                                                installing.set(None);
                                                             });
+                                                            let progress = move |evt: pentest_tools::installers::InstallEvent| {
+                                                                let _ = tx.send(evt.message);
+                                                            };
+                                                            match pentest_tools::catalog::install_by_binary(&bin, &progress).await {
+                                                                Ok(()) => {
+                                                                    let items = pentest_tools::catalog::build_catalog_items().await;
+                                                                    catalog_items.set(Some(items));
+                                                                }
+                                                                Err(e) => install_error.set(Some(e.to_string())),
+                                                            }
+                                                            installing.set(None);
+                                                        });
+                                                    }
+                                                };
+                                                rsx! {
+                                                    div {
+                                                        class: "tool-status-card missing",
+                                                        role: "button",
+                                                        tabindex: if disabled { -1 } else { 0 },
+                                                        "aria-disabled": "{disabled}",
+                                                        onclick: {
+                                                            let start = start_install.clone();
+                                                            move |_| start()
+                                                        },
+                                                        onkeydown: {
+                                                            let start = start_install.clone();
+                                                            move |evt: Event<KeyboardData>| {
+                                                                let key = evt.key();
+                                                                if key == Key::Enter
+                                                                    || matches!(key, Key::Character(ref c) if c == " ")
+                                                                {
+                                                                    evt.prevent_default();
+                                                                    start();
+                                                                }
+                                                            }
                                                         },
                                                         div { class: "tool-status-card-name", "{item.display_name}" }
                                                         if !desc.is_empty() {

--- a/crates/ui/src/components/settings_page.rs
+++ b/crates/ui/src/components/settings_page.rs
@@ -6,6 +6,7 @@ use pentest_core::config::{BorderRadius, Density, ShellMode, Theme};
 use pentest_platform::WifiConnectionStatus;
 
 use super::icons::{Download, Palette, Settings, Wifi};
+use super::tool_category::{category_icon, humanize_category};
 use crate::platform_helper;
 use pentest_core::seed::{SeedManager, SeedProgress, SeedTier};
 
@@ -381,62 +382,40 @@ pub fn SettingsPage(
                         div { class: "text-dim-xs", style: "margin-top: 12px;", "Loading tools..." }
                     } else if let Some(items) = catalog_items() {
                         for category in tool_categories(&items) {
-                            div { class: "tool-category", style: "margin-top: 12px;",
-                                div { class: "text-dim-xs", style: "font-weight: 600; margin-bottom: 4px;",
-                                    {humanize_category(&category)}
+                            div { class: "settings-tools-section",
+                                div { class: "settings-tools-header",
+                                    span { class: "settings-tools-icon", {category_icon(&category)} }
+                                    h3 { class: "settings-tools-title", "{humanize_category(&category)}" }
                                 }
-                                for item in items.iter().filter(|i| i.category == category).cloned() {
-                                    div { class: "tool-row",
-                                        style: "display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 4px 0;",
-                                        div { style: "min-width: 0;",
-                                            div { "{item.display_name}" }
-                                            // Status chip
+                                div { class: "tools-grid",
+                                    for item in items.iter().filter(|i| i.category == category).cloned() {
+                                        {
+                                            let desc = item.description.clone();
                                             if item.state == "installed" {
-                                                span { class: "text-success text-dim-xs",
-                                                    "\u{2713} Installed"
-                                                }
-                                            } else if item.state == "missing" {
-                                                span { class: "text-dim-xs", "Not installed" }
-                                            } else if item.state == "manual" {
-                                                span { class: "text-dim-xs", "Manual" }
-                                            } else {
-                                                span { class: "text-dim-xs", "Unknown" }
-                                            }
-                                        }
-                                        // Action
-                                        if item.state == "installed" {
-                                            // No action; chip shown above.
-                                        } else if item.auto_installable {
-                                            if installing() == Some(item.binary_name.clone()) {
-                                                {
-                                                    let (fraction, label) = install_progress(install_elapsed(), install_estimate());
-                                                    rsx! {
-                                                        div { style: "flex: 1; max-width: 240px;",
-                                                            div { class: "text-dim-xs",
-                                                                "Installing... {install_message}"
-                                                            }
-                                                            div { class: "download-progress",
-                                                                if install_estimate() > 0 {
-                                                                    div {
-                                                                        class: "download-progress-fill",
-                                                                        style: "width: {fraction * 100.0}%",
-                                                                    }
-                                                                } else {
-                                                                    div { class: "download-progress-fill indeterminate" }
-                                                                }
-                                                            }
-                                                            div { class: "text-dim-xs", "{label}" }
+                                                rsx! {
+                                                    div { class: "tool-status-card installed",
+                                                        div { class: "tool-status-card-name", "{item.display_name}" }
+                                                        if !desc.is_empty() {
+                                                            div { class: "tool-status-card-desc", title: "{desc}", "{desc}" }
+                                                        }
+                                                        div { class: "tool-status-card-status installed",
+                                                            "\u{2713} Installed"
                                                         }
                                                     }
                                                 }
-                                            } else {
-                                                button {
-                                                    class: "sidebar-download-btn",
-                                                    disabled: installing().is_some(),
-                                                    onclick: {
-                                                        let bin = item.binary_name.clone();
-                                                        let estimate = item.estimated_secs;
-                                                        move |_| {
+                                            } else if item.auto_installable {
+                                                // Missing but installable: the whole card is a
+                                                // button so click-to-install is keyboard- and
+                                                // screen-reader-accessible without extra wiring.
+                                                let installing_this =
+                                                    installing() == Some(item.binary_name.clone());
+                                                let bin = item.binary_name.clone();
+                                                let estimate = item.estimated_secs;
+                                                rsx! {
+                                                    button {
+                                                        class: "tool-status-card missing",
+                                                        disabled: installing().is_some(),
+                                                        onclick: move |_| {
                                                             let bin = bin.clone();
                                                             spawn(async move {
                                                                 use tokio::sync::mpsc;
@@ -463,15 +442,67 @@ pub fn SettingsPage(
                                                                 }
                                                                 installing.set(None);
                                                             });
+                                                        },
+                                                        div { class: "tool-status-card-name", "{item.display_name}" }
+                                                        if !desc.is_empty() {
+                                                            div { class: "tool-status-card-desc", title: "{desc}", "{desc}" }
                                                         }
-                                                    },
-                                                    "Install"
+                                                        if installing_this {
+                                                            {
+                                                                let (fraction, label) = install_progress(install_elapsed(), install_estimate());
+                                                                rsx! {
+                                                                    div { class: "tool-status-card-status action",
+                                                                        "Installing... {install_message}"
+                                                                    }
+                                                                    div { class: "download-progress",
+                                                                        if install_estimate() > 0 {
+                                                                            div {
+                                                                                class: "download-progress-fill",
+                                                                                style: "width: {fraction * 100.0}%",
+                                                                            }
+                                                                        } else {
+                                                                            div { class: "download-progress-fill indeterminate" }
+                                                                        }
+                                                                    }
+                                                                    div { class: "tool-status-card-status muted", "{label}" }
+                                                                }
+                                                            }
+                                                        } else {
+                                                            div { class: "tool-status-card-status action",
+                                                                "\u{2193} Install"
+                                                            }
+                                                        }
+                                                    }
                                                 }
-                                            }
-                                        } else if let Some(instructions) = item.manual_instructions.clone() {
-                                            div { class: "setup-error-message", white_space: "pre-wrap",
-                                                style: "flex: 1; max-width: 240px;",
-                                                "{instructions}"
+                                            } else if let Some(instructions) = item.manual_instructions.clone() {
+                                                rsx! {
+                                                    div { class: "tool-status-card manual",
+                                                        div { class: "tool-status-card-name", "{item.display_name}" }
+                                                        div { class: "tool-status-card-status muted", "Manual install" }
+                                                        div {
+                                                            class: "tool-status-card-instructions",
+                                                            title: "{instructions}",
+                                                            "{instructions}"
+                                                        }
+                                                    }
+                                                }
+                                            } else {
+                                                let status_text = if item.state == "manual" {
+                                                    "Manual"
+                                                } else if item.state == "missing" {
+                                                    "Not installed"
+                                                } else {
+                                                    "Unknown"
+                                                };
+                                                rsx! {
+                                                    div { class: "tool-status-card manual",
+                                                        div { class: "tool-status-card-name", "{item.display_name}" }
+                                                        if !desc.is_empty() {
+                                                            div { class: "tool-status-card-desc", title: "{desc}", "{desc}" }
+                                                        }
+                                                        div { class: "tool-status-card-status muted", "{status_text}" }
+                                                    }
+                                                }
                                             }
                                         }
                                     }
@@ -1507,29 +1538,6 @@ fn tool_categories(items: &[pentest_tools::catalog::CatalogItem]) -> Vec<String>
         }
     }
     seen
-}
-
-/// Turn a stable category key (e.g. "active_directory") into a display label.
-fn humanize_category(category: &str) -> String {
-    match category {
-        "active_directory" => "Active Directory".to_string(),
-        "web" => "Web".to_string(),
-        "network" => "Network".to_string(),
-        "post_exploit" => "Post Exploitation".to_string(),
-        "other" => "Other".to_string(),
-        // Fallback: replace underscores and capitalize each word.
-        _ => category
-            .split('_')
-            .map(|word| {
-                let mut chars = word.chars();
-                match chars.next() {
-                    Some(first) => first.to_uppercase().chain(chars).collect::<String>(),
-                    None => String::new(),
-                }
-            })
-            .collect::<Vec<_>>()
-            .join(" "),
-    }
 }
 
 #[cfg(test)]

--- a/crates/ui/src/components/tool_category.rs
+++ b/crates/ui/src/components/tool_category.rs
@@ -1,0 +1,46 @@
+//! Shared rendering helpers for tool catalog categories.
+//!
+//! Both the read-only Tools page (`tools_page`) and the Settings Tools panel
+//! (`settings_page`) group tools by a stable snake_case category key derived
+//! from [`pentest_core::tools::ToolCategory`]. These helpers keep the section
+//! labels and icons identical across both surfaces so the two never drift
+//! (previously each maintained its own divergent `humanize_category` map).
+
+use dioxus::prelude::*;
+
+use super::icons::{Folder, Lock, Network, Search, Shield, Terminal, Wifi};
+
+/// Humanize a stable category key into a section label.
+///
+/// Covers both the catalog categories (from `ToolCategory`) and the extra keys
+/// the read-only overview can emit (`system`, `files`). Unknown keys fall back
+/// to "Other".
+pub fn humanize_category(category: &str) -> &'static str {
+    match category {
+        "network" => "Network",
+        "web" => "Web",
+        "active_directory" => "Active Directory",
+        "credentials" => "Credentials",
+        "post_exploit" => "Post-Exploitation",
+        "wireless" => "Wireless",
+        "recon" => "Reconnaissance",
+        "forensics" => "Forensics",
+        "system" => "System",
+        "files" => "Files",
+        _ => "Other",
+    }
+}
+
+/// Icon for a category key. Unknown keys fall back to a terminal glyph.
+pub fn category_icon(category: &str) -> Element {
+    match category {
+        "network" => rsx! { Network { size: 18 } },
+        "web" => rsx! { Search { size: 18 } },
+        "active_directory" | "credentials" => rsx! { Lock { size: 18 } },
+        "post_exploit" => rsx! { Shield { size: 18 } },
+        "wireless" => rsx! { Wifi { size: 18 } },
+        "recon" | "forensics" => rsx! { Search { size: 18 } },
+        "files" => rsx! { Folder { size: 18 } },
+        _ => rsx! { Terminal { size: 18 } },
+    }
+}

--- a/crates/ui/src/components/tools_page.rs
+++ b/crates/ui/src/components/tools_page.rs
@@ -7,41 +7,7 @@
 
 use dioxus::prelude::*;
 
-use super::icons::{Folder, Lock, Network, Search, Shield, Terminal, Wifi};
-
-/// Humanize a stable category key into a section label.
-fn humanize_category(category: &str) -> &'static str {
-    match category {
-        "network" => "Network",
-        "web" => "Web",
-        "active_directory" => "Active Directory",
-        "credentials" => "Credentials",
-        "post_exploit" => "Post-Exploitation",
-        "wireless" => "Wireless",
-        "recon" => "Reconnaissance",
-        "forensics" => "Forensics",
-        "system" => "System",
-        "files" => "Files",
-        _ => "Other",
-    }
-}
-
-/// Icon per category key.
-fn render_category_icon(category: &str) -> Element {
-    match category {
-        "network" => rsx! { Network { size: 18 } },
-        "web" => rsx! { Search { size: 18 } },
-        "active_directory" => rsx! { Lock { size: 18 } },
-        "credentials" => rsx! { Lock { size: 18 } },
-        "post_exploit" => rsx! { Shield { size: 18 } },
-        "wireless" => rsx! { Wifi { size: 18 } },
-        "recon" => rsx! { Search { size: 18 } },
-        "forensics" => rsx! { Search { size: 18 } },
-        "system" => rsx! { Terminal { size: 18 } },
-        "files" => rsx! { Folder { size: 18 } },
-        _ => rsx! { Terminal { size: 18 } },
-    }
-}
+use super::tool_category::{category_icon, humanize_category};
 
 /// Tools page — displays all registered connector tools grouped by category.
 #[component]
@@ -64,7 +30,7 @@ pub fn ToolsPage(on_open_chat: EventHandler<String>) -> Element {
                         div { class: "tools-category-header",
                             span {
                                 class: "tools-category-icon",
-                                {render_category_icon(&category)}
+                                {category_icon(&category)}
                             }
                             h3 { class: "tools-category-title", "{humanize_category(&category)}" }
                         }


### PR DESCRIPTION
## Summary

Redesigns the Settings -> Tools card from a tall vertical `tool-row` list into a **responsive grid of compact status cards grouped by category**, reclaiming vertical space and making install state scannable at a glance.

Closes #193.

- **Category-grouped grid.** Each category (Network, Web, Credentials, ...) gets an icon + header, then a `repeat(auto-fill, minmax(180px, 1fr))` grid that reflows to window width (2 columns at the 480px desktop width, more when wider).
- **Color-coded install state** via a card left-border: green (installed), muted (missing/installable), neutral (manual), plus matching status text (`checkmark Installed`, `Install`, `Manual install`).
- **Accessible click-to-install.** Missing + auto-installable cards render as a `<button>`, so keyboard/screen-reader users get the install action for free. The existing per-item progress bar (elapsed vs `estimated_secs`) and the bulk "Install all recommended" action are preserved unchanged.
- **DRY cleanup.** The duplicated, *divergent* `humanize_category` helpers in `tools_page.rs` and `settings_page.rs` are unified into a shared `components::tool_category` module (also shared `category_icon`), so both surfaces label categories identically. Previously settings mapped `post_exploit` -> "Post Exploitation" and had no `recon` arm, while the Tools page used "Post-Exploitation"/"Reconnaissance".

**No backend/data-model change.** Cards render entirely from existing `CatalogItem` fields (`display_name`, `description`, `category`, `state`, `auto_installable`, `manual_instructions`, `estimated_secs`).

## Scope

Standalone frontend polish, intentionally independent of epic #250 (BlackArch-driven live category model + group-install). When #250 lands its live-queried categories, this grid consumes them unchanged.

## Verification

- `cargo check -p pentest-desktop` (real build target): clean, exit 0.
- `cargo check --workspace --all-targets` and `... --features pentest-platform/desktop-pcap` (CI + pre-push configs): 0 errors.
- `cargo clippy -p pentest-ui -p pentest-desktop -- -D warnings`: clean, exit 0.
- `cargo fmt -p pentest-ui -- --check`: clean.
- `cargo test --workspace --features pentest-platform/desktop-pcap`: all pass, including the 4 `settings_page` tests.
- Visual: rendered the new markup with the real `settings_page.css` + dark theme tokens at 480px via headless Chrome; confirmed grid layout, per-state color-coding, inline install progress, and manual-instruction clamping.

## Test plan

- [ ] Open Settings -> Tools; confirm tools render as a category-grouped grid, not a vertical list.
- [ ] Confirm installed cards show green, missing show an Install affordance, manual show instructions.
- [ ] Click a missing tool card; confirm inline progress bar and that the catalog refreshes to "Installed" on success.
- [ ] Resize the window narrow/wide; confirm the grid reflows columns without overflow.
- [ ] Confirm the read-only Tools page still renders correctly (shared category helpers).