### PR TITLE
fix(#266): web UI resolves a free port instead of hard-binding 3000

### DIFF
--- a/apps/web/src/main.rs
+++ b/apps/web/src/main.rs
@@ -37,7 +37,13 @@ fn preferred_port() -> u16 {
 /// retry; any other bind error is fatal and returned as-is.
 async fn bind_with_fallback(preferred: u16) -> std::io::Result<(TcpListener, u16)> {
     for offset in 0..MAX_PORT_ATTEMPTS {
-        let port = preferred.saturating_add(offset);
+        // Stop rather than re-probe: near the u16 ceiling `preferred + offset`
+        // would saturate and re-target the same top port, so a busy port high
+        // in the range would spin uselessly. Skipping keeps every attempt a
+        // distinct port.
+        let Some(port) = preferred.checked_add(offset) else {
+            break;
+        };
         let addr = SocketAddr::from(([0, 0, 0, 0], port));
         match TcpListener::bind(&addr).await {
             Ok(listener) => {

--- a/apps/web/src/main.rs
+++ b/apps/web/src/main.rs
@@ -41,12 +41,17 @@ async fn bind_with_fallback(preferred: u16) -> std::io::Result<(TcpListener, u16
         let addr = SocketAddr::from(([0, 0, 0, 0], port));
         match TcpListener::bind(&addr).await {
             Ok(listener) => {
+                // Read the port back from the socket rather than trusting
+                // `port`: with PORT=0 the OS assigns an ephemeral port, and the
+                // caller must log the real one (not 0). Falls back to `port`
+                // only if local_addr() somehow fails.
+                let bound = listener.local_addr().map(|a| a.port()).unwrap_or(port);
                 if offset > 0 {
                     tracing::warn!(
-                        "Port {preferred} was in use; bound {port} instead (set PORT to pin a specific port)"
+                        "Port {preferred} was in use; bound {bound} instead (set PORT to pin a specific port)"
                     );
                 }
-                return Ok((listener, port));
+                return Ok((listener, bound));
             }
             Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
                 tracing::debug!("Port {port} in use, trying next");

--- a/apps/web/src/main.rs
+++ b/apps/web/src/main.rs
@@ -4,9 +4,65 @@ use axum::Router;
 use dioxus::prelude::*;
 use dioxus_liveview::LiveviewRouter;
 use std::net::SocketAddr;
+use tokio::net::TcpListener;
 
 use pentest_core::config::ShellMode;
 use pentest_ui::{connector_app, mobile_css, theme_css, utils_css, ConnectorAppConfig};
+
+/// Default port for the web UI when `PORT` is unset.
+const DEFAULT_PORT: u16 = 3000;
+
+/// How many consecutive ports to try before giving up. Keeps auto-increment
+/// bounded so a misconfigured host can't spin forever.
+const MAX_PORT_ATTEMPTS: u16 = 20;
+
+/// Resolve the starting port from the `PORT` env var, falling back to
+/// [`DEFAULT_PORT`]. A malformed value is rejected loudly rather than silently
+/// ignored, so a typo'd `PORT` surfaces instead of masquerading as the default.
+fn preferred_port() -> u16 {
+    match std::env::var("PORT") {
+        Ok(raw) => raw.trim().parse().unwrap_or_else(|_| {
+            tracing::warn!(
+                "PORT='{raw}' is not a valid port number; falling back to {DEFAULT_PORT}"
+            );
+            DEFAULT_PORT
+        }),
+        Err(_) => DEFAULT_PORT,
+    }
+}
+
+/// Bind the first free port at or above `preferred`, scanning up to
+/// [`MAX_PORT_ATTEMPTS`] ports. Returns the listener plus the port actually
+/// bound so the caller can report the real URL. Only `AddrInUse` triggers a
+/// retry; any other bind error is fatal and returned as-is.
+async fn bind_with_fallback(preferred: u16) -> std::io::Result<(TcpListener, u16)> {
+    for offset in 0..MAX_PORT_ATTEMPTS {
+        let port = preferred.saturating_add(offset);
+        let addr = SocketAddr::from(([0, 0, 0, 0], port));
+        match TcpListener::bind(&addr).await {
+            Ok(listener) => {
+                if offset > 0 {
+                    tracing::warn!(
+                        "Port {preferred} was in use; bound {port} instead (set PORT to pin a specific port)"
+                    );
+                }
+                return Ok((listener, port));
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+                tracing::debug!("Port {port} in use, trying next");
+                continue;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    Err(std::io::Error::new(
+        std::io::ErrorKind::AddrInUse,
+        format!(
+            "no free port in {preferred}..{} after {MAX_PORT_ATTEMPTS} attempts",
+            preferred.saturating_add(MAX_PORT_ATTEMPTS)
+        ),
+    ))
+}
 
 const WEB_CONFIG: ConnectorAppConfig = ConnectorAppConfig {
     platform_name: "Web (Liveview)",
@@ -31,10 +87,18 @@ async fn main() {
     let ucss = utils_css();
     let full_css = format!("{css}{mcss}{ucss}");
 
-    let addr: SocketAddr = "0.0.0.0:3000"
-        .parse()
-        .expect("valid socket address literal");
-    tracing::info!("Listening on http://{}", addr);
+    // Bind before building the app so a port collision (e.g. another local
+    // Dioxus app already on 3000) fails fast with a clear message instead of
+    // panicking or silently serving the wrong app.
+    let (listener, port) = match bind_with_fallback(preferred_port()).await {
+        Ok(bound) => bound,
+        Err(e) => {
+            tracing::error!("Could not bind a web UI port: {e}");
+            eprintln!("error: could not bind a web UI port: {e}");
+            std::process::exit(1);
+        }
+    };
+    tracing::info!("Pick web UI available at http://localhost:{port}");
 
     let app = Router::new()
         .merge(pentest_ui::shell_ws::shell_routes(ShellMode::Native))
@@ -60,9 +124,6 @@ async fn main() {
             )
         });
 
-    let listener = tokio::net::TcpListener::bind(&addr)
-        .await
-        .expect("failed to bind TCP listener");
     axum::serve(listener, app.into_make_service())
         .await
         .expect("server error");


### PR DESCRIPTION
## Summary

The web app hard-bound `0.0.0.0:3000` via `.expect()`. On a port collision it either **panicked**, or - when another local Dioxus app already held 3000 (real case: **4n6 Nexus** / `nexus-web`) - the operator saw that app's near-identical `<title>Dioxus Liveview App</title>` shell with **no signal they were on the wrong process**. Running Pick alongside another local Dioxus app is a normal DFIR/pentest-workstation scenario, so this recurred.

Closes #266.

## What changed (`apps/web/src/main.rs`)

- **`PORT` env var** for explicit operator control (default 3000); a malformed `PORT` warns and falls back rather than silently masquerading as the default.
- **Auto-increment** to the next free port on `AddrInUse`, bounded to 20 attempts so a misconfigured host can't spin forever. Only `AddrInUse` retries; any other bind error is fatal.
- **Loud logging** of the actual bound URL: `Pick web UI available at http://localhost:<port>` - this is the piece that prevents the silent-wrong-app confusion.
- **No more panic**: a clear error + `exit(1)` if no port is free.

## Scope note (investigation finding)

The issue proposed also fixing the `3030` liveview server. On inspection that constant (`LIVEVIEW_PORT` in `crates/ui/src/liveview_server.rs`) is **vestigial** - that server binds a PID-based IPC socket (Unix socket / named pipe), never a TCP port, so it has no collision to fix and already avoids conflicts across simultaneous connectors. `apps/web` was the only fixed TCP bind in the codebase (other binds use ephemeral `:0`). Scope narrowed accordingly.

## Verification

- `cargo check -p pentest-web`, `cargo clippy -p pentest-web -- -D warnings`, `cargo fmt --check`: all clean.
- **Live behavioral test** (the actual scenario from #266): with `nexus-web` holding `:3000`, launched `pentest-web` and observed:
  ```
  Port 3000 in use, trying next
  Port 3000 was in use; bound 3001 instead (set PORT to pin a specific port)
  Pick web UI available at http://localhost:3001
  ```
  `ss` confirmed `pentest-web` on 3001 and `nexus-web` still on 3000 - both running simultaneously, no panic.

## Test plan

- [x] With nothing on the preferred port, binds it directly with no fallback (verified via known-free `PORT=3999` -> bound 3999, no warning; literal 3000 not tested since another local app holds it).
- [x] With 3000 occupied (4n6 Nexus), binds 3001 and logs the collision + chosen port.
- [x] `PORT=3456` binds 3456 (verified).
- [x] `PORT=garbage` warns and falls back (then 3000 busy -> bound 3001).


---
**Manual test run (2026-07-18):** all four scenarios verified against the built binary. Testing also surfaced that `PORT=0` (OS-assigned ephemeral) logged `localhost:0` instead of the real port; fixed in `b09ecbe` by reading the bound port from `listener.local_addr()` (now logs e.g. `:44005`). `PORT=0` re-verified after the fix.