### PR TITLE
feat(#265): uninstall tools from the Settings panel (trash-can + confirm)

### DIFF
--- a/crates/tools/src/catalog.rs
+++ b/crates/tools/src/catalog.rs
@@ -346,7 +346,13 @@ async fn install_apt_host(entry: &CatalogEntry, progress: &ProgressSink) -> Resu
 /// metacharacters that could matter on the sandbox's shell-escaped exec path.
 /// Allows the conservative set of characters real package names use.
 fn validate_package_name(pkg: &str) -> Result<()> {
+    // A leading '-' would be parsed by pacman/apt-get as a flag rather than a
+    // package (argument injection): a name like "-Syu" or "--purge" would
+    // change the command's behavior. Real package names never start with '-',
+    // so reject it explicitly. This matters most on the uninstall path, where
+    // "--purge" would escalate `apt-get remove` into config deletion.
     if pkg.is_empty()
+        || pkg.starts_with('-')
         || !pkg
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.' | '+'))
@@ -405,6 +411,10 @@ pub struct CatalogItem {
     pub recommended: bool,
     /// Whether an Install button should be offered (auto-installable in mode).
     pub auto_installable: bool,
+    /// Whether the UI should offer to uninstall this tool (removable in the
+    /// current mode). Only meaningful when `state == "installed"`.
+    #[serde(default)]
+    pub uninstallable: bool,
     /// Manual instructions to show when not auto-installable.
     pub manual_instructions: Option<String>,
     /// Tools that declared this dependency.
@@ -435,6 +445,7 @@ impl From<&CatalogEntry> for CatalogItem {
             state: state.to_string(),
             recommended: e.recommended,
             auto_installable: e.is_auto_installable(),
+            uninstallable: is_uninstallable(&e.install_method),
             manual_instructions: e.manual_instructions(),
             used_by: e.used_by.clone(),
             estimated_secs: e.estimated_install_secs(),
@@ -578,6 +589,95 @@ pub async fn install_by_binary(binary_name: &str, progress: &ProgressSink) -> Re
     install_entry(entry, progress).await
 }
 
+/// Whether a catalog entry can be uninstalled from the UI in the current mode.
+///
+/// Mirrors [`CatalogEntry::is_auto_installable`]: we only offer removal for
+/// mechanisms we can actually drive here.
+/// - `Pacman`: only inside the sandbox (that's where the package lives).
+/// - `AptHost`: only in native mode (the host's package manager).
+/// - `Custom`: never (bespoke installers have no standard teardown; a future
+///   `ToolInstaller::uninstall` could enable this per-installer).
+/// - `Manual`: never (we didn't install it, so we won't remove it).
+pub fn is_uninstallable(method: &InstallMethod) -> bool {
+    match method {
+        InstallMethod::Pacman => sandbox_enabled(),
+        InstallMethod::AptHost => !sandbox_enabled(),
+        InstallMethod::Custom { .. } | InstallMethod::Manual { .. } => false,
+    }
+}
+
+/// Remove a single catalog entry, routing by its install method. Emits progress
+/// through `progress`. Refuses methods that [`is_uninstallable`] rejects rather
+/// than attempting a removal it cannot safely perform.
+pub async fn uninstall_entry(entry: &CatalogEntry, progress: &ProgressSink) -> Result<()> {
+    if !is_uninstallable(&entry.install_method) {
+        return Err(Error::ToolExecution(format!(
+            "{} cannot be uninstalled from here.",
+            entry.display_name
+        )));
+    }
+    match &entry.install_method {
+        InstallMethod::Pacman => uninstall_pacman(entry, progress).await,
+        InstallMethod::AptHost => uninstall_apt_host(entry, progress).await,
+        // Guarded by is_uninstallable above; unreachable in practice.
+        InstallMethod::Custom { .. } | InstallMethod::Manual { .. } => Err(Error::ToolExecution(
+            format!("{} cannot be uninstalled from here.", entry.display_name),
+        )),
+    }
+}
+
+/// Remove a Pacman entry from the sandbox via `pacman -Rns`.
+async fn uninstall_pacman(entry: &CatalogEntry, progress: &ProgressSink) -> Result<()> {
+    progress(InstallEvent::step(format!(
+        "Removing {} via pacman...",
+        entry.display_name
+    )));
+    let pkg = pacman_package_for(&entry.binary_name).unwrap_or_else(|| entry.binary_name.clone());
+    validate_package_name(&pkg)?;
+    crate::installers::pacman::uninstall(&pkg, Duration::from_secs(300)).await?;
+    progress(InstallEvent::step(format!(
+        "{} removed",
+        entry.display_name
+    )));
+    Ok(())
+}
+
+/// Remove an apt-host entry (native mode) via `apt-get remove`.
+async fn uninstall_apt_host(entry: &CatalogEntry, progress: &ProgressSink) -> Result<()> {
+    progress(InstallEvent::step(format!(
+        "Removing {} via apt-get...",
+        entry.display_name
+    )));
+    let platform = get_platform();
+    let pkg = entry.binary_name.clone();
+    validate_package_name(&pkg)?;
+    let result = platform
+        .execute_command("apt-get", &["remove", "-y", &pkg], Duration::from_secs(300))
+        .await?;
+    if result.exit_code != 0 {
+        return Err(Error::ToolExecution(format!(
+            "Failed to apt-get remove {pkg}: {}",
+            result.stderr
+        )));
+    }
+    progress(InstallEvent::step(format!(
+        "{} removed",
+        entry.display_name
+    )));
+    Ok(())
+}
+
+/// Uninstall the catalog entry keyed by `binary_name`. UI entrypoint mirroring
+/// [`install_by_binary`].
+pub async fn uninstall_by_binary(binary_name: &str, progress: &ProgressSink) -> Result<()> {
+    let catalog = build_catalog().await;
+    let entry = catalog
+        .iter()
+        .find(|e| e.binary_name == binary_name)
+        .ok_or_else(|| Error::ToolExecution(format!("Unknown tool '{binary_name}'")))?;
+    uninstall_entry(entry, progress).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -623,7 +723,18 @@ mod tests {
         ] {
             assert!(validate_package_name(ok).is_ok(), "should accept {ok}");
         }
-        for bad in ["pkg; rm -rf /", "a b", "$(id)", "", "pkg|nc", "../evil"] {
+        for bad in [
+            "pkg; rm -rf /",
+            "a b",
+            "$(id)",
+            "",
+            "pkg|nc",
+            "../evil",
+            // Flag injection: a leading dash would be read as a pacman/apt-get
+            // option, not a package (e.g. -Syu, --purge). Must be rejected.
+            "-Syu",
+            "--purge",
+        ] {
             assert!(validate_package_name(bad).is_err(), "should reject {bad:?}");
         }
     }
@@ -676,6 +787,37 @@ mod tests {
         assert!(entry.manual_instructions().unwrap().contains("manually"));
     }
 
+    #[tokio::test]
+    async fn manual_and_custom_entries_are_never_uninstallable() {
+        // We never installed Manual tools (Burp) and have no standard teardown
+        // for Custom installers, so the UI must not offer to remove them.
+        assert!(!is_uninstallable(&InstallMethod::Manual {
+            url: None,
+            instructions: "x".into(),
+        }));
+        assert!(!is_uninstallable(&InstallMethod::Custom {
+            id: "zap".into()
+        }));
+
+        // uninstall_entry must refuse a Manual entry rather than shell out.
+        let entry = CatalogEntry {
+            binary_name: "burpsuite".into(),
+            display_name: "Burp Suite".into(),
+            description: "proxy".into(),
+            category: ToolCategory::Proxy,
+            install_method: InstallMethod::Manual {
+                url: None,
+                instructions: "install manually".into(),
+            },
+            recommended: false,
+            used_by: vec![],
+            state: InstallState::Installed,
+        };
+        let progress = crate::installers::noop_progress();
+        let result = uninstall_entry(&entry, progress.as_ref()).await;
+        assert!(result.is_err(), "manual entries must not be uninstalled");
+    }
+
     #[test]
     fn catalog_item_maps_state_and_category_to_strings() {
         let entry = CatalogEntry {
@@ -707,6 +849,7 @@ mod tests {
             state: "installed".into(),
             recommended: true,
             auto_installable: true,
+            uninstallable: false,
             manual_instructions: None,
             used_by: vec!["zap".into()],
             estimated_secs: 150,

--- a/crates/tools/src/installers/pacman.rs
+++ b/crates/tools/src/installers/pacman.rs
@@ -49,6 +49,43 @@ pub(crate) async fn install(pkg: &str, timeout: Duration) -> Result<()> {
     Ok(())
 }
 
+/// Build the `pacman` argument vector for a sandbox package removal.
+///
+/// `-Rns` removes the package, its now-unneeded dependencies (`s`), and its
+/// config files (`n`). This is scoped to the package the operator explicitly
+/// chose to remove; `-s` only reaps dependencies that no *other* installed
+/// package still needs, so a shared dependency of another tool is preserved.
+/// `--noconfirm` because the UI already gathered confirmation before calling.
+pub(crate) fn uninstall_args(pkg: &str) -> [&str; 3] {
+    ["-Rns", "--noconfirm", pkg]
+}
+
+/// Remove `pkg` from the sandbox via `pacman -Rns --noconfirm`.
+///
+/// Returns a `ToolExecution` error carrying pacman's stderr on non-zero exit.
+/// Removing a package that isn't installed is treated as success (idempotent):
+/// pacman reports "target not found", which for a *removal* means the desired
+/// end-state (absent) already holds.
+pub(crate) async fn uninstall(pkg: &str, timeout: Duration) -> Result<()> {
+    let platform = get_platform();
+    let result = platform
+        .execute_command("pacman", &uninstall_args(pkg), timeout)
+        .await?;
+
+    if result.exit_code != 0 {
+        // Not-installed is the desired end state for a removal — succeed.
+        if result.stderr.contains("target not found") {
+            return Ok(());
+        }
+        return Err(Error::ToolExecution(format!(
+            "Failed to remove {pkg}: {}",
+            result.stderr
+        )));
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -74,5 +111,28 @@ mod tests {
             !args.contains(&"-S"),
             "bare -S skips the DB refresh and reintroduces the stale-DB failure"
         );
+    }
+
+    #[test]
+    fn uninstall_args_use_recursive_removal_and_are_unattended() {
+        let args = uninstall_args("nmap");
+        // -Rns: remove the package + now-unneeded deps (s) + config files (n).
+        assert_eq!(args[0], "-Rns", "removal must recurse unneeded deps");
+        assert!(args.contains(&"--noconfirm"), "removal must be unattended");
+        assert_eq!(
+            args.last().copied(),
+            Some("nmap"),
+            "package name must be the final argument"
+        );
+    }
+
+    #[test]
+    fn uninstall_args_never_use_capital_dash_r_alone() {
+        // -Rns (not a bare -R) so orphaned dependencies are reaped; -s only
+        // removes deps no other installed package still needs, so shared deps
+        // of other tools survive.
+        let args = uninstall_args("sqlmap");
+        assert_eq!(args[0], "-Rns");
+        assert!(!args.contains(&"-R"), "use -Rns, not a bare -R");
     }
 }

--- a/crates/ui/src/components/css/settings_page.css
+++ b/crates/ui/src/components/css/settings_page.css
@@ -574,6 +574,7 @@
    manual) or a <button> (missing + auto-installable, click-to-install). Reset
    button chrome so both render identically. */
 .tool-status-card {
+    position: relative;
     display: flex;
     flex-direction: column;
     gap: 4px;
@@ -587,6 +588,125 @@
     color: var(--foreground);
     width: 100%;
     min-width: 0;
+}
+
+/* Trash-can, top-right of an installed card. Faint until the card is hovered
+   so it doesn't compete with the tool name, then clarifies to destructive red. */
+.tool-uninstall-btn {
+    position: absolute;
+    top: 6px;
+    right: 6px;
+    padding: 2px 4px;
+    border: none;
+    background: transparent;
+    color: var(--muted-foreground);
+    font-size: 12px;
+    line-height: 1;
+    cursor: pointer;
+    opacity: 0.35;
+    border-radius: 4px;
+    transition: opacity 0.15s, color 0.15s, background-color 0.15s;
+}
+
+.tool-status-card:hover .tool-uninstall-btn {
+    opacity: 1;
+}
+
+.tool-uninstall-btn:hover:not(:disabled) {
+    color: var(--destructive, #ef4444);
+    background: rgba(239, 68, 68, 0.12);
+}
+
+.tool-uninstall-btn:focus-visible {
+    opacity: 1;
+    outline: 2px solid var(--ring);
+    outline-offset: 1px;
+}
+
+.tool-uninstall-btn:disabled {
+    opacity: 0.2;
+    cursor: not-allowed;
+}
+
+/* Uninstall confirmation dialog. */
+.uninstall-dialog-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 50;
+    padding: 16px;
+}
+
+.uninstall-dialog {
+    background: var(--secondary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 20px;
+    max-width: 420px;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+.uninstall-dialog-title {
+    margin: 0;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--foreground);
+}
+
+.uninstall-dialog-body {
+    font-size: 13px;
+    color: var(--muted-foreground);
+    line-height: 1.5;
+}
+
+.uninstall-dialog-pkg {
+    font-family: var(--font-mono);
+    color: var(--foreground);
+}
+
+.uninstall-dialog-warning {
+    font-size: 12px;
+    line-height: 1.5;
+    color: #ff9800;
+    background: rgba(255, 152, 0, 0.1);
+    border-left: 3px solid #ff9800;
+    border-radius: 3px;
+    padding: 8px 10px;
+}
+
+.uninstall-dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 4px;
+}
+
+.uninstall-dialog-confirm-btn {
+    background: var(--destructive, #ef4444);
+    color: #fff;
+    border: none;
+    border-radius: 4px;
+    padding: 8px 16px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    cursor: pointer;
+    transition: opacity 0.15s;
+}
+
+.uninstall-dialog-confirm-btn:hover:not(:disabled) {
+    opacity: 0.9;
+}
+
+.uninstall-dialog-confirm-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
 }
 
 /* Color-coded install state via the left border + status text. */

--- a/crates/ui/src/components/settings_page.rs
+++ b/crates/ui/src/components/settings_page.rs
@@ -100,6 +100,12 @@ pub fn SettingsPage(
     // for a later install — even a restart of the same tool, where `installing`
     // would otherwise look unchanged.
     let mut install_generation = use_signal(|| 0u64);
+    // The tool pending an uninstall confirmation, if any. Some(item) shows the
+    // confirm dialog; cleared to None on cancel or after removal completes.
+    let mut uninstall_confirm = use_signal(|| None::<pentest_tools::catalog::CatalogItem>);
+    // binary_name currently being uninstalled, or None when idle. Disables the
+    // trash-cans and shows a per-card "Removing..." state.
+    let mut uninstalling = use_signal(|| None::<String>);
 
     // Load seed status on mount
     use_effect(move || {
@@ -445,14 +451,39 @@ pub fn SettingsPage(
                                         {
                                             let desc = item.description.clone();
                                             if item.state == "installed" {
+                                                let removing = uninstalling() == Some(item.binary_name.clone());
                                                 rsx! {
                                                     div { class: "tool-status-card installed",
+                                                        // Trash-can (top-right) opens the confirm
+                                                        // dialog. Only shown when the tool can
+                                                        // actually be removed in this mode.
+                                                        if item.uninstallable {
+                                                            button {
+                                                                class: "tool-uninstall-btn",
+                                                                r#type: "button",
+                                                                disabled: uninstalling().is_some(),
+                                                                title: "Uninstall {item.display_name}",
+                                                                "aria-label": "Uninstall {item.display_name}",
+                                                                onclick: {
+                                                                    let confirm_item = item.clone();
+                                                                    move |evt: Event<MouseData>| {
+                                                                        evt.stop_propagation();
+                                                                        uninstall_confirm.set(Some(confirm_item.clone()));
+                                                                    }
+                                                                },
+                                                                "\u{1F5D1}"
+                                                            }
+                                                        }
                                                         div { class: "tool-status-card-name", "{item.display_name}" }
                                                         if !desc.is_empty() {
                                                             div { class: "tool-status-card-desc", title: "{desc}", "{desc}" }
                                                         }
-                                                        div { class: "tool-status-card-status installed",
-                                                            "\u{2713} Installed"
+                                                        if removing {
+                                                            div { class: "tool-status-card-status muted", "Removing..." }
+                                                        } else {
+                                                            div { class: "tool-status-card-status installed",
+                                                                "\u{2713} Installed"
+                                                            }
                                                         }
                                                     }
                                                 }
@@ -601,6 +632,85 @@ pub fn SettingsPage(
                         }
                     } else {
                         div { class: "text-dim-xs", style: "margin-top: 12px;", "No tools available" }
+                    }
+                }
+            }
+
+            // Uninstall confirmation dialog. Destructive action, so it is always
+            // gated behind an explicit confirm that names the package and warns
+            // about other tools that share the dependency (blast radius).
+            if let Some(target) = uninstall_confirm() {
+                {
+                    let bin = target.binary_name.clone();
+                    // Other tools that declared this same binary dependency. pacman
+                    // -Rns keeps deps still needed by another package, but removing a
+                    // shared binary can still break sibling tools, so surface them.
+                    let shared_with: Vec<String> = target
+                        .used_by
+                        .iter()
+                        .filter(|t| **t != target.display_name && **t != target.binary_name)
+                        .cloned()
+                        .collect();
+                    rsx! {
+                        div { class: "uninstall-dialog-overlay",
+                            onclick: move |_| uninstall_confirm.set(None),
+                            div { class: "uninstall-dialog",
+                                onclick: move |evt: Event<MouseData>| evt.stop_propagation(),
+                                h3 { class: "uninstall-dialog-title", "Uninstall {target.display_name}?" }
+                                div { class: "uninstall-dialog-body",
+                                    "This removes the "
+                                    span { class: "uninstall-dialog-pkg", "{target.binary_name}" }
+                                    " package and its unneeded dependencies."
+                                }
+                                if !shared_with.is_empty() {
+                                    div { class: "uninstall-dialog-warning",
+                                        "Heads up: this dependency is also used by "
+                                        strong { "{shared_with.join(\", \")}" }
+                                        ". Removing it may affect those tools."
+                                    }
+                                }
+                                div { class: "uninstall-dialog-actions",
+                                    button {
+                                        class: "settings-discard-btn",
+                                        r#type: "button",
+                                        onclick: move |_| uninstall_confirm.set(None),
+                                        "Cancel"
+                                    }
+                                    button {
+                                        class: "uninstall-dialog-confirm-btn",
+                                        r#type: "button",
+                                        disabled: uninstalling().is_some(),
+                                        onclick: move |_| {
+                                            let bin = bin.clone();
+                                            uninstall_confirm.set(None);
+                                            spawn(async move {
+                                                use tokio::sync::mpsc;
+                                                uninstalling.set(Some(bin.clone()));
+                                                install_error.set(None);
+                                                let (tx, mut rx) = mpsc::unbounded_channel();
+                                                spawn(async move {
+                                                    while let Some(msg) = rx.recv().await {
+                                                        install_message.set(msg);
+                                                    }
+                                                });
+                                                let progress = move |evt: pentest_tools::installers::InstallEvent| {
+                                                    let _ = tx.send(evt.message);
+                                                };
+                                                match pentest_tools::catalog::uninstall_by_binary(&bin, &progress).await {
+                                                    Ok(()) => {
+                                                        let items = pentest_tools::catalog::build_catalog_items().await;
+                                                        catalog_items.set(Some(items));
+                                                    }
+                                                    Err(e) => install_error.set(Some(e.to_string())),
+                                                }
+                                                uninstalling.set(None);
+                                            });
+                                        },
+                                        "Uninstall"
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Child E of epic #250. Adds an operator-driven **uninstall** for installed tools — the trash-can + confirm-dialog the issue specced — completing the install/uninstall loop in the redesigned Tools panel.

Closes #265.

### Backend (`crates/tools`)
- `pacman::uninstall` -> `pacman -Rns --noconfirm <pkg>` (package + now-unneeded deps + config files; `-s` preserves deps other installed packages still need). "target not found" is treated as success (idempotent).
- `catalog::is_uninstallable` gates by mode: `Pacman` in-sandbox, `AptHost` in native; **never** `Manual` (we didn't install it) or `Custom` (no standard teardown). `uninstall_entry` / `uninstall_by_binary` mirror the install path; apt-host removal via `apt-get remove -y`.
- `CatalogItem.uninstallable` flag so the UI knows when to show the trash-can. Reuses `validate_package_name` on both removal paths.

### UI (`crates/ui`)
- Trash-can top-right of installed cards (only when `uninstallable`), opening a confirm dialog that **names the package** and **warns about sibling tools that share the dependency** (the `used_by` blast radius). Destructive-red confirm button; per-card "Removing..." state; one-op-at-a-time guard; overlay-click and Cancel both dismiss.

### Security review (destructive commands, per the issue + CLAUDE.md)
Ran a security-reviewer pass focused on the `pacman -Rns` / `apt-get remove` construction. Verdict: **safe to merge** — package names come from hardcoded schemas (not user input), pass `validate_package_name` (rejects shell metacharacters), commands use argv (`execute_command(cmd, &[args])`) not a shell string, and Manual/Custom tools are provably unremovable (guarded in `uninstall_entry`, verified by test).

Two findings actioned:
- **Applied now**: added an explicit leading-dash reject to `validate_package_name`, so a name like `-Syu` / `--purge` can't be parsed as a pacman/apt-get flag (argument injection). Not currently reachable, but defense-in-depth on the widened `apt-get remove` surface (where `--purge` would escalate to config deletion). Test extended to cover it.
- **Deferred (pre-existing, filed as #274)**: the sandbox command path builds a shell string and escapes only the args, not the command name. Not exploitable today (static `cmd`, validated names) and affects the install path equally, so out of scope here.

## Verification
- `cargo fmt --all --check`, `cargo clippy -p pentest-desktop -p pentest-tools --features pentest-platform/desktop-pcap -- -D warnings`: clean.
- `cargo test -p pentest-tools --features pentest-platform/desktop-pcap`: green, incl. new tests — pacman `uninstall_args` (-Rns, unattended, no bare -R), `is_uninstallable` rejects Manual/Custom, `uninstall_entry` refuses a Manual entry, and flag-injection names (`-Syu`/`--purge`) rejected.
- **Visual**: rendered the installed card + trash-can + confirm dialog (with a `used_by` warning) at 480px via headless Chrome — trash-can faint→red on hover, dialog names the package and lists shared-dependency tools.

## Test plan
- [x] Installed pacman tool shows a trash-can, click opens the confirm dialog naming the package (verified: button gated on `item.uninstallable`; dialog renders `item.display_name` + `binary_name`; visually confirmed at 480px via headless render).
- [x] Dialog warns on shared `used_by` (the `shared_with` filter), and both Cancel and overlay-click clear `uninstall_confirm` without removing (verified in code + earlier screenshot showing the 'also used by smbmap, enum4linux' warning).
- [ ] **Not exercised end-to-end — blocked by #248.** Confirm calls `uninstall_by_binary` -> `pacman -Rns` and the card re-renders from a refreshed catalog; but a true removal needs an installed pacman tool in a working sandbox, and #248 (pacman DBs unreadable) prevents install/remove in the sandbox today. The routing + "Removing..." state + catalog-refresh are present in code and unit-tested (`manual_and_custom_entries_are_never_uninstallable`, `uninstall_args_*`), but the live flip has NOT been observed. To be checked once #248 lands.
- [x] Manual (Burp) and Custom (ZAP/Metasploit) show NO trash-can (verified: `is_uninstallable` returns false for Manual/Custom, button gated on it; unit test `manual_and_custom_entries_are_never_uninstallable` passes).
- [x] Keyboard-accessible: the trash-can is a native `<button>` (focusable + Enter/Space activatable for free) and the dialog Cancel/Uninstall are native buttons (verified structurally).

Part of epic #250. Remaining: #263 (live BlackArch tier, blocked by #248), #264 (group install-all).


---
**Test-plan status (2026-07-20):** 4 of 5 verified by evidence (unit tests + code/markup + earlier headless render). The 5th — live `pacman -Rns` removal + card flip — is blocked by #248 (sandbox pacman DBs unreadable) and is honestly left unchecked until the sandbox works end-to-end.