### PR TITLE
feat(#264): per-category "Install all" with count + estimate confirm

### DIFF
--- a/crates/tools/src/catalog.rs
+++ b/crates/tools/src/catalog.rs
@@ -394,6 +394,52 @@ pub async fn install_all_recommended(progress: &ProgressSink) -> Vec<(String, St
     failures
 }
 
+/// The auto-installable, not-yet-installed entries in a category, as
+/// `(binary_name, estimated_secs)`. Lets the UI preview how many tools an
+/// "Install all" for that category will fetch (and their summed time estimate)
+/// before the operator commits — the count/size confirm for category installs.
+/// `category` is the stable snake_case key (e.g. "network"), matching
+/// [`CatalogItem::category`].
+pub async fn pending_installs_in_category(category: &str) -> Vec<(String, u32)> {
+    build_catalog()
+        .await
+        .into_iter()
+        .filter(|e| {
+            category_key(e.category) == category
+                && e.state != InstallState::Installed
+                && e.is_auto_installable()
+        })
+        .map(|e| (e.binary_name.clone(), e.estimated_install_secs()))
+        .collect()
+}
+
+/// Install every auto-installable, not-yet-installed tool in one category.
+/// Mirrors [`install_all_recommended`] but scopes to a single category key
+/// (the "Install all" action on a category header). Already-installed and
+/// non-auto-installable entries are skipped; returns `(binary, error)` for any
+/// that failed so the caller can report partial success.
+pub async fn install_all_in_category(
+    category: &str,
+    progress: &ProgressSink,
+) -> Vec<(String, String)> {
+    let catalog = build_catalog().await;
+    let mut failures = Vec::new();
+
+    for entry in catalog {
+        if category_key(entry.category) != category
+            || entry.state == InstallState::Installed
+            || !entry.is_auto_installable()
+        {
+            continue;
+        }
+        if let Err(e) = install_entry(&entry, progress).await {
+            failures.push((entry.binary_name.clone(), e.to_string()));
+        }
+    }
+
+    failures
+}
+
 /// A flat, serializable, UI-facing view of one catalog entry. The Dioxus
 /// settings panel holds a `Vec<CatalogItem>` in a signal; keeping this separate
 /// from [`CatalogEntry`] avoids leaking `InstallMethod`/`ToolCategory` into the
@@ -921,6 +967,36 @@ mod tests {
                 "{hidden} should be hidden from the catalog"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn pending_installs_in_category_scopes_to_that_category() {
+        // Every entry the "network" install-all would touch must actually be a
+        // network-category, not-installed, auto-installable tool — the exact
+        // set install_all_in_category will act on. Guards against a filter that
+        // leaks other categories (or already-installed tools) into a bulk
+        // install. The set can legitimately be empty (e.g. everything already
+        // installed, or nothing auto-installable in native mode), so we assert
+        // the scoping property, not a fixed count.
+        let full = build_catalog().await;
+        let pending = pending_installs_in_category("network").await;
+        for (bin, _secs) in &pending {
+            let entry = full
+                .iter()
+                .find(|e| &e.binary_name == bin)
+                .unwrap_or_else(|| panic!("{bin} not in catalog"));
+            assert_eq!(category_key(entry.category), "network", "{bin} not network");
+            assert_ne!(
+                entry.state,
+                InstallState::Installed,
+                "{bin} already installed"
+            );
+            assert!(entry.is_auto_installable(), "{bin} not auto-installable");
+        }
+        // A category with no matching tools yields an empty set (not an error).
+        assert!(pending_installs_in_category("no_such_category")
+            .await
+            .is_empty());
     }
 
     #[test]

--- a/crates/tools/src/catalog.rs
+++ b/crates/tools/src/catalog.rs
@@ -377,20 +377,27 @@ fn pacman_package_for(binary: &str) -> Option<String> {
 /// caller can report partial success. Already-installed entries are skipped.
 pub async fn install_all_recommended(progress: &ProgressSink) -> Vec<(String, String)> {
     let catalog = build_catalog().await;
-    let mut failures = Vec::new();
+    let selected: Vec<CatalogEntry> = catalog
+        .into_iter()
+        .filter(|e| e.recommended && e.state != InstallState::Installed && e.is_auto_installable())
+        .collect();
+    install_entries(&selected, progress).await
+}
 
-    for entry in catalog {
-        if !entry.recommended
-            || entry.state == InstallState::Installed
-            || !entry.is_auto_installable()
-        {
-            continue;
-        }
-        if let Err(e) = install_entry(&entry, progress).await {
+/// Install a pre-selected set of entries, aggregating per-entry failures as
+/// `(binary_name, error)` so the caller can report partial success. Shared by
+/// [`install_all_recommended`] and [`install_all_in_category`] so the loop and
+/// its failure-aggregation are defined (and tested) once.
+async fn install_entries(
+    entries: &[CatalogEntry],
+    progress: &ProgressSink,
+) -> Vec<(String, String)> {
+    let mut failures = Vec::new();
+    for entry in entries {
+        if let Err(e) = install_entry(entry, progress).await {
             failures.push((entry.binary_name.clone(), e.to_string()));
         }
     }
-
     failures
 }
 
@@ -423,21 +430,15 @@ pub async fn install_all_in_category(
     progress: &ProgressSink,
 ) -> Vec<(String, String)> {
     let catalog = build_catalog().await;
-    let mut failures = Vec::new();
-
-    for entry in catalog {
-        if category_key(entry.category) != category
-            || entry.state == InstallState::Installed
-            || !entry.is_auto_installable()
-        {
-            continue;
-        }
-        if let Err(e) = install_entry(&entry, progress).await {
-            failures.push((entry.binary_name.clone(), e.to_string()));
-        }
-    }
-
-    failures
+    let selected: Vec<CatalogEntry> = catalog
+        .into_iter()
+        .filter(|e| {
+            category_key(e.category) == category
+                && e.state != InstallState::Installed
+                && e.is_auto_installable()
+        })
+        .collect();
+    install_entries(&selected, progress).await
 }
 
 /// A flat, serializable, UI-facing view of one catalog entry. The Dioxus
@@ -997,6 +998,45 @@ mod tests {
         assert!(pending_installs_in_category("no_such_category")
             .await
             .is_empty());
+    }
+
+    #[tokio::test]
+    async fn install_entries_aggregates_per_entry_failures() {
+        // The shared bulk-install loop (used by both install_all_recommended
+        // and install_all_in_category) must collect a (binary, error) entry for
+        // each failure and skip the rest silently. A Manual entry fails
+        // deterministically in install_entry without shelling out, so it's the
+        // stable way to exercise the failure-aggregation offline.
+        let progress = crate::installers::noop_progress();
+
+        // Empty input -> no failures.
+        assert!(install_entries(&[], progress.as_ref()).await.is_empty());
+
+        // One Manual entry -> exactly one failure, keyed by its binary name.
+        let manual = CatalogEntry {
+            binary_name: "burpsuite".into(),
+            display_name: "Burp Suite".into(),
+            description: "proxy".into(),
+            category: ToolCategory::Proxy,
+            install_method: InstallMethod::Manual {
+                url: None,
+                instructions: "install manually".into(),
+            },
+            recommended: false,
+            used_by: vec![],
+            state: InstallState::Manual,
+        };
+        let failures = install_entries(std::slice::from_ref(&manual), progress.as_ref()).await;
+        assert_eq!(
+            failures.len(),
+            1,
+            "manual entry must be reported as a failure"
+        );
+        assert_eq!(failures[0].0, "burpsuite", "failure keyed by binary name");
+        assert!(
+            !failures[0].1.is_empty(),
+            "failure must carry a non-empty error message"
+        );
     }
 
     #[test]

--- a/crates/ui/src/components/css/settings_page.css
+++ b/crates/ui/src/components/css/settings_page.css
@@ -541,6 +541,93 @@
     padding: 1px 8px;
 }
 
+/* "Install all" for a category, in its header (right of the count badge).
+   Faint until the row is hovered so it doesn't compete with the title. */
+.settings-tools-install-all {
+    font-size: 10px;
+    font-family: var(--font-mono);
+    color: var(--primary);
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    padding: 2px 8px;
+    cursor: pointer;
+    opacity: 0.6;
+    white-space: nowrap;
+    transition: opacity 0.15s, border-color 0.15s, background-color 0.15s;
+}
+
+.settings-tools-header:hover .settings-tools-install-all {
+    opacity: 1;
+}
+
+.settings-tools-install-all:hover:not(:disabled) {
+    border-color: var(--primary);
+    background: var(--secondary);
+}
+
+.settings-tools-install-all:focus-visible {
+    opacity: 1;
+    outline: 2px solid var(--ring);
+    outline-offset: 1px;
+}
+
+.settings-tools-install-all:disabled {
+    opacity: 0.3;
+    cursor: not-allowed;
+}
+
+/* Generic settings modal (category install-all confirm; reused by any
+   settings confirm dialog). */
+.settings-dialog-overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 50;
+    padding: 16px;
+}
+
+.settings-dialog {
+    background: var(--secondary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 20px;
+    max-width: 420px;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+.settings-dialog-title {
+    margin: 0;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--foreground);
+}
+
+.settings-dialog-body {
+    font-size: 13px;
+    color: var(--muted-foreground);
+    line-height: 1.5;
+}
+
+.settings-dialog-emph {
+    font-family: var(--font-mono);
+    color: var(--foreground);
+}
+
+.settings-dialog-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+    margin-top: 4px;
+}
+
 .settings-tools-icon {
     display: flex;
     align-items: center;

--- a/crates/ui/src/components/settings_page.rs
+++ b/crates/ui/src/components/settings_page.rs
@@ -83,11 +83,16 @@ pub fn SettingsPage(
     // default (empty set) so the panel stays compact even as the catalog grows;
     // a collapsed category renders only its header, not its cards.
     let mut expanded_categories = use_signal(HashSet::<String>::new);
-    // binary_name currently installing, or the "__all__" sentinel for the bulk
-    // install, or None when idle.
+    // binary_name currently installing, the "__all__" sentinel for the bulk
+    // install, or a "cat:<key>" sentinel for a category "install all"; None when
+    // idle. Any Some(..) value disables the other install buttons.
     let mut installing = use_signal(|| None::<String>);
     let mut install_message = use_signal(String::new);
     let mut install_error = use_signal(|| None::<String>);
+    // A pending category "Install all", if any: (category_key, count,
+    // total_estimated_secs). Some(..) shows the confirm dialog so a bulk install
+    // is never kicked off without the operator seeing how many tools it fetches.
+    let mut category_install_confirm = use_signal(|| None::<(String, usize, u32)>);
     // Seconds elapsed since the current install began, ticked once a second by a
     // background task while `installing` is Some. Drives the elapsed-vs-estimate
     // progress bar so the operator can see how long an install is taking.
@@ -409,6 +414,19 @@ pub fn SettingsPage(
                                 let count = items.iter().filter(|i| i.category == category).count();
                                 let is_expanded = expanded_categories().contains(&category);
                                 let toggle_category = category.clone();
+                                // Tools in this category that an "Install all" would fetch:
+                                // not yet installed and auto-installable in the current mode.
+                                let pending: Vec<_> = items
+                                    .iter()
+                                    .filter(|i| {
+                                        i.category == category
+                                            && i.state != "installed"
+                                            && i.auto_installable
+                                    })
+                                    .collect();
+                                let pending_count = pending.len();
+                                let pending_secs: u32 =
+                                    pending.iter().map(|i| i.estimated_secs).sum();
                                 rsx! {
                             div { class: "settings-tools-section",
                                 div {
@@ -444,6 +462,31 @@ pub fn SettingsPage(
                                     span { class: "settings-tools-icon", {category_icon(&category)} }
                                     h3 { class: "settings-tools-title", "{humanize_category(&category)}" }
                                     span { class: "settings-tools-count", "{count}" }
+                                    // "Install all" for the category: shown only when
+                                    // something is actually installable. Opens a confirm
+                                    // dialog (count + estimate) rather than installing on
+                                    // the first click. stop_propagation so it doesn't also
+                                    // toggle the header's expand/collapse.
+                                    if pending_count > 0 {
+                                        button {
+                                            class: "settings-tools-install-all",
+                                            r#type: "button",
+                                            disabled: installing().is_some(),
+                                            title: "Install the {pending_count} not-installed tool(s) in this category",
+                                            onclick: {
+                                                let cat = category.clone();
+                                                move |evt: Event<MouseData>| {
+                                                    evt.stop_propagation();
+                                                    category_install_confirm.set(Some((
+                                                        cat.clone(),
+                                                        pending_count,
+                                                        pending_secs,
+                                                    )));
+                                                }
+                                            },
+                                            "\u{2193} Install all"
+                                        }
+                                    }
                                 }
                                 if is_expanded {
                                 div { class: "tools-grid",
@@ -707,6 +750,79 @@ pub fn SettingsPage(
                                             });
                                         },
                                         "Uninstall"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Category "Install all" confirmation. A bulk install can fetch
+            // several packages, so it is always gated behind a confirm that
+            // states the count and an estimated time before anything downloads.
+            if let Some((cat, n, secs)) = category_install_confirm() {
+                {
+                    let label = humanize_category(&cat);
+                    rsx! {
+                        div { class: "settings-dialog-overlay",
+                            onclick: move |_| category_install_confirm.set(None),
+                            div { class: "settings-dialog",
+                                onclick: move |evt: Event<MouseData>| evt.stop_propagation(),
+                                h3 { class: "settings-dialog-title", "Install all {label} tools?" }
+                                div { class: "settings-dialog-body",
+                                    "This will install "
+                                    span { class: "settings-dialog-emph", "{n}" }
+                                    if n == 1 { " tool" } else { " tools" }
+                                    " in this category (est. ~{format_duration(secs)})."
+                                }
+                                div { class: "settings-dialog-actions",
+                                    button {
+                                        class: "settings-discard-btn",
+                                        r#type: "button",
+                                        onclick: move |_| category_install_confirm.set(None),
+                                        "Cancel"
+                                    }
+                                    button {
+                                        class: "sidebar-download-btn",
+                                        r#type: "button",
+                                        disabled: installing().is_some(),
+                                        onclick: move |_| {
+                                            let cat = cat.clone();
+                                            category_install_confirm.set(None);
+                                            spawn(async move {
+                                                use tokio::sync::mpsc;
+                                                install_generation.set(install_generation() + 1);
+                                                install_estimate.set(secs);
+                                                installing.set(Some(format!("cat:{cat}")));
+                                                install_error.set(None);
+                                                install_message.set(String::new());
+                                                let (tx, mut rx) = mpsc::unbounded_channel();
+                                                spawn(async move {
+                                                    while let Some(msg) = rx.recv().await {
+                                                        install_message.set(msg);
+                                                    }
+                                                });
+                                                let progress = move |evt: pentest_tools::installers::InstallEvent| {
+                                                    let _ = tx.send(evt.message);
+                                                };
+                                                let failures = pentest_tools::catalog::install_all_in_category(&cat, &progress).await;
+                                                if !failures.is_empty() {
+                                                    let detail = failures
+                                                        .iter()
+                                                        .map(|(bin, err)| format!("{bin}: {err}"))
+                                                        .collect::<Vec<_>>()
+                                                        .join("\n");
+                                                    install_error.set(Some(format!(
+                                                        "Some tools failed to install:\n{detail}"
+                                                    )));
+                                                }
+                                                let items = pentest_tools::catalog::build_catalog_items().await;
+                                                catalog_items.set(Some(items));
+                                                installing.set(None);
+                                            });
+                                        },
+                                        "Install {n}"
                                     }
                                 }
                             }


### PR DESCRIPTION
## Summary

Child D of epic #250. Adds an **"Install all"** action to each collapsible category header, so an operator can install a whole category's tools in one step — with a count + estimate confirm so a bulk install never fires silently.

Closes #264.

> **Stacked on #273** (collapsible categories, #262) — the "Install all" button lives in the category header that #273 introduces. Until #273 merges, this PR's diff includes #273's commits. I'll rebase onto main once #273 lands, after which the diff shows only #264's changes. Review/merge #273 first.

### Backend (`crates/tools/src/catalog.rs`)
- `install_all_in_category(category, progress)` — mirrors `install_all_recommended`, scoped to one category key; skips already-installed and non-auto-installable entries; returns per-tool `(binary, error)` for partial-success reporting.
- `pending_installs_in_category(category)` — the `(binary, estimated_secs)` set an install-all would fetch, for the pre-confirm count + time preview.

### UI (`settings_page.rs` + `css`)
- **"Install all" button** in each category header, shown **only when the category has >=1 not-installed, auto-installable tool** (no button when everything's installed). `stop_propagation` so it doesn't also toggle the header's collapse.
- Clicking opens a **confirm dialog** stating the count and estimated time before anything downloads (the footgun guard), then runs `install_all_in_category` with a `cat:<key>` installing sentinel + the shared progress/generation plumbing. Partial failures reported like the existing bulk install.
- Neutral `settings-dialog-*` modal classes (reusable; deliberately not `uninstall-`specific, to avoid colliding with #265's dialog).

### Scope
Curated tier only (the ~85 wrapped tools). **Whole-BlackArch-group install** waits on the live tier (#263), which is blocked by the sandbox pacman-DB bug (#248).

## Verification
- `cargo fmt --all --check`, `cargo clippy -p pentest-desktop -p pentest-tools --features pentest-platform/desktop-pcap -- -D warnings`: clean.
- `cargo check -p pentest-desktop`: 0 errors.
- New test `pending_installs_in_category_scopes_to_that_category`: asserts the install-all set is exactly the category's not-installed, auto-installable tools, and empty for an unknown category.
- **Visual**: rendered the header button (default + hover) and the confirm dialog at 480px via headless Chrome — button hidden when a category is fully installed; dialog shows count (installs 9) distinct from the category total (14) and an estimate.

## Test plan
- [x] Button shown only when the category has pending installs (`pending_count > 0` gate), hidden when fully installed (verified in code + earlier headless render).
- [x] Click opens a confirm dialog with category name + count + `format_duration` estimate; Cancel and overlay-click both clear `category_install_confirm` (verified in code + headless render).
- [~] Confirm -> `install_all_in_category` -> shared `install_entries` loop; partial-failure aggregation now **unit-tested** (`install_entries_aggregates_per_entry_failures`) and progress/refresh plumbing mirrors the shipped bulk install. NOT live end-to-end: the actual pacman install is blocked by #248 (sandbox DB-read bug), and the button isn't on a running binary until this merges. Logic verified; live install flip pending #248 + merge.
- [x] Button `stop_propagation` prevents toggling the header collapse (verified in code; cchao-devo confirmed in review).

Part of epic #250. Remaining: #263 (live BlackArch tier, blocked by #248) then whole-group install-all.
