### PR TITLE
feat(#262): collapsible tool category sections (collapsed by default)

### DIFF
--- a/crates/ui/src/components/css/settings_page.css
+++ b/crates/ui/src/components/css/settings_page.css
@@ -494,6 +494,51 @@
     display: flex;
     align-items: center;
     gap: 6px;
+    cursor: pointer;
+    user-select: none;
+    padding: 2px 0;
+    border-radius: 4px;
+    transition: color 0.15s;
+}
+
+.settings-tools-header:hover .settings-tools-title,
+.settings-tools-header:hover .settings-tools-caret {
+    color: var(--foreground);
+}
+
+.settings-tools-header:focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
+}
+
+/* Chevron rotates from pointing-right (collapsed) to down (expanded). */
+.settings-tools-caret {
+    display: flex;
+    align-items: center;
+    color: var(--muted-foreground);
+    transform: rotate(-90deg);
+    transition: transform 0.15s ease;
+}
+
+.settings-tools-caret.expanded {
+    transform: rotate(0deg);
+}
+
+.settings-tools-caret svg {
+    width: 14px;
+    height: 14px;
+}
+
+/* Per-category tool count, right-aligned in the header. */
+.settings-tools-count {
+    margin-left: auto;
+    font-size: 11px;
+    font-family: var(--font-mono);
+    color: var(--muted-foreground);
+    background: var(--background);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1px 8px;
 }
 
 .settings-tools-icon {

--- a/crates/ui/src/components/css/tools_page.css
+++ b/crates/ui/src/components/css/tools_page.css
@@ -27,6 +27,50 @@
     display: flex;
     align-items: center;
     gap: 8px;
+    cursor: pointer;
+    user-select: none;
+    padding: 2px 0;
+    border-radius: 4px;
+}
+
+.tools-category-header:hover .tools-category-title,
+.tools-category-header:hover .tools-category-caret {
+    color: var(--foreground);
+}
+
+.tools-category-header:focus-visible {
+    outline: 2px solid var(--ring);
+    outline-offset: 2px;
+}
+
+/* Chevron rotates from pointing-right (collapsed) to down (expanded). */
+.tools-category-caret {
+    display: flex;
+    align-items: center;
+    color: var(--muted-foreground);
+    transform: rotate(-90deg);
+    transition: transform 0.15s ease;
+}
+
+.tools-category-caret.expanded {
+    transform: rotate(0deg);
+}
+
+.tools-category-caret svg {
+    width: 14px;
+    height: 14px;
+}
+
+/* Per-category tool count, right-aligned in the header. */
+.tools-category-count {
+    margin-left: auto;
+    font-size: 11px;
+    font-family: var(--font-mono);
+    color: var(--muted-foreground);
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 1px 8px;
 }
 
 .tools-category-icon {

--- a/crates/ui/src/components/settings_page.rs
+++ b/crates/ui/src/components/settings_page.rs
@@ -4,8 +4,9 @@
 use dioxus::prelude::*;
 use pentest_core::config::{BorderRadius, Density, ShellMode, Theme};
 use pentest_platform::WifiConnectionStatus;
+use std::collections::HashSet;
 
-use super::icons::{Download, Palette, Settings, Wifi};
+use super::icons::{ChevronDown, Download, Palette, Settings, Wifi};
 use super::tool_category::{category_icon, humanize_category};
 use crate::platform_helper;
 use pentest_core::seed::{SeedManager, SeedProgress, SeedTier};
@@ -78,6 +79,10 @@ pub fn SettingsPage(
     // Tools catalog state
     let mut catalog_items = use_signal(|| None::<Vec<pentest_tools::catalog::CatalogItem>>);
     let mut catalog_loading = use_signal(|| false);
+    // Category keys the operator has expanded. Categories are collapsed by
+    // default (empty set) so the panel stays compact even as the catalog grows;
+    // a collapsed category renders only its header, not its cards.
+    let mut expanded_categories = use_signal(HashSet::<String>::new);
     // binary_name currently installing, or the "__all__" sentinel for the bulk
     // install, or None when idle.
     let mut installing = use_signal(|| None::<String>);
@@ -394,11 +399,47 @@ pub fn SettingsPage(
                         div { class: "text-dim-xs", style: "margin-top: 12px;", "Loading tools..." }
                     } else if let Some(items) = catalog_items() {
                         for category in tool_categories(&items) {
+                            {
+                                let count = items.iter().filter(|i| i.category == category).count();
+                                let is_expanded = expanded_categories().contains(&category);
+                                let toggle_category = category.clone();
+                                rsx! {
                             div { class: "settings-tools-section",
-                                div { class: "settings-tools-header",
+                                div {
+                                    class: "settings-tools-header",
+                                    role: "button",
+                                    tabindex: 0,
+                                    "aria-expanded": "{is_expanded}",
+                                    onclick: move |_| {
+                                        let mut set = expanded_categories.write();
+                                        if !set.remove(&toggle_category) {
+                                            set.insert(toggle_category.clone());
+                                        }
+                                    },
+                                    onkeydown: {
+                                        let key_category = category.clone();
+                                        move |evt: Event<KeyboardData>| {
+                                            let key = evt.key();
+                                            if key == Key::Enter
+                                                || matches!(key, Key::Character(ref c) if c == " ")
+                                            {
+                                                evt.prevent_default();
+                                                let mut set = expanded_categories.write();
+                                                if !set.remove(&key_category) {
+                                                    set.insert(key_category.clone());
+                                                }
+                                            }
+                                        }
+                                    },
+                                    span {
+                                        class: if is_expanded { "settings-tools-caret expanded" } else { "settings-tools-caret" },
+                                        ChevronDown { size: 14 }
+                                    }
                                     span { class: "settings-tools-icon", {category_icon(&category)} }
                                     h3 { class: "settings-tools-title", "{humanize_category(&category)}" }
+                                    span { class: "settings-tools-count", "{count}" }
                                 }
+                                if is_expanded {
                                 div { class: "tools-grid",
                                     for item in items.iter().filter(|i| i.category == category).cloned() {
                                         {
@@ -552,6 +593,9 @@ pub fn SettingsPage(
                                             }
                                         }
                                     }
+                                }
+                                }
+                            }
                                 }
                             }
                         }

--- a/crates/ui/src/components/tools_page.rs
+++ b/crates/ui/src/components/tools_page.rs
@@ -5,8 +5,11 @@
 //! tool appears and new tools show up automatically. Clicking a tool opens the
 //! chat pre-seeded with a prompt to use it.
 
+use std::collections::HashSet;
+
 use dioxus::prelude::*;
 
+use super::icons::ChevronDown;
 use super::tool_category::{category_icon, humanize_category};
 
 /// Tools page — displays all registered connector tools grouped by category.
@@ -18,6 +21,11 @@ pub fn ToolsPage(on_open_chat: EventHandler<String>) -> Element {
     let categories = pentest_tools::catalog::tools_overview_categories(&tools);
     let total = tools.len();
 
+    // Category keys currently expanded. Collapsed by default so the page stays
+    // scannable as the catalog grows; a collapsed category renders only its
+    // header (its cards are not built). Toggled by clicking the header.
+    let mut expanded = use_signal(HashSet::<String>::new);
+
     rsx! {
         style { {include_str!("css/tools_page.css")} }
 
@@ -26,14 +34,48 @@ pub fn ToolsPage(on_open_chat: EventHandler<String>) -> Element {
                 div { class: "text-dim-sm", style: "margin-bottom: 8px;",
                     "{total} tools available" }
                 for category in categories {
+                    {
+                        let count = tools.iter().filter(|t| t.category == category).count();
+                        let is_expanded = expanded().contains(&category);
+                        let click_category = category.clone();
+                        let key_category = category.clone();
+                        rsx! {
                     div { class: "tools-category",
-                        div { class: "tools-category-header",
+                        div {
+                            class: "tools-category-header",
+                            role: "button",
+                            tabindex: 0,
+                            "aria-expanded": "{is_expanded}",
+                            onclick: move |_| {
+                                let mut set = expanded.write();
+                                if !set.remove(&click_category) {
+                                    set.insert(click_category.clone());
+                                }
+                            },
+                            onkeydown: move |evt: Event<KeyboardData>| {
+                                let key = evt.key();
+                                if key == Key::Enter
+                                    || matches!(key, Key::Character(ref c) if c == " ")
+                                {
+                                    evt.prevent_default();
+                                    let mut set = expanded.write();
+                                    if !set.remove(&key_category) {
+                                        set.insert(key_category.clone());
+                                    }
+                                }
+                            },
+                            span {
+                                class: if is_expanded { "tools-category-caret expanded" } else { "tools-category-caret" },
+                                ChevronDown { size: 14 }
+                            }
                             span {
                                 class: "tools-category-icon",
                                 {category_icon(&category)}
                             }
                             h3 { class: "tools-category-title", "{humanize_category(&category)}" }
+                            span { class: "tools-category-count", "{count}" }
                         }
+                        if is_expanded {
                         div { class: "tools-grid",
                             for tool in tools.iter().filter(|t| t.category == category).cloned() {
                                 {
@@ -53,6 +95,9 @@ pub fn ToolsPage(on_open_chat: EventHandler<String>) -> Element {
                                     }
                                 }
                             }
+                        }
+                        }
+                    }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Child B of epic #250. Makes the category sections collapsible (collapsed by default) in both the **Settings Tools panel** and the **read-only Tools page**, so the panel stays compact and scannable as the catalog grows.

Closes #262.

- **Keyboard-accessible toggle header**: `role=button` + `tabindex=0` + `aria-expanded`, with `onclick` and `onkeydown` (Enter/Space) sharing the toggle. Rotating chevron (`>` collapsed -> `v` expanded) and a per-category tool-count badge.
- **Lazy render**: a collapsed category renders only its header; the card grid is not built at all. This matters at the eventual ~3000-package full-tier scale (#263), not just visually.
- **State**: a per-mount `HashSet<String>` of expanded category keys (empty = all collapsed).
- No data-model change; both surfaces render from existing catalog/overview data. Shared `humanize_category`/`category_icon` helpers unchanged.

## Verification

- `cargo fmt --all --check`: clean.
- `cargo check -p pentest-desktop`: 0 errors.
- `cargo clippy -p pentest-desktop --features pentest-platform/desktop-pcap -- -D warnings`: clean.
- **Visual**: rendered the collapsible markup with the real `settings_page.css` + dark theme at 480px (headless Chrome). Confirmed: collapsed sections show header-only with a right-pointing chevron + count badge; the expanded section shows its card grid with a down chevron; per-#261 color-coding intact.

## Design note (one deliberate call)

Default is **all-collapsed** on both surfaces. For the read-only Tools page (the primary tool browser) that trades one click for compactness. If you'd prefer that page expanded-by-default for discoverability, it's a one-line change (seed the expand set with all category keys on mount) — happy to flip it.

## Test plan
- [ ] Settings -> Tools: categories start collapsed (headers + counts only); clicking a header expands its card grid; clicking again collapses.
- [ ] Keyboard: Tab to a header, Enter/Space toggles it; focus ring visible.
- [ ] Read-only Tools page: same collapse/expand behavior; clicking a tool card still opens chat.
- [ ] Chevron rotates and count matches the number of tools in each category.

Part of epic #250. Next: #263 (live BlackArch tier), #264 (group install-all), #265 (uninstall).