### PR TITLE
feat(mobile): build the iOS app on nix + Xcode

### DIFF
--- a/crates/platform/src/ios/mod.rs
+++ b/crates/platform/src/ios/mod.rs
@@ -1,5 +1,7 @@
 //! iOS platform implementation (stub)
 
+pub mod pty_shell;
+
 use crate::traits::*;
 use async_trait::async_trait;
 use pentest_core::error::{Error, Result};

--- a/crates/platform/src/ios/pty_shell.rs
+++ b/crates/platform/src/ios/pty_shell.rs
@@ -1,0 +1,49 @@
+//! iOS PTY shell — unsupported.
+//!
+//! iOS application sandboxing forbids spawning subprocesses and allocating
+//! PTYs, so the interactive shell (proot/native, as on Android/desktop) has no
+//! iOS implementation. This stub exists only to satisfy the shared `shell_ws`
+//! call sites at compile time; `spawn` fails immediately with a clear message,
+//! and the remaining methods are never reached at runtime.
+
+use pentest_core::config::ShellMode;
+use pentest_core::error::{Error, Result};
+use std::io::{Read, Write};
+use std::path::Path;
+
+fn unsupported() -> Error {
+    Error::PlatformNotSupported("interactive shell is not available on iOS".to_string())
+}
+
+/// Placeholder interactive PTY shell for iOS. Construction always fails.
+pub struct PtyShell {
+    _private: (),
+}
+
+impl PtyShell {
+    pub async fn spawn(
+        _cols: u16,
+        _rows: u16,
+        _progress: Option<tokio::sync::mpsc::Sender<String>>,
+        _cwd: Option<&Path>,
+        _shell_mode: ShellMode,
+    ) -> Result<Self> {
+        Err(unsupported())
+    }
+
+    pub fn resize(&self, _cols: u16, _rows: u16) -> Result<()> {
+        Err(unsupported())
+    }
+
+    pub fn try_clone_reader(&self) -> Result<Box<dyn Read + Send>> {
+        Err(unsupported())
+    }
+
+    pub fn take_writer(&self) -> Result<Box<dyn Write + Send>> {
+        Err(unsupported())
+    }
+
+    pub fn try_wait(&mut self) -> Result<Option<std::process::ExitStatus>> {
+        Ok(None)
+    }
+}

--- a/crates/platform/src/lib.rs
+++ b/crates/platform/src/lib.rs
@@ -26,9 +26,24 @@ pub use desktop::pty_shell::PtyShell;
 #[cfg(all(feature = "android", not(feature = "desktop")))]
 pub use android::pty_shell::PtyShell;
 
+#[cfg(all(feature = "ios", not(feature = "desktop"), not(feature = "android")))]
+pub use ios::pty_shell::PtyShell;
+
 /// Re-export sandbox control for desktop
 #[cfg(feature = "desktop")]
 pub use desktop::{is_sandbox_enabled, set_use_sandbox};
+
+/// Command sandboxing (bubblewrap/proot) is a desktop-only concept. On
+/// non-desktop platforms (mobile) there is no command sandbox, so report it
+/// disabled and make toggling it a no-op. Mirrors the `is_pcap_available`
+/// fallback below so callers can stay platform-agnostic.
+#[cfg(not(feature = "desktop"))]
+pub fn is_sandbox_enabled() -> bool {
+    false
+}
+
+#[cfg(not(feature = "desktop"))]
+pub fn set_use_sandbox(_use_sandbox: bool) {}
 
 /// Re-export capture session management for desktop
 #[cfg(feature = "desktop")]

--- a/crates/ui/src/components/router.rs
+++ b/crates/ui/src/components/router.rs
@@ -394,7 +394,7 @@ fn Settings() -> Element {
                     crate::download_manager::set_global_progress(Some(-1.0));
                     state.write().download_progress = Some(-1.0);
                     spawn(async move {
-                        #[cfg(all(feature = "shell-ws", not(target_os = "android")))]
+                        #[cfg(all(feature = "shell-ws", not(any(target_os = "android", target_os = "ios"))))]
                         {
                             let result = pentest_platform::desktop::sandbox::get_sandbox_manager()
                                 .await
@@ -421,7 +421,7 @@ fn Settings() -> Element {
                 shell_mode,
                 on_shell_mode_change: move |mode: ShellMode| {
                     state.write().set_shell_mode(mode);
-                    #[cfg(all(feature = "shell-ws", not(target_os = "android")))]
+                    #[cfg(all(feature = "shell-ws", not(any(target_os = "android", target_os = "ios"))))]
                     pentest_platform::set_use_sandbox(mode == ShellMode::Proot);
                 },
             }

--- a/crates/ui/src/components/workspace_app.rs
+++ b/crates/ui/src/components/workspace_app.rs
@@ -508,7 +508,7 @@ pub fn WorkspaceApp() -> Element {
                             download_progress.set(Some(-1.0));
 
                             spawn(async move {
-                                #[cfg(all(feature = "shell-ws", not(target_os = "android")))]
+                                #[cfg(all(feature = "shell-ws", not(any(target_os = "android", target_os = "ios"))))]
                                 {
                                     let result = match pentest_platform::desktop::sandbox::get_sandbox_manager().await {
                                         Ok(manager) => manager.ensure_ready().await.map_err(|e| format!("{}", e)),
@@ -540,7 +540,7 @@ pub fn WorkspaceApp() -> Element {
                         let mut s = settings.write();
                         s.shell_mode = mode;
                         let _ = save_settings(&s);
-                        #[cfg(all(feature = "shell-ws", not(target_os = "android")))]
+                        #[cfg(all(feature = "shell-ws", not(any(target_os = "android", target_os = "ios"))))]
                         pentest_platform::set_use_sandbox(mode == ShellMode::Proot);
                     },
                     wifi_adapter: settings.read().wifi_adapter.clone(),

--- a/crates/ui/src/connector_app.rs
+++ b/crates/ui/src/connector_app.rs
@@ -601,7 +601,7 @@ pub fn connector_app(cfg: ConnectorAppConfig) -> Element {
         download_progress.set(Some(-1.0));
 
         spawn(async move {
-            #[cfg(all(feature = "shell-ws", not(target_os = "android")))]
+            #[cfg(all(feature = "shell-ws", not(any(target_os = "android", target_os = "ios"))))]
             {
                 let result = match pentest_platform::desktop::sandbox::get_sandbox_manager().await {
                     Ok(manager) => manager.ensure_ready().await.map_err(|e| format!("{}", e)),

--- a/flake.nix
+++ b/flake.nix
@@ -162,45 +162,35 @@
         '';
       };
 
-      devShells.${darwinSystem}.default = darwinPkgs.mkShell {
+      # mkShellNoCC (not mkShell): we deliberately do NOT pull Nix's darwin cc
+      # stdenv. That stdenv wraps clang/ld for a *macOS* sysroot and injects
+      # `-mmacos-version-min` plus its own `xcrun` shim and DEVELOPER_DIR — all of
+      # which fight iOS cross-compilation (ObjC deps get `-mmacos-version-min` vs
+      # `-mios-simulator-version-min` conflicts, and cc-rs can't find the iphone
+      # SDK). On a Mac with real Xcode, the system Apple toolchain already
+      # compiles/links both host (macOS) and iOS targets correctly, so we let it,
+      # and Nix supplies only Rust (+ iOS std), dx, and build-time tools.
+      devShells.${darwinSystem}.default = darwinPkgs.mkShellNoCC {
         packages = [
           darwinRust
           dxCliDarwin   # `dx` 0.7.9, matches dioxus 0.7.9 in Cargo.lock
           darwinPkgs.just
         ];
 
-        # Native build deps. The desktop GTK/WebKit stack (gtk3, webkitgtk,
-        # dbus, libsoup, xdotool) is Linux-only and irrelevant to iOS, so the
-        # macOS shell stays lean.
+        # Build-time tools only. protoc for build.rs; pkg-config so crates that
+        # need it can still discover libs. No GTK/WebKit stack (Linux desktop
+        # only) and no Nix C compiler — Apple's clang/ld from Xcode does the work.
         nativeBuildInputs = with darwinPkgs; [ pkg-config protobuf ];
-        buildInputs = with darwinPkgs; [ openssl libpcap ];
 
         shellHook = ''
           # Point the justfile's `dx` (defaults to ~/.dx/bin/dx) at the Nix CLI.
           export DX_PATH="$(command -v dx)"
 
-          # iOS builds need Apple's real iOS SDKs (iphoneos / iphonesimulator),
-          # which Nix cannot vendor. The Nix darwin stdenv ships only a macOS SDK
-          # stub plus an `xcrun` shim and points DEVELOPER_DIR at them — so cc-rs,
-          # compiling ObjC deps (objc2 &c.) for an iOS target, fails on
-          # `xcrun --show-sdk-path --sdk iphonesimulator`.
-          #
-          # When a full Xcode with the iPhone platforms is installed, defer iOS
-          # SDK resolution to Apple's toolchain: point DEVELOPER_DIR at the real
-          # Xcode and shadow the Nix `xcrun` shim with /usr/bin/xcrun. Rust, cargo
-          # and dx still come from Nix; only Apple's SDK lookups go to Xcode. The
-          # whole block is guarded on a working iphonesimulator SDK, so it is a
-          # no-op (shell behaves identically) until Xcode is present.
-          _dev="$(/usr/bin/xcode-select -p 2>/dev/null || true)"
-          if [ -n "$_dev" ] && DEVELOPER_DIR="$_dev" /usr/bin/xcrun --sdk iphonesimulator --show-sdk-path >/dev/null 2>&1; then
-            export DEVELOPER_DIR="$_dev"
-            _ios_shim="$PWD/.nix-ios-shims"
-            mkdir -p "$_ios_shim"
-            ln -sf /usr/bin/xcrun "$_ios_shim/xcrun"
-            export PATH="$_ios_shim:$PATH"
-            echo "iOS: deferring SDK resolution to system Xcode ($_dev)."
-          else
-            echo "WARNING: full Xcode iOS SDK not found (only a macOS SDK stub)."
+          # Host + iOS compiles use Apple's clang from the active Xcode; no Nix cc
+          # wrapper is present, so /usr/bin is the toolchain source. Warn early if
+          # a full Xcode isn't selected (Command Line Tools alone lack the iOS SDK).
+          if ! /usr/bin/xcrun --sdk iphonesimulator --show-sdk-path >/dev/null 2>&1; then
+            echo "WARNING: no iphonesimulator SDK found."
             echo "  iOS builds need full Xcode, not just Command Line Tools."
             echo "  Install Xcode, then: sudo xcode-select --switch /Applications/Xcode.app"
           fi


### PR DESCRIPTION
## What

Enables building the iOS app from `nix develop` on an Apple-silicon Mac with Xcode installed. Stacked on #249 (Android build work) since it depends on that branch's `PlatformProvider` host-interface fix.

Verified end to end on a macOS 26.5 / Xcode 26.6 VM:

```
nix develop --command dx build --platform ios --package pentest-mobile
```

produces `target/dx/pentest-mobile/debug/ios/PentestMobile.app` — a Mach-O **arm64, platform IOSSIMULATOR, SDK 26.5** binary, all 586 crates compiled clean.

## How

**`flake.nix` — darwin devShell via `mkShellNoCC` (not `mkShell`).** Nix's darwin `cc` stdenv wraps clang/ld for a macOS sysroot, injects `-mmacos-version-min`, and ships an `xcrun` shim + `DEVELOPER_DIR` pointing at a macOS SDK stub — all of which fight iOS cross-compilation (ObjC `-mmacos-version-min` vs `-mios-simulator-version-min` conflicts; host build scripts lose their sysroot; `xcode-select`/`xcrun` honor the Nix `DEVELOPER_DIR` and return the stub). With `mkShellNoCC`, the system Xcode toolchain handles both host and iOS compiles, and Nix supplies only rust (+ iOS `std` targets), `dx`, `protoc`, `pkg-config`, and `just`.

**`pentest-platform` — iOS was treated as "not desktop".** The codebase used `not(target_os = "android")` as a proxy for "desktop", pulling desktop-only APIs into iOS builds. Added non-desktop fallbacks for `is_sandbox_enabled`/`set_use_sandbox` (no command sandbox on mobile) and an iOS `PtyShell` stub whose `spawn` returns `PlatformNotSupported` (iOS cannot allocate PTYs or run proot).

**`pentest-ui`** — gate the `shell-ws` sandbox setup off for iOS as well as Android in `router`, `workspace_app`, and `connector_app`.

## Scope / caveats

- This is a **simulator** build. A physical-device build (`aarch64-apple-ios`) additionally needs code signing (Apple team + provisioning) — not included here.
- The interactive shell is intentionally unavailable on iOS (platform can't spawn it).
- No changes to desktop or Android behavior: the platform fallbacks are `#[cfg(not(feature = "desktop"))]` and the UI gates only add iOS to an existing Android exclusion.