### PR TITLE
fix(#269): serialize webwright evidence tests to stop CI flakiness

### DIFF
--- a/crates/tools/tests/webwright_integration.rs
+++ b/crates/tools/tests/webwright_integration.rs
@@ -14,6 +14,20 @@ use pentest_tools::webwright::evidence::{ingest_webwright_evidence, ingest_webwr
 use pentest_tools::webwright::workspace::WebwrightWorkspace;
 use pentest_tools::WebwrightTool;
 use serde_json::json;
+use std::sync::{Mutex, MutexGuard};
+
+/// Serializes the tests that touch the process-global `PENDING_EVIDENCE`
+/// buffer (via `push_evidence`/`drain_pending_evidence`). Without this, tests
+/// that drain-then-assert-count race each other: one test's pushed nodes land
+/// in another's drain, so counts come out wrong nondeterministically (the
+/// classic doubling/halving). Holding this lock for the whole
+/// drain-ingest-drain sequence makes each such test see only its own evidence.
+/// Poison-tolerant: a panic in one test must not cascade-fail the others.
+static EVIDENCE_LOCK: Mutex<()> = Mutex::new(());
+
+fn lock_evidence() -> MutexGuard<'static, ()> {
+    EVIDENCE_LOCK.lock().unwrap_or_else(|e| e.into_inner())
+}
 
 /// Test that execute mode runs a Python script and captures output.
 #[tokio::test]
@@ -396,6 +410,7 @@ async fn workspace_creates_and_collects_artifacts() {
 fn evidence_ingestion_produces_typed_nodes() {
     use pentest_core::provenance::ProbeCommand;
 
+    let _guard = lock_evidence();
     let _ = drain_pending_evidence();
 
     let artifacts = json!({
@@ -488,6 +503,7 @@ fn findings_ingestion_maps_all_severity_levels() {
     use pentest_core::export::Severity;
     use pentest_core::provenance::ProbeCommand;
 
+    let _guard = lock_evidence();
     let _ = drain_pending_evidence();
 
     let findings = json!([


### PR DESCRIPTION
## Summary

Two tests in `crates/tools/tests/webwright_integration.rs` -  `evidence_ingestion_produces_typed_nodes` and `findings_ingestion_maps_all_severity_levels` - fail nondeterministically under the full-workspace parallel test run, red-lighting unrelated PRs (it just failed #267's CI; would hit #270 and every future PR).

Closes #269.

## Root cause

Both tests drain the **process-global** `PENDING_EVIDENCE` buffer (`evidence_producer.rs`), ingest a fixed set of nodes, then assert on the drained count. When they run concurrently with each other or any other test that pushes evidence, nodes bleed across tests - so the count comes out wrong (observed: got 1, 3, or 10 vs expected 8/5). The varying number is the signature of a shared-state race, not a logic bug. A/B-verified: fails identically on clean `main`; passes single-threaded.

## Fix

Add a test-local `EVIDENCE_LOCK: Mutex<()>` and hold it across each test's full drain-ingest-drain sequence, so each test sees only its own evidence.

- **Why not `#[ignore]`** (the pattern the 3 evidence-buffer unit tests use): CI has **no `--ignored` step**, so ignoring these would silently drop their coverage. Serializing keeps them running in normal CI.
- **Poison-tolerant** (`into_inner()` on a poisoned lock) so a panic in one guarded test doesn't cascade-fail the others.
- Only the 2 non-ignored buffer tests are guarded. The two sandbox-gated `#[ignore]`'d tests that also touch the buffer `.await` across their buffer ops (holding a std Mutex across await = deadlock/`await_holding_lock` risk) and don't run in normal CI, so they're intentionally left unguarded.

## Verification

- `cargo test --workspace --features pentest-platform/desktop-pcap`: **exit 0, 0 failures** (previously 2 failed) - this is the exact CI condition that failed.
- `webwright_integration` binary: green across 3 repeated parallel runs.
- `cargo clippy --workspace --tests -- -D warnings`: clean (no `await_holding_lock`).
- `cargo fmt --all --check`: clean.

## Impact on other PRs

Once merged, #267 and #270 rebase onto this and go green deterministically. This removes the flake for all future PRs.

## Test plan
- [x] Full workspace test passes (exit 0).
- [x] webwright_integration passes across repeated parallel runs.
- [x] clippy `-D warnings` clean (no await-holding-lock).
- [ ] CI Test job passes on this PR.