### PR TITLE
feat(#261): curated tool category taxonomy + re-tag all wrapped tools

### DIFF
--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -214,20 +214,32 @@ pub enum InstallMethod {
 pub enum ToolCategory {
     /// Host/port/service discovery and network mapping.
     Network,
-    /// Web application scanning and fuzzing.
+    /// Web application scanning and exploitation (nikto, sqlmap, nuclei, ...).
     Web,
+    /// Web content/endpoint discovery and fuzzing (gobuster, ffuf, katana, ...).
+    WebDiscovery,
+    /// Intercepting/scanning web proxies (Burp Suite, OWASP ZAP).
+    Proxy,
     /// Active Directory, SMB, Kerberos, LDAP.
     ActiveDirectory,
-    /// Credential attacks: cracking, spraying, dumping.
+    /// Credential attacks: cracking, spraying, wordlist generation.
     Credentials,
+    /// Exploitation frameworks and exploit lookup (Metasploit, searchsploit).
+    Exploitation,
     /// Post-exploitation, C2, lateral movement, payload generation.
     PostExploit,
+    /// Traffic sniffing and network spoofing/poisoning.
+    Sniffing,
     /// Wireless.
     Wireless,
     /// OSINT and reconnaissance.
     Recon,
+    /// TLS/SSL and cryptography analysis.
+    Crypto,
     /// Forensics and evidence handling.
     Forensics,
+    /// General-purpose networking/support utilities (socat, ncat, exiftool).
+    Utilities,
     /// Anything that doesn't fit a more specific group.
     #[default]
     Other,

--- a/crates/tools/src/catalog.rs
+++ b/crates/tools/src/catalog.rs
@@ -133,9 +133,10 @@ impl CatalogEntry {
 /// Binaries that are install prerequisites for other tools rather than
 /// operator-facing tools in their own right. They are hidden from the catalog
 /// UI (no one "installs Python" as a pentest tool), but remain real
-/// `external_dependency` declarations so the tools that need them (e.g.
-/// webwright) still pull them in through their own installer.
-const HIDDEN_CATALOG_BINARIES: &[&str] = &["python3", "playwright"];
+/// `external_dependency` declarations so the tools that need them still pull
+/// them in through their own installer: `python3`/`playwright` for webwright,
+/// `node` (Node.js) for the CyberChef recipe runner.
+const HIDDEN_CATALOG_BINARIES: &[&str] = &["python3", "playwright", "node"];
 
 /// Collect the unique external dependencies declared across all registered
 /// tools, mapping each `binary_name` to its dependency plus the tools that use

--- a/crates/tools/src/catalog.rs
+++ b/crates/tools/src/catalog.rs
@@ -130,6 +130,13 @@ impl CatalogEntry {
     }
 }
 
+/// Binaries that are install prerequisites for other tools rather than
+/// operator-facing tools in their own right. They are hidden from the catalog
+/// UI (no one "installs Python" as a pentest tool), but remain real
+/// `external_dependency` declarations so the tools that need them (e.g.
+/// webwright) still pull them in through their own installer.
+const HIDDEN_CATALOG_BINARIES: &[&str] = &["python3", "playwright"];
+
 /// Collect the unique external dependencies declared across all registered
 /// tools, mapping each `binary_name` to its dependency plus the tools that use
 /// it. Uses a `BTreeMap` for deterministic ordering.
@@ -144,6 +151,9 @@ fn collect_dependencies() -> BTreeMap<String, (ExternalDependency, Vec<String>)>
     // advertised/executed, not here. See #183.
     for schema in registry.schemas() {
         for dep in &schema.external_dependencies {
+            if HIDDEN_CATALOG_BINARIES.contains(&dep.binary_name.as_str()) {
+                continue;
+            }
             let entry = deps
                 .entry(dep.binary_name.clone())
                 .or_insert_with(|| (dep.clone(), Vec::new()));
@@ -459,6 +469,32 @@ pub struct ToolOverviewItem {
     pub category: String,
 }
 
+/// Stable lowercase key for a [`ToolCategory`], matching its serde rename.
+///
+/// This is the single source of truth for category string keys shared by the
+/// catalog and the read-only overview. It is an exhaustive match on purpose:
+/// adding a `ToolCategory` variant without a key here is a compile error, so a
+/// new category can never silently fall through to a wrong bucket.
+fn category_key(cat: ToolCategory) -> &'static str {
+    match cat {
+        ToolCategory::Network => "network",
+        ToolCategory::Web => "web",
+        ToolCategory::WebDiscovery => "web_discovery",
+        ToolCategory::Proxy => "proxy",
+        ToolCategory::ActiveDirectory => "active_directory",
+        ToolCategory::Credentials => "credentials",
+        ToolCategory::Exploitation => "exploitation",
+        ToolCategory::PostExploit => "post_exploit",
+        ToolCategory::Sniffing => "sniffing",
+        ToolCategory::Wireless => "wireless",
+        ToolCategory::Recon => "recon",
+        ToolCategory::Crypto => "crypto",
+        ToolCategory::Forensics => "forensics",
+        ToolCategory::Utilities => "utilities",
+        ToolCategory::Other => "other",
+    }
+}
+
 /// Map a tool's name + its (optional) declared category to a display category.
 ///
 /// Tools that declare an `ExternalDependency` carry an explicit
@@ -467,18 +503,11 @@ pub struct ToolOverviewItem {
 /// sensibly rather than dumping everything in "other".
 fn overview_category(name: &str, declared: Option<ToolCategory>) -> &'static str {
     if let Some(cat) = declared {
-        // Reuse the serde rename for a stable key.
-        return match cat {
-            ToolCategory::Network => "network",
-            ToolCategory::Web => "web",
-            ToolCategory::ActiveDirectory => "active_directory",
-            ToolCategory::Credentials => "credentials",
-            ToolCategory::PostExploit => "post_exploit",
-            ToolCategory::Wireless => "wireless",
-            ToolCategory::Recon => "recon",
-            ToolCategory::Forensics => "forensics",
-            ToolCategory::Other => "other",
-        };
+        // Reuse the serde rename for a stable key. Deriving it from serde
+        // (rather than a hand-written match) keeps this in lockstep with the
+        // enum: new `ToolCategory` variants are covered automatically and can
+        // never silently fall through.
+        return category_key(cat);
     }
     // Heuristic for built-ins with no declared category.
     match name {
@@ -620,7 +649,7 @@ mod tests {
         assert!(nmap.is_some(), "nmap should be in the catalog");
         let nmap = nmap.unwrap();
         assert!(!nmap.used_by.is_empty());
-        assert_eq!(nmap.category, ToolCategory::Other); // nmap hasn't set a category yet
+        assert_eq!(nmap.category, ToolCategory::Network);
     }
 
     #[tokio::test]
@@ -722,6 +751,32 @@ mod tests {
         assert_eq!(overview_category("read_file", None), "files");
         // Unknown built-in falls back to "other".
         assert_eq!(overview_category("some_new_builtin", None), "other");
+    }
+
+    #[test]
+    fn category_key_covers_new_taxonomy_variants() {
+        // The curated taxonomy keys must match the enum's serde rename so the
+        // UI's humanize_category lookups line up.
+        assert_eq!(category_key(ToolCategory::WebDiscovery), "web_discovery");
+        assert_eq!(category_key(ToolCategory::Proxy), "proxy");
+        assert_eq!(category_key(ToolCategory::Exploitation), "exploitation");
+        assert_eq!(category_key(ToolCategory::Sniffing), "sniffing");
+        assert_eq!(category_key(ToolCategory::Crypto), "crypto");
+        assert_eq!(category_key(ToolCategory::Utilities), "utilities");
+    }
+
+    #[tokio::test]
+    async fn runtime_dep_binaries_are_hidden_from_catalog() {
+        // python3 / playwright are install prerequisites, not operator-facing
+        // tools; they must not appear as catalog entries even though tools
+        // (webwright) declare them as dependencies.
+        let catalog = build_catalog().await;
+        for hidden in HIDDEN_CATALOG_BINARIES {
+            assert!(
+                !catalog.iter().any(|e| &e.binary_name == hidden),
+                "{hidden} should be hidden from the catalog"
+            );
+        }
     }
 
     #[test]

--- a/crates/tools/src/external/burp.rs
+++ b/crates/tools/src/external/burp.rs
@@ -54,7 +54,7 @@ impl PentestTool for BurpSuiteTool {
                      paid license.",
                     Some("https://portswigger.net/burp/communitydownload".to_string()),
                 )
-                .category(ToolCategory::Web)
+                .category(ToolCategory::Proxy)
                 .recommended(false),
             )
             .param(ToolParam::optional(

--- a/crates/tools/src/external/dirb.rs
+++ b/crates/tools/src/external/dirb.rs
@@ -31,14 +31,17 @@ impl PentestTool for DirbTool {
     }
 
     fn schema(&self) -> ToolSchema {
-        use pentest_core::tools::ExternalDependency;
+        use pentest_core::tools::{ExternalDependency, ToolCategory};
 
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "dirb",
-                "dirb",
-                "Web content scanner for dictionary-based attacks",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "dirb",
+                    "dirb",
+                    "Web content scanner for dictionary-based attacks",
+                )
+                .category(ToolCategory::WebDiscovery),
+            )
             .param(ToolParam::required(
                 "url",
                 ParamType::String,

--- a/crates/tools/src/external/enum4linux.rs
+++ b/crates/tools/src/external/enum4linux.rs
@@ -30,14 +30,13 @@ impl PentestTool for Enum4linuxTool {
     }
 
     fn schema(&self) -> ToolSchema {
-        use pentest_core::tools::ExternalDependency;
+        use pentest_core::tools::{ExternalDependency, ToolCategory};
 
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "enum4linux",
-                "enum4linux",
-                "SMB/Windows enumeration tool",
-            ))
+            .external_dependency(
+                ExternalDependency::new("enum4linux", "enum4linux", "SMB/Windows enumeration tool")
+                    .category(ToolCategory::ActiveDirectory),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/ffuf.rs
+++ b/crates/tools/src/external/ffuf.rs
@@ -33,14 +33,13 @@ impl PentestTool for FfufTool {
     }
 
     fn schema(&self) -> ToolSchema {
-        use pentest_core::tools::ExternalDependency;
+        use pentest_core::tools::{ExternalDependency, ToolCategory};
 
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "ffuf",
-                "ffuf",
-                "Fast web fuzzer written in Go",
-            ))
+            .external_dependency(
+                ExternalDependency::new("ffuf", "ffuf", "Fast web fuzzer written in Go")
+                    .category(ToolCategory::WebDiscovery),
+            )
             .param(ToolParam::required(
                 "url",
                 ParamType::String,

--- a/crates/tools/src/external/forensics/exiftool.rs
+++ b/crates/tools/src/external/forensics/exiftool.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,14 @@ impl PentestTool for ExiftoolTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "exiftool",
-                "perl-image-exiftool",
-                "Metadata extraction tool (Perl-based)",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "exiftool",
+                    "perl-image-exiftool",
+                    "Metadata extraction tool (Perl-based)",
+                )
+                .category(ToolCategory::Forensics),
+            )
             .param(ToolParam::required(
                 "file_path",
                 ParamType::String,

--- a/crates/tools/src/external/gobuster.rs
+++ b/crates/tools/src/external/gobuster.rs
@@ -31,14 +31,17 @@ impl PentestTool for GobusterTool {
     }
 
     fn schema(&self) -> ToolSchema {
-        use pentest_core::tools::ExternalDependency;
+        use pentest_core::tools::{ExternalDependency, ToolCategory};
 
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "gobuster",
-                "gobuster",
-                "Directory/DNS/vhost bruteforce tool written in Go",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "gobuster",
+                    "gobuster",
+                    "Directory/DNS/vhost bruteforce tool written in Go",
+                )
+                .category(ToolCategory::WebDiscovery),
+            )
             .param(ToolParam::required(
                 "mode",
                 ParamType::String,

--- a/crates/tools/src/external/hydra.rs
+++ b/crates/tools/src/external/hydra.rs
@@ -32,14 +32,17 @@ impl PentestTool for HydraTool {
     }
 
     fn schema(&self) -> ToolSchema {
-        use pentest_core::tools::ExternalDependency;
+        use pentest_core::tools::{ExternalDependency, ToolCategory};
 
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "hydra",
-                "hydra",
-                "Parallelized login bruteforcer (THC Hydra)",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "hydra",
+                    "hydra",
+                    "Parallelized login bruteforcer (THC Hydra)",
+                )
+                .category(ToolCategory::Credentials),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/john.rs
+++ b/crates/tools/src/external/john.rs
@@ -29,14 +29,13 @@ impl PentestTool for JohnTool {
     }
 
     fn schema(&self) -> ToolSchema {
-        use pentest_core::tools::ExternalDependency;
+        use pentest_core::tools::{ExternalDependency, ToolCategory};
 
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "john",
-                "john",
-                "John the Ripper password cracker",
-            ))
+            .external_dependency(
+                ExternalDependency::new("john", "john", "John the Ripper password cracker")
+                    .category(ToolCategory::Credentials),
+            )
             .param(ToolParam::required(
                 "hash_file",
                 ParamType::String,

--- a/crates/tools/src/external/masscan.rs
+++ b/crates/tools/src/external/masscan.rs
@@ -32,14 +32,15 @@ impl PentestTool for MasscanTool {
     }
 
     fn schema(&self) -> ToolSchema {
-        use pentest_core::tools::ExternalDependency;
+        use pentest_core::tools::{ExternalDependency, ToolCategory};
 
         ToolSchema::new(self.name(), self.description())
             .external_dependency(ExternalDependency::new(
                 "masscan",
                 "masscan",
                 "Internet-scale asynchronous TCP port scanner",
-            ))
+            )
+            .category(ToolCategory::Network))
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/metasploit.rs
+++ b/crates/tools/src/external/metasploit.rs
@@ -59,7 +59,7 @@ impl PentestTool for MetasploitTool {
                     "Metasploit Framework - exploitation and payload generation",
                 )
                 .custom_installer("metasploit")
-                .category(ToolCategory::PostExploit)
+                .category(ToolCategory::Exploitation)
                 .recommended(false),
             )
             .param(ToolParam::required(

--- a/crates/tools/src/external/network/arp_scan.rs
+++ b/crates/tools/src/external/network/arp_scan.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for ArpScanTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "arp-scan",
-                "arp-scan",
-                "ARP scanner",
-            ))
+            .external_dependency(
+                ExternalDependency::new("arp-scan", "arp-scan", "ARP scanner")
+                    .category(ToolCategory::Network),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/network/arping.rs
+++ b/crates/tools/src/external/network/arping.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,7 +27,10 @@ impl PentestTool for ArpingTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new("arping", "iputils", "IP utilities"))
+            .external_dependency(
+                ExternalDependency::new("arping", "iputils", "IP utilities")
+                    .category(ToolCategory::Network),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/network/bettercap.rs
+++ b/crates/tools/src/external/network/bettercap.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -28,11 +28,14 @@ impl PentestTool for BettercapTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "bettercap",
-                "bettercap",
-                "Network attack framework (Go-based)",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "bettercap",
+                    "bettercap",
+                    "Network attack framework (Go-based)",
+                )
+                .category(ToolCategory::Sniffing),
+            )
             .param(ToolParam::optional(
                 "interface",
                 ParamType::String,

--- a/crates/tools/src/external/network/hping3.rs
+++ b/crates/tools/src/external/network/hping3.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,7 +27,10 @@ impl PentestTool for Hping3Tool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new("hping3", "hping", "Packet tool"))
+            .external_dependency(
+                ExternalDependency::new("hping3", "hping", "Packet tool")
+                    .category(ToolCategory::Network),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/network/masscan_fast.rs
+++ b/crates/tools/src/external/network/masscan_fast.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for MasscanFastTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "masscan",
-                "masscan",
-                "Fast port scanner",
-            ))
+            .external_dependency(
+                ExternalDependency::new("masscan", "masscan", "Fast port scanner")
+                    .category(ToolCategory::Network),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/network/nbtscan.rs
+++ b/crates/tools/src/external/network/nbtscan.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for NbtscanTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "nbtscan",
-                "nbtscan",
-                "NetBIOS scanner",
-            ))
+            .external_dependency(
+                ExternalDependency::new("nbtscan", "nbtscan", "NetBIOS scanner")
+                    .category(ToolCategory::Network),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/network/netdiscover.rs
+++ b/crates/tools/src/external/network/netdiscover.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -28,11 +28,10 @@ impl PentestTool for NetdiscoverTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "netdiscover",
-                "netdiscover",
-                "ARP scanner",
-            ))
+            .external_dependency(
+                ExternalDependency::new("netdiscover", "netdiscover", "ARP scanner")
+                    .category(ToolCategory::Network),
+            )
             .param(ToolParam::optional(
                 "range",
                 ParamType::String,

--- a/crates/tools/src/external/network/nmap_vuln.rs
+++ b/crates/tools/src/external/network/nmap_vuln.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,7 +27,10 @@ impl PentestTool for NmapVulnTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new("nmap", "nmap", "Network scanner"))
+            .external_dependency(
+                ExternalDependency::new("nmap", "nmap", "Network scanner")
+                    .category(ToolCategory::Network),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/network/responder.rs
+++ b/crates/tools/src/external/network/responder.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -28,11 +28,14 @@ impl PentestTool for ResponderTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "responder",
-                "responder",
-                "Network poisoning tool (Python-based)",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "responder",
+                    "responder",
+                    "Network poisoning tool (Python-based)",
+                )
+                .category(ToolCategory::Sniffing),
+            )
             .param(ToolParam::required(
                 "interface",
                 ParamType::String,

--- a/crates/tools/src/external/network/tshark.rs
+++ b/crates/tools/src/external/network/tshark.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for TsharkTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "tshark",
-                "wireshark-cli",
-                "Packet analyzer",
-            ))
+            .external_dependency(
+                ExternalDependency::new("tshark", "wireshark-cli", "Packet analyzer")
+                    .category(ToolCategory::Sniffing),
+            )
             .param(ToolParam::optional(
                 "interface",
                 ParamType::String,

--- a/crates/tools/src/external/network/unicornscan.rs
+++ b/crates/tools/src/external/network/unicornscan.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for UnicornscanTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "unicornscan",
-                "unicornscan",
-                "Network scanner",
-            ))
+            .external_dependency(
+                ExternalDependency::new("unicornscan", "unicornscan", "Network scanner")
+                    .category(ToolCategory::Network),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/nikto.rs
+++ b/crates/tools/src/external/nikto.rs
@@ -32,14 +32,13 @@ impl PentestTool for NiktoTool {
     }
 
     fn schema(&self) -> ToolSchema {
-        use pentest_core::tools::ExternalDependency;
+        use pentest_core::tools::{ExternalDependency, ToolCategory};
 
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "nikto",
-                "nikto",
-                "Web server vulnerability scanner"
-            ))
+            .external_dependency(
+                ExternalDependency::new("nikto", "nikto", "Web server vulnerability scanner")
+                    .category(ToolCategory::Web),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/nmap.rs
+++ b/crates/tools/src/external/nmap.rs
@@ -34,14 +34,15 @@ impl PentestTool for NmapTool {
     }
 
     fn schema(&self) -> ToolSchema {
-        use pentest_core::tools::ExternalDependency;
+        use pentest_core::tools::{ExternalDependency, ToolCategory};
 
         ToolSchema::new(self.name(), self.description())
             .external_dependency(ExternalDependency::new(
                 "nmap",
                 "nmap",
                 "Network Mapper - Security scanner for network exploration"
-            ))
+            )
+            .category(ToolCategory::Network))
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/postexploit/crackmapexec.rs
+++ b/crates/tools/src/external/postexploit/crackmapexec.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -28,11 +28,14 @@ impl PentestTool for CrackmapexecTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "crackmapexec",
-                "crackmapexec",
-                "Network pentesting tool (Python-based)",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "crackmapexec",
+                    "crackmapexec",
+                    "Network pentesting tool (Python-based)",
+                )
+                .category(ToolCategory::ActiveDirectory),
+            )
             .param(ToolParam::required(
                 "protocol",
                 ParamType::String,

--- a/crates/tools/src/external/postexploit/evilwinrm.rs
+++ b/crates/tools/src/external/postexploit/evilwinrm.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,14 @@ impl PentestTool for EvilwinrmTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "evil-winrm",
-                "evil-winrm",
-                "WinRM shell tool (Ruby-based)",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "evil-winrm",
+                    "evil-winrm",
+                    "WinRM shell tool (Ruby-based)",
+                )
+                .category(ToolCategory::ActiveDirectory),
+            )
             .param(ToolParam::required(
                 "host",
                 ParamType::String,

--- a/crates/tools/src/external/postexploit/impacket_getuserspns.rs
+++ b/crates/tools/src/external/postexploit/impacket_getuserspns.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,14 @@ impl PentestTool for ImpacketGetuserspnsTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "impacket-getuserspns",
-                "impacket",
-                "Kerberoasting (Impacket)",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "impacket-getuserspns",
+                    "impacket",
+                    "Kerberoasting (Impacket)",
+                )
+                .category(ToolCategory::ActiveDirectory),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/postexploit/impacket_psexec.rs
+++ b/crates/tools/src/external/postexploit/impacket_psexec.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,14 @@ impl PentestTool for ImpacketPsexecTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "impacket-psexec",
-                "impacket",
-                "Remote execution tool via SMB (Python-based, part of Impacket)",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "impacket-psexec",
+                    "impacket",
+                    "Remote execution tool via SMB (Python-based, part of Impacket)",
+                )
+                .category(ToolCategory::ActiveDirectory),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/postexploit/impacket_secretsdump.rs
+++ b/crates/tools/src/external/postexploit/impacket_secretsdump.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -28,11 +28,14 @@ impl PentestTool for ImpacketSecretsdumpTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "impacket-secretsdump",
-                "impacket",
-                "Windows credential extraction tool (Python-based, part of Impacket suite)",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "impacket-secretsdump",
+                    "impacket",
+                    "Windows credential extraction tool (Python-based, part of Impacket suite)",
+                )
+                .category(ToolCategory::ActiveDirectory),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/postexploit/impacket_wmiexec.rs
+++ b/crates/tools/src/external/postexploit/impacket_wmiexec.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for ImpacketWmiexecTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "impacket-wmiexec",
-                "impacket",
-                "WMI execution (Impacket)",
-            ))
+            .external_dependency(
+                ExternalDependency::new("impacket-wmiexec", "impacket", "WMI execution (Impacket)")
+                    .category(ToolCategory::ActiveDirectory),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/postexploit/linpeas.rs
+++ b/crates/tools/src/external/postexploit/linpeas.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -28,11 +28,14 @@ impl PentestTool for LinpeasTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "linpeas",
-                "peass",
-                "Linux privilege escalation enumeration (Bash script)",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "linpeas",
+                    "peass",
+                    "Linux privilege escalation enumeration (Bash script)",
+                )
+                .category(ToolCategory::PostExploit),
+            )
             .param(ToolParam::optional(
                 "all_checks",
                 ParamType::Boolean,

--- a/crates/tools/src/external/rustscan.rs
+++ b/crates/tools/src/external/rustscan.rs
@@ -31,14 +31,17 @@ impl PentestTool for RustScanTool {
     }
 
     fn schema(&self) -> ToolSchema {
-        use pentest_core::tools::ExternalDependency;
+        use pentest_core::tools::{ExternalDependency, ToolCategory};
 
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "rustscan",
-                "rustscan",
-                "Modern ultra-fast port scanner written in Rust",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "rustscan",
+                    "rustscan",
+                    "Modern ultra-fast port scanner written in Rust",
+                )
+                .category(ToolCategory::Network),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/specialized/cewl.rs
+++ b/crates/tools/src/external/specialized/cewl.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for CewlTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "cewl",
-                "cewl",
-                "Wordlist generator (Ruby-based)",
-            ))
+            .external_dependency(
+                ExternalDependency::new("cewl", "cewl", "Wordlist generator (Ruby-based)")
+                    .category(ToolCategory::Credentials),
+            )
             .param(ToolParam::required("url", ParamType::String, "Target URL"))
             .param(ToolParam::optional(
                 "depth",

--- a/crates/tools/src/external/specialized/changeme.rs
+++ b/crates/tools/src/external/specialized/changeme.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for ChangemeTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "changeme",
-                "changeme",
-                "Default cred scanner",
-            ))
+            .external_dependency(
+                ExternalDependency::new("changeme", "changeme", "Default cred scanner")
+                    .category(ToolCategory::PostExploit),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/specialized/crunch.rs
+++ b/crates/tools/src/external/specialized/crunch.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for CrunchTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "crunch",
-                "crunch",
-                "Wordlist generator",
-            ))
+            .external_dependency(
+                ExternalDependency::new("crunch", "crunch", "Wordlist generator")
+                    .category(ToolCategory::Credentials),
+            )
             .param(ToolParam::required(
                 "min_length",
                 ParamType::Integer,

--- a/crates/tools/src/external/specialized/dnsenum.rs
+++ b/crates/tools/src/external/specialized/dnsenum.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for DnsenumTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "dnsenum",
-                "dnsenum",
-                "DNS enumeration tool",
-            ))
+            .external_dependency(
+                ExternalDependency::new("dnsenum", "dnsenum", "DNS enumeration tool")
+                    .category(ToolCategory::Recon),
+            )
             .param(ToolParam::required(
                 "domain",
                 ParamType::String,

--- a/crates/tools/src/external/specialized/dnsrecon.rs
+++ b/crates/tools/src/external/specialized/dnsrecon.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for DnsreconTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "dnsrecon",
-                "dnsrecon",
-                "DNS reconnaissance tool",
-            ))
+            .external_dependency(
+                ExternalDependency::new("dnsrecon", "dnsrecon", "DNS reconnaissance tool")
+                    .category(ToolCategory::Recon),
+            )
             .param(ToolParam::required(
                 "domain",
                 ParamType::String,

--- a/crates/tools/src/external/specialized/enum4linux_ng.rs
+++ b/crates/tools/src/external/specialized/enum4linux_ng.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for Enum4linuxNgTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "enum4linux-ng",
-                "enum4linux-ng",
-                "SMB enumerator",
-            ))
+            .external_dependency(
+                ExternalDependency::new("enum4linux-ng", "enum4linux-ng", "SMB enumerator")
+                    .category(ToolCategory::ActiveDirectory),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/specialized/eyewitness.rs
+++ b/crates/tools/src/external/specialized/eyewitness.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for EyewitnessTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "eyewitness",
-                "eyewitness",
-                "Screenshot tool",
-            ))
+            .external_dependency(
+                ExternalDependency::new("eyewitness", "eyewitness", "Screenshot tool")
+                    .category(ToolCategory::Web),
+            )
             .param(ToolParam::required(
                 "url",
                 ParamType::String,

--- a/crates/tools/src/external/specialized/eyewitness.rs
+++ b/crates/tools/src/external/specialized/eyewitness.rs
@@ -29,7 +29,7 @@ impl PentestTool for EyewitnessTool {
         ToolSchema::new(self.name(), self.description())
             .external_dependency(
                 ExternalDependency::new("eyewitness", "eyewitness", "Screenshot tool")
-                    .category(ToolCategory::Web),
+                    .category(ToolCategory::Recon),
             )
             .param(ToolParam::required(
                 "url",

--- a/crates/tools/src/external/specialized/fierce.rs
+++ b/crates/tools/src/external/specialized/fierce.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for FierceTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "fierce",
-                "fierce",
-                "DNS reconnaissance",
-            ))
+            .external_dependency(
+                ExternalDependency::new("fierce", "fierce", "DNS reconnaissance")
+                    .category(ToolCategory::Recon),
+            )
             .param(ToolParam::required(
                 "domain",
                 ParamType::String,

--- a/crates/tools/src/external/specialized/hashcat.rs
+++ b/crates/tools/src/external/specialized/hashcat.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,14 @@ impl PentestTool for HashcatTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "hashcat",
-                "hashcat",
-                "GPU password cracker (requires GPU drivers for full performance)",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "hashcat",
+                    "hashcat",
+                    "GPU password cracker (requires GPU drivers for full performance)",
+                )
+                .category(ToolCategory::Credentials),
+            )
             .param(ToolParam::required(
                 "hash_file",
                 ParamType::String,

--- a/crates/tools/src/external/specialized/ldapsearch_tool.rs
+++ b/crates/tools/src/external/specialized/ldapsearch_tool.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for LdapsearchTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "ldapsearch",
-                "openldap",
-                "LDAP utilities",
-            ))
+            .external_dependency(
+                ExternalDependency::new("ldapsearch", "openldap", "LDAP utilities")
+                    .category(ToolCategory::ActiveDirectory),
+            )
             .param(ToolParam::required("host", ParamType::String, "LDAP host"))
             .param(ToolParam::optional(
                 "base",

--- a/crates/tools/src/external/specialized/ncat.rs
+++ b/crates/tools/src/external/specialized/ncat.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -28,11 +28,10 @@ impl PentestTool for NcatTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "ncat",
-                "nmap",
-                "Networking utility (part of Nmap)",
-            ))
+            .external_dependency(
+                ExternalDependency::new("ncat", "nmap", "Networking utility (part of Nmap)")
+                    .category(ToolCategory::Utilities),
+            )
             .param(ToolParam::required(
                 "host",
                 ParamType::String,

--- a/crates/tools/src/external/specialized/nikto_ng.rs
+++ b/crates/tools/src/external/specialized/nikto_ng.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,7 +27,10 @@ impl PentestTool for NiktoNgTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new("nikto", "nikto", "Web scanner"))
+            .external_dependency(
+                ExternalDependency::new("nikto", "nikto", "Web scanner")
+                    .category(ToolCategory::Web),
+            )
             .param(ToolParam::required(
                 "host",
                 ParamType::String,

--- a/crates/tools/src/external/specialized/onesixtyone.rs
+++ b/crates/tools/src/external/specialized/onesixtyone.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for OnesixtyoneTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "onesixtyone",
-                "onesixtyone",
-                "SNMP scanner",
-            ))
+            .external_dependency(
+                ExternalDependency::new("onesixtyone", "onesixtyone", "SNMP scanner")
+                    .category(ToolCategory::Network),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/specialized/recon_ng.rs
+++ b/crates/tools/src/external/specialized/recon_ng.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for ReconNgTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "recon-ng",
-                "recon-ng",
-                "Recon framework",
-            ))
+            .external_dependency(
+                ExternalDependency::new("recon-ng", "recon-ng", "Recon framework")
+                    .category(ToolCategory::Recon),
+            )
             .param(ToolParam::required(
                 "domain",
                 ParamType::String,

--- a/crates/tools/src/external/specialized/searchsploit.rs
+++ b/crates/tools/src/external/specialized/searchsploit.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -28,11 +28,14 @@ impl PentestTool for SearchsploitTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "searchsploit",
-                "exploitdb",
-                "Exploit database search tool (local exploit-db)",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "searchsploit",
+                    "exploitdb",
+                    "Exploit database search tool (local exploit-db)",
+                )
+                .category(ToolCategory::Exploitation),
+            )
             .param(ToolParam::required(
                 "search_term",
                 ParamType::String,

--- a/crates/tools/src/external/specialized/skipfish.rs
+++ b/crates/tools/src/external/specialized/skipfish.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for SkipfishTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "skipfish",
-                "skipfish",
-                "Web recon tool",
-            ))
+            .external_dependency(
+                ExternalDependency::new("skipfish", "skipfish", "Web recon tool")
+                    .category(ToolCategory::Web),
+            )
             .param(ToolParam::required("url", ParamType::String, "Target URL"))
             .param(ToolParam::optional(
                 "output",

--- a/crates/tools/src/external/specialized/smbmap.rs
+++ b/crates/tools/src/external/specialized/smbmap.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for SmbmapTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "smbmap",
-                "smbmap",
-                "SMB enumeration",
-            ))
+            .external_dependency(
+                ExternalDependency::new("smbmap", "smbmap", "SMB enumeration")
+                    .category(ToolCategory::ActiveDirectory),
+            )
             .param(ToolParam::required(
                 "host",
                 ParamType::String,

--- a/crates/tools/src/external/specialized/snmpwalk.rs
+++ b/crates/tools/src/external/specialized/snmpwalk.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for SnmpwalkTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "snmpwalk",
-                "net-snmp",
-                "SNMP tools",
-            ))
+            .external_dependency(
+                ExternalDependency::new("snmpwalk", "net-snmp", "SNMP tools")
+                    .category(ToolCategory::Network),
+            )
             .param(ToolParam::required(
                 "host",
                 ParamType::String,

--- a/crates/tools/src/external/specialized/socat.rs
+++ b/crates/tools/src/external/specialized/socat.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for SocatTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "socat",
-                "socat",
-                "Multipurpose relay",
-            ))
+            .external_dependency(
+                ExternalDependency::new("socat", "socat", "Multipurpose relay")
+                    .category(ToolCategory::Utilities),
+            )
             .param(ToolParam::required(
                 "source",
                 ParamType::String,

--- a/crates/tools/src/external/specialized/spiderfoot.rs
+++ b/crates/tools/src/external/specialized/spiderfoot.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for SpiderfootTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "spiderfoot",
-                "spiderfoot",
-                "OSINT tool",
-            ))
+            .external_dependency(
+                ExternalDependency::new("spiderfoot", "spiderfoot", "OSINT tool")
+                    .category(ToolCategory::Recon),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/specialized/sslscan.rs
+++ b/crates/tools/src/external/specialized/sslscan.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for SslscanTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "sslscan",
-                "sslscan",
-                "SSL/TLS scanner",
-            ))
+            .external_dependency(
+                ExternalDependency::new("sslscan", "sslscan", "SSL/TLS scanner")
+                    .category(ToolCategory::Crypto),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/specialized/testssl.rs
+++ b/crates/tools/src/external/specialized/testssl.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for TestsslTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "testssl",
-                "testssl.sh",
-                "TLS/SSL tester",
-            ))
+            .external_dependency(
+                ExternalDependency::new("testssl", "testssl.sh", "TLS/SSL tester")
+                    .category(ToolCategory::Crypto),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/specialized/theharvester.rs
+++ b/crates/tools/src/external/specialized/theharvester.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for TheHarvesterTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "theHarvester",
-                "theharvester",
-                "OSINT gathering tool",
-            ))
+            .external_dependency(
+                ExternalDependency::new("theHarvester", "theharvester", "OSINT gathering tool")
+                    .category(ToolCategory::Recon),
+            )
             .param(ToolParam::required(
                 "domain",
                 ParamType::String,

--- a/crates/tools/src/external/specialized/whois_tool.rs
+++ b/crates/tools/src/external/specialized/whois_tool.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,7 +27,10 @@ impl PentestTool for WhoisTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new("whois", "whois", "WHOIS client"))
+            .external_dependency(
+                ExternalDependency::new("whois", "whois", "WHOIS client")
+                    .category(ToolCategory::Recon),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/web/amass.rs
+++ b/crates/tools/src/external/web/amass.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -28,11 +28,14 @@ impl PentestTool for AmassTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "amass",
-                "amass",
-                "DNS enumeration and network mapping tool (Go-based)",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "amass",
+                    "amass",
+                    "DNS enumeration and network mapping tool (Go-based)",
+                )
+                .category(ToolCategory::Recon),
+            )
             .param(ToolParam::required(
                 "domain",
                 ParamType::String,

--- a/crates/tools/src/external/web/arjun.rs
+++ b/crates/tools/src/external/web/arjun.rs
@@ -5,8 +5,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -30,11 +30,14 @@ impl PentestTool for ArjunTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "arjun",
-                "arjun",
-                "HTTP parameter discovery tool (Python-based)",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "arjun",
+                    "arjun",
+                    "HTTP parameter discovery tool (Python-based)",
+                )
+                .category(ToolCategory::WebDiscovery),
+            )
             .param(ToolParam::required(
                 "url",
                 ParamType::String,

--- a/crates/tools/src/external/web/assetfinder.rs
+++ b/crates/tools/src/external/web/assetfinder.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for AssetfinderTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "assetfinder",
-                "assetfinder",
-                "Asset discovery tool",
-            ))
+            .external_dependency(
+                ExternalDependency::new("assetfinder", "assetfinder", "Asset discovery tool")
+                    .category(ToolCategory::Recon),
+            )
             .param(ToolParam::required(
                 "domain",
                 ParamType::String,

--- a/crates/tools/src/external/web/commix.rs
+++ b/crates/tools/src/external/web/commix.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -28,11 +28,14 @@ impl PentestTool for CommixTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "commix",
-                "commix",
-                "Command injection exploitation tool (Python-based)",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "commix",
+                    "commix",
+                    "Command injection exploitation tool (Python-based)",
+                )
+                .category(ToolCategory::Web),
+            )
             .param(ToolParam::required(
                 "url",
                 ParamType::String,

--- a/crates/tools/src/external/web/dalfox.rs
+++ b/crates/tools/src/external/web/dalfox.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,7 +27,10 @@ impl PentestTool for DalfoxTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new("dalfox", "dalfox", "XSS scanner"))
+            .external_dependency(
+                ExternalDependency::new("dalfox", "dalfox", "XSS scanner")
+                    .category(ToolCategory::Web),
+            )
             .param(ToolParam::required("url", ParamType::String, "Target URL"))
             .param(ToolParam::optional(
                 "timeout",

--- a/crates/tools/src/external/web/dirsearch.rs
+++ b/crates/tools/src/external/web/dirsearch.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,14 @@ impl PentestTool for DirsearchTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "dirsearch",
-                "dirsearch",
-                "Web path scanner (Python-based)",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "dirsearch",
+                    "dirsearch",
+                    "Web path scanner (Python-based)",
+                )
+                .category(ToolCategory::WebDiscovery),
+            )
             .param(ToolParam::required("url", ParamType::String, "Target URL"))
             .param(ToolParam::optional(
                 "extensions",

--- a/crates/tools/src/external/web/droopescan.rs
+++ b/crates/tools/src/external/web/droopescan.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for DroopescanTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "droopescan",
-                "droopescan",
-                "CMS scanner",
-            ))
+            .external_dependency(
+                ExternalDependency::new("droopescan", "droopescan", "CMS scanner")
+                    .category(ToolCategory::Web),
+            )
             .param(ToolParam::required("url", ParamType::String, "Target URL"))
             .param(ToolParam::optional(
                 "cms",

--- a/crates/tools/src/external/web/feroxbuster.rs
+++ b/crates/tools/src/external/web/feroxbuster.rs
@@ -5,8 +5,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -35,7 +35,7 @@ impl PentestTool for FeroxbusterTool {
                 "feroxbuster",
                 "feroxbuster",
                 "Fast content discovery tool (Rust-based)"
-            ))
+            ).category(ToolCategory::WebDiscovery))
             .param(ToolParam::required(
                 "url",
                 ParamType::String,

--- a/crates/tools/src/external/web/ffuf_dns.rs
+++ b/crates/tools/src/external/web/ffuf_dns.rs
@@ -29,7 +29,7 @@ impl PentestTool for FfufDnsTool {
         ToolSchema::new(self.name(), self.description())
             .external_dependency(
                 ExternalDependency::new("ffuf", "ffuf", "Fast fuzzer")
-                    .category(ToolCategory::WebDiscovery),
+                    .category(ToolCategory::Recon),
             )
             .param(ToolParam::required(
                 "domain",

--- a/crates/tools/src/external/web/ffuf_dns.rs
+++ b/crates/tools/src/external/web/ffuf_dns.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,7 +27,10 @@ impl PentestTool for FfufDnsTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new("ffuf", "ffuf", "Fast fuzzer"))
+            .external_dependency(
+                ExternalDependency::new("ffuf", "ffuf", "Fast fuzzer")
+                    .category(ToolCategory::WebDiscovery),
+            )
             .param(ToolParam::required(
                 "domain",
                 ParamType::String,

--- a/crates/tools/src/external/web/gau.rs
+++ b/crates/tools/src/external/web/gau.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,7 +27,10 @@ impl PentestTool for GauTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new("gau", "gau", "Get All URLs tool"))
+            .external_dependency(
+                ExternalDependency::new("gau", "gau", "Get All URLs tool")
+                    .category(ToolCategory::Recon),
+            )
             .param(ToolParam::required(
                 "domain",
                 ParamType::String,

--- a/crates/tools/src/external/web/gospider.rs
+++ b/crates/tools/src/external/web/gospider.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for GospiderTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "gospider",
-                "gospider",
-                "Web crawler (Go)",
-            ))
+            .external_dependency(
+                ExternalDependency::new("gospider", "gospider", "Web crawler (Go)")
+                    .category(ToolCategory::WebDiscovery),
+            )
             .param(ToolParam::required("url", ParamType::String, "Target URL"))
             .param(ToolParam::optional(
                 "depth",

--- a/crates/tools/src/external/web/hakrawler.rs
+++ b/crates/tools/src/external/web/hakrawler.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for HakrawlerTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "hakrawler",
-                "hakrawler",
-                "Web crawler (Go-based)",
-            ))
+            .external_dependency(
+                ExternalDependency::new("hakrawler", "hakrawler", "Web crawler (Go-based)")
+                    .category(ToolCategory::WebDiscovery),
+            )
             .param(ToolParam::required("url", ParamType::String, "Target URL"))
             .param(ToolParam::optional(
                 "depth",

--- a/crates/tools/src/external/web/httprobe.rs
+++ b/crates/tools/src/external/web/httprobe.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for HttpprobeTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "httprobe",
-                "httprobe",
-                "HTTP probe (Go-based)",
-            ))
+            .external_dependency(
+                ExternalDependency::new("httprobe", "httprobe", "HTTP probe (Go-based)")
+                    .category(ToolCategory::Recon),
+            )
             .param(ToolParam::required(
                 "domains",
                 ParamType::String,

--- a/crates/tools/src/external/web/joomscan.rs
+++ b/crates/tools/src/external/web/joomscan.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for JoomscanTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "joomscan",
-                "joomscan",
-                "Joomla scanner",
-            ))
+            .external_dependency(
+                ExternalDependency::new("joomscan", "joomscan", "Joomla scanner")
+                    .category(ToolCategory::Web),
+            )
             .param(ToolParam::required("url", ParamType::String, "Target URL"))
             .param(ToolParam::optional(
                 "timeout",

--- a/crates/tools/src/external/web/katana.rs
+++ b/crates/tools/src/external/web/katana.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,7 +27,10 @@ impl PentestTool for KatanaTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new("katana", "katana", "Web crawler"))
+            .external_dependency(
+                ExternalDependency::new("katana", "katana", "Web crawler")
+                    .category(ToolCategory::WebDiscovery),
+            )
             .param(ToolParam::required("url", ParamType::String, "Target URL"))
             .param(ToolParam::optional(
                 "depth",

--- a/crates/tools/src/external/web/nuclei.rs
+++ b/crates/tools/src/external/web/nuclei.rs
@@ -6,8 +6,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -32,11 +32,14 @@ impl PentestTool for NucleiTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "nuclei",
-                "nuclei",
-                "Template-based vulnerability scanner (Go binary + ~500MB templates on first run)",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "nuclei",
+                    "nuclei",
+                    "Template-based vulnerability scanner (Go binary + ~500MB templates on first run)",
+                )
+                .category(ToolCategory::Web),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/web/paramspider.rs
+++ b/crates/tools/src/external/web/paramspider.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for ParamspiderTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "paramspider",
-                "paramspider",
-                "Parameter discovery",
-            ))
+            .external_dependency(
+                ExternalDependency::new("paramspider", "paramspider", "Parameter discovery")
+                    .category(ToolCategory::WebDiscovery),
+            )
             .param(ToolParam::required(
                 "domain",
                 ParamType::String,

--- a/crates/tools/src/external/web/sqlmap.rs
+++ b/crates/tools/src/external/web/sqlmap.rs
@@ -6,8 +6,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -32,11 +32,14 @@ impl PentestTool for SqlmapTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "sqlmap",
-                "sqlmap",
-                "SQL injection automation tool (Python-based, ~30MB download)"
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "sqlmap",
+                    "sqlmap",
+                    "SQL injection automation tool (Python-based, ~30MB download)",
+                )
+                .category(ToolCategory::Web),
+            )
             .param(ToolParam::required(
                 "target",
                 ParamType::String,

--- a/crates/tools/src/external/web/subfinder.rs
+++ b/crates/tools/src/external/web/subfinder.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for SubfinderTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "subfinder",
-                "subfinder",
-                "Subdomain discovery",
-            ))
+            .external_dependency(
+                ExternalDependency::new("subfinder", "subfinder", "Subdomain discovery")
+                    .category(ToolCategory::Recon),
+            )
             .param(ToolParam::required(
                 "domain",
                 ParamType::String,

--- a/crates/tools/src/external/web/sublist3r.rs
+++ b/crates/tools/src/external/web/sublist3r.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -28,11 +28,14 @@ impl PentestTool for Sublist3rTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "sublist3r",
-                "sublist3r",
-                "Subdomain enumeration tool (Python-based)",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "sublist3r",
+                    "sublist3r",
+                    "Subdomain enumeration tool (Python-based)",
+                )
+                .category(ToolCategory::Recon),
+            )
             .param(ToolParam::required(
                 "domain",
                 ParamType::String,

--- a/crates/tools/src/external/web/wafw00f.rs
+++ b/crates/tools/src/external/web/wafw00f.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,10 @@ impl PentestTool for Wafw00fTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "wafw00f",
-                "wafw00f",
-                "WAF detector",
-            ))
+            .external_dependency(
+                ExternalDependency::new("wafw00f", "wafw00f", "WAF detector")
+                    .category(ToolCategory::Web),
+            )
             .param(ToolParam::required("url", ParamType::String, "Target URL"))
             .param(ToolParam::optional(
                 "timeout",

--- a/crates/tools/src/external/web/waybackurls.rs
+++ b/crates/tools/src/external/web/waybackurls.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,14 @@ impl PentestTool for WaybackurlsTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "waybackurls",
-                "waybackurls",
-                "Wayback Machine URL fetcher (Go)",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "waybackurls",
+                    "waybackurls",
+                    "Wayback Machine URL fetcher (Go)",
+                )
+                .category(ToolCategory::Recon),
+            )
             .param(ToolParam::required(
                 "domain",
                 ParamType::String,

--- a/crates/tools/src/external/web/wfuzz.rs
+++ b/crates/tools/src/external/web/wfuzz.rs
@@ -7,8 +7,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -32,11 +32,10 @@ impl PentestTool for WfuzzTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "wfuzz",
-                "wfuzz",
-                "Web application fuzzer (Python-based)",
-            ))
+            .external_dependency(
+                ExternalDependency::new("wfuzz", "wfuzz", "Web application fuzzer (Python-based)")
+                    .category(ToolCategory::WebDiscovery),
+            )
             .param(ToolParam::required(
                 "url",
                 ParamType::String,

--- a/crates/tools/src/external/web/whatweb.rs
+++ b/crates/tools/src/external/web/whatweb.rs
@@ -4,7 +4,7 @@ use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
     execute_timed_with_provenance, ExternalDependency, ParamType, PentestTool, Platform,
-    ToolContext, ToolParam, ToolResult, ToolSchema,
+    ToolCategory, ToolContext, ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -28,11 +28,10 @@ impl PentestTool for WhatwebTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "whatweb",
-                "whatweb",
-                "Web tech identifier",
-            ))
+            .external_dependency(
+                ExternalDependency::new("whatweb", "whatweb", "Web tech identifier")
+                    .category(ToolCategory::Web),
+            )
             .param(ToolParam::required("url", ParamType::String, "Target URL"))
             .param(ToolParam::optional(
                 "timeout",

--- a/crates/tools/src/external/web/wpscan.rs
+++ b/crates/tools/src/external/web/wpscan.rs
@@ -5,8 +5,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -31,11 +31,14 @@ impl PentestTool for WpscanTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "wpscan",
-                "wpscan",
-                "WordPress vulnerability scanner (Ruby-based)"
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "wpscan",
+                    "wpscan",
+                    "WordPress vulnerability scanner (Ruby-based)",
+                )
+                .category(ToolCategory::Web),
+            )
             .param(ToolParam::required(
                 "url",
                 ParamType::String,

--- a/crates/tools/src/external/web/xsstrike.rs
+++ b/crates/tools/src/external/web/xsstrike.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,14 @@ impl PentestTool for XsstrikeTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "xsstrike",
-                "xsstrike",
-                "XSS detection tool (Python-based)",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "xsstrike",
+                    "xsstrike",
+                    "XSS detection tool (Python-based)",
+                )
+                .category(ToolCategory::Web),
+            )
             .param(ToolParam::required("url", ParamType::String, "Target URL"))
             .param(ToolParam::optional(
                 "data",

--- a/crates/tools/src/external/wireless/aircrackng.rs
+++ b/crates/tools/src/external/wireless/aircrackng.rs
@@ -3,8 +3,8 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::tools::{
-    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolContext, ToolParam,
-    ToolResult, ToolSchema,
+    execute_timed, ExternalDependency, ParamType, PentestTool, Platform, ToolCategory, ToolContext,
+    ToolParam, ToolResult, ToolSchema,
 };
 use pentest_platform::{get_platform, CommandExec};
 use serde_json::{json, Value};
@@ -27,11 +27,14 @@ impl PentestTool for AircrackngTool {
 
     fn schema(&self) -> ToolSchema {
         ToolSchema::new(self.name(), self.description())
-            .external_dependency(ExternalDependency::new(
-                "aircrack-ng",
-                "aircrack-ng",
-                "WiFi security auditing suite",
-            ))
+            .external_dependency(
+                ExternalDependency::new(
+                    "aircrack-ng",
+                    "aircrack-ng",
+                    "WiFi security auditing suite",
+                )
+                .category(ToolCategory::Wireless),
+            )
             .param(ToolParam::required(
                 "capture_file",
                 ParamType::String,

--- a/crates/tools/src/external/zap.rs
+++ b/crates/tools/src/external/zap.rs
@@ -53,7 +53,7 @@ impl PentestTool for ZapTool {
                     "OWASP ZAP - dynamic application security testing engine",
                 )
                 .custom_installer("zap")
-                .category(ToolCategory::Web),
+                .category(ToolCategory::Proxy),
             )
             .param(ToolParam::required(
                 "target",

--- a/crates/ui/src/components/tool_category.rs
+++ b/crates/ui/src/components/tool_category.rs
@@ -17,14 +17,20 @@ use super::icons::{Folder, Lock, Network, Search, Shield, Terminal, Wifi};
 /// to "Other".
 pub fn humanize_category(category: &str) -> &'static str {
     match category {
-        "network" => "Network",
-        "web" => "Web",
-        "active_directory" => "Active Directory",
-        "credentials" => "Credentials",
+        "network" => "Network Scanning",
+        "web" => "Web - Scanning & Exploit",
+        "web_discovery" => "Web - Content Discovery",
+        "proxy" => "Proxies",
+        "active_directory" => "Active Directory & Windows",
+        "credentials" => "Password Attacks",
+        "exploitation" => "Exploitation",
         "post_exploit" => "Post-Exploitation",
+        "sniffing" => "Sniffing & Spoofing",
         "wireless" => "Wireless",
-        "recon" => "Reconnaissance",
+        "recon" => "Recon & OSINT",
+        "crypto" => "TLS / Crypto",
         "forensics" => "Forensics",
+        "utilities" => "Utilities",
         "system" => "System",
         "files" => "Files",
         _ => "Other",
@@ -35,11 +41,15 @@ pub fn humanize_category(category: &str) -> &'static str {
 pub fn category_icon(category: &str) -> Element {
     match category {
         "network" => rsx! { Network { size: 18 } },
-        "web" => rsx! { Search { size: 18 } },
+        "web" | "web_discovery" => rsx! { Search { size: 18 } },
+        "proxy" => rsx! { Network { size: 18 } },
         "active_directory" | "credentials" => rsx! { Lock { size: 18 } },
-        "post_exploit" => rsx! { Shield { size: 18 } },
+        "exploitation" | "post_exploit" => rsx! { Shield { size: 18 } },
+        "sniffing" => rsx! { Wifi { size: 18 } },
         "wireless" => rsx! { Wifi { size: 18 } },
         "recon" | "forensics" => rsx! { Search { size: 18 } },
+        "crypto" => rsx! { Lock { size: 18 } },
+        "utilities" => rsx! { Terminal { size: 18 } },
         "files" => rsx! { Folder { size: 18 } },
         _ => rsx! { Terminal { size: 18 } },
     }


### PR DESCRIPTION
## Summary

Child A of epic #250. Expands the tool taxonomy so the Settings Tools grid (from #259) and the read-only Tools page group tools into meaningful, BlackArch-aligned categories instead of dumping ~80 tools into "Other".

Closes #261.

### Enum (`crates/core/src/tools.rs`)
Added 6 curated categories - `WebDiscovery`, `Proxy`, `Exploitation`, `Sniffing`, `Crypto`, `Utilities` - alongside the existing Network, Web, ActiveDirectory, Credentials, PostExploit, Wireless, Recon, Forensics.

### Catalog (`crates/tools/src/catalog.rs`)
- **`category_key()`** - one exhaustive match from `ToolCategory` to its stable serde key, shared by the catalog and the overview. Replaces a hand-written match in `overview_category` that had already gone stale, and makes a future missing key a **compile error**.
- **Hide runtime deps** - `python3` / `playwright` are filtered from the catalog UI (`HIDDEN_CATALOG_BINARIES`). They stay real dependencies for webwright's installer; they're just not operator-facing "tools" (per maintainer decision).

### Re-tagging (~80 files)
Every `ExternalDependency::new(...)` now declares a `.category(...)`. Also corrected 3 that predated the taxonomy: burp/zap `Web` -> `Proxy`, metasploit `PostExploit` -> `Exploitation`. Final distribution (no tool left in "Other"):

| Category | # | Category | # |
|---|---|---|---|
| Web (scan/exploit) | 14 | Credentials | 5 |
| Recon & OSINT | 14 | Sniffing | 3 |
| Active Directory | 14 | Proxy / PostExploit / Exploitation / Utilities | 2 each |
| Network | 13 | Wireless / Forensics / Crypto | 1 each |
| Web Discovery | 12 | | |

### UI (`crates/ui/src/components/tool_category.rs`)
Friendly labels ("Recon & OSINT", "Web - Content Discovery", "TLS / Crypto", ...) and icons for every new key, shared by both surfaces.

## How the ~80 re-taggings were done
The mechanical `.category(...)` insertion + import handling was fanned out across 6 parallel subagents over disjoint file sets, each self-verifying with `cargo check`. I then verified the whole set centrally: 0 files untagged, category distribution matches the intended mapping, and diffs contain only category/import/rustfmt-reflow changes (no logic/param edits) - spot-checked several files.

## Verification
- `cargo fmt --all --check`: clean.
- `cargo check --workspace --features pentest-platform/desktop-pcap`: 0 errors.
- `cargo clippy --workspace --features pentest-platform/desktop-pcap -- -D warnings`: clean (exit 0).
- New tests pass: `category_key_covers_new_taxonomy_variants`, `runtime_dep_binaries_are_hidden_from_catalog`; updated the nmap-category assertion.

### Note on 2 flaky tests
`webwright_integration`'s `evidence_ingestion_produces_typed_nodes` and `findings_ingestion_maps_all_severity_levels` fail under full-workspace parallelism. **A/B-verified as pre-existing and unrelated**: they fail identically on clean `main`, pass single-threaded and pass when that binary runs alone, and share a process-global evidence buffer (`drain_pending_evidence()`). My diff does not touch evidence ingestion. Filed as #269.

## Test plan
- [x] Installable catalog groups into the new categories with nothing in "Other" (verified by building `build_catalog_items()`: 0 entries in "other" after also hiding the `node` runtime dep - see note).
- [x] python3 / playwright (and node) absent from the catalog (verified against `build_catalog_items()`).
- [x] Read-only overview emits the same category keys via the shared helpers (verified via `tools_overview_categories()`; built-in tools still use the name-heuristic buckets system/files/other, which is unchanged and out of scope).
- [x] burpsuite -> proxy, zaproxy -> proxy, msfconsole -> exploitation, eyewitness -> recon (all verified against the built catalog).

Part of epic #250. Next: #262 (collapsible categories), then #263 (live BlackArch tier), #264 (group install-all), #265 (uninstall).


---
**Manual verification (2026-07-18):** built the live catalog (`build_catalog_items()`) and the read-only overview (`tools_overview_categories()`) rather than only grepping the source.

- Surfaced one entry still in "other": `node`, declared by the CyberChef tool (crates/cyberchef) - a Node.js runtime prerequisite, now hidden alongside python3/playwright (commit `caad6a8`). Catalog "other" is now empty.
- Note on `ffuf`: `ffuf` (base, WebDiscovery) and `ffuf_dns` (Recon) share the binary `ffuf`, so the catalog dedups to a single WebDiscovery entry (correct - it installs one `ffuf` binary). The Recon fix for `ffuf_dns` still applies to the per-tool read-only overview.