### PR TITLE
ci(#252): workflow to build openat2-capable static proot

### DIFF
--- a/.github/proot-build/ashmem.h
+++ b/.github/proot-build/ashmem.h
@@ -1,0 +1,20 @@
+/* Minimal linux/ashmem.h stub for building termux/proot on glibc/Debian.
+ *
+ * termux/proot's Android-only `ashmem_memfd` extension #includes
+ * <linux/ashmem.h>, which does not exist in mainline glibc headers. We stub it
+ * (rather than delete the object) because cli/proot.c references
+ * ashmem_memfd_callback. See .github/workflows/build-proot.yml and #248/#252.
+ */
+#ifndef _LINUX_ASHMEM_H
+#define _LINUX_ASHMEM_H
+
+#include <linux/limits.h>
+#include <linux/ioctl.h>
+
+#define ASHMEM_NAME_LEN 256
+#define ASHMEM_NAME_DEF "dev/ashmem"
+
+#define ASHMEM_SET_NAME _IOW(0x77, 1, char[ASHMEM_NAME_LEN])
+#define ASHMEM_SET_SIZE _IOW(0x77, 3, size_t)
+
+#endif /* _LINUX_ASHMEM_H */

--- a/.github/proot-build/build.sh
+++ b/.github/proot-build/build.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Build a static, openat2-capable proot from termux/proot (#248/#252).
+#
+# Runs INSIDE a debian:bookworm container (see build-proot.yml), with the repo
+# bind-mounted at /work. Reads $TERMUX_PROOT_REF and $ARCH from the env.
+# Recipe verified A/B during the #248 spike:
+#   - glibc-static (musl fails on `struct rlimit64`)
+#   - strip the lld-only `--rosegment` linker flag (GNU ld rejects it)
+#   - stub <linux/ashmem.h> so the Android-only ashmem_memfd extension compiles
+#     (do NOT delete the object — cli/proot.c references ashmem_memfd_callback)
+set -euo pipefail
+
+: "${TERMUX_PROOT_REF:?TERMUX_PROOT_REF must be set}"
+: "${ARCH:?ARCH must be set}"
+
+apt-get update
+apt-get install -y --no-install-recommends \
+  git ca-certificates build-essential libc6-dev \
+  pkg-config uthash-dev libtalloc-dev python3 gzip file
+
+git clone https://github.com/termux/proot /src
+cd /src
+git checkout "$TERMUX_PROOT_REF"
+
+# Patch 1: strip the lld-only --rosegment flag (GNU ld rejects it).
+if grep -rl -- "--rosegment" . >/dev/null 2>&1; then
+  grep -rl -- "--rosegment" . | xargs sed -i "s/-Wl,--rosegment//g"
+fi
+
+# Patch 2: install the committed linux/ashmem.h stub.
+mkdir -p /usr/include/linux
+cp /work/.github/proot-build/ashmem.h /usr/include/linux/ashmem.h
+
+# Static glibc build.
+make -C src LDFLAGS="-static" V=1
+/src/src/proot --version
+
+cp /src/src/proot "/work/proot-${ARCH}"
+file "/work/proot-${ARCH}"

--- a/.github/proot-build/openat2_probe.c
+++ b/.github/proot-build/openat2_probe.c
@@ -1,0 +1,30 @@
+/* openat2 smoke test for the freshly built proot (#248/#252).
+ *
+ * #248: the old proot could not translate the openat2 syscall, so libalpm's
+ * pacman-DB reads failed under the sandbox. This probe opens a file via
+ * openat2 (syscall 437). Run UNDER the new proot it must return a valid fd; if
+ * proot cannot translate openat2 it returns an error and the CI build fails,
+ * so a regression can never ship. Compiled and invoked by
+ * .github/workflows/build-proot.yml.
+ */
+#define _GNU_SOURCE
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/syscall.h>
+#include <linux/openat2.h>
+
+int main(void) {
+    struct open_how how;
+    memset(&how, 0, sizeof(how));
+    how.flags = O_RDONLY;
+
+    long fd = syscall(SYS_openat2, AT_FDCWD, "/etc/hostname", &how, sizeof(how));
+    if (fd < 0) {
+        perror("openat2");
+        return 2;
+    }
+    printf("openat2 ok, fd=%ld\n", fd);
+    return 0;
+}

--- a/.github/workflows/build-proot.yml
+++ b/.github/workflows/build-proot.yml
@@ -1,0 +1,159 @@
+# Build an openat2-capable static `proot` for the BlackArch sandbox.
+#
+# Why this exists (#248 / #252): the upstream proot-me v5.3.0 binary the
+# connector downloads cannot translate the `openat2` syscall. Modern libalpm
+# (pacman 7) opens the sync databases with `openat2`, so under that proot every
+# DB read fails with a bogus "not readable: No such file or directory" and
+# ALL pacman-based tool installs fail with "target not found" — even though the
+# .db files are on disk and readable via cat.
+#
+# termux/proot carries an `openat2 -> openat` rewrite that upstream proot-me
+# lacks. Building that statically (glibc, not musl — musl chokes on
+# `struct rlimit64`) produces a proot whose DB reads work, which fixes #248.
+#
+# This workflow builds that binary for x86_64 + aarch64, verifies it can
+# translate openat2 (smoke test), checksums it, and — on a tagged/dispatched
+# run — publishes it to a GitHub release the connector's downloader points at.
+#
+# Manual, not push-triggered: building proot is infrastructure, run
+# deliberately (workflow_dispatch) or when a `proot-openat2-vN` tag is pushed.
+name: Build proot
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag to publish under (e.g. proot-openat2-v1). Blank = build + smoke-test only, no publish."
+        required: false
+        default: ""
+  push:
+    tags:
+      - "proot-openat2-v*"
+
+permissions:
+  contents: write
+
+env:
+  # Pinned termux/proot commit that carries the openat2 rewrite. Pin by SHA so
+  # the build is reproducible and an upstream force-push can't change what we
+  # ship. TODO(#252): replace with the exact commit verified during the spike
+  # before this workflow is relied upon.
+  TERMUX_PROOT_REF: "master"
+
+jobs:
+  build:
+    name: Build proot (${{ matrix.arch }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            docker_platform: linux/amd64
+          - arch: aarch64
+            docker_platform: linux/arm64
+    steps:
+      - uses: actions/checkout@v5
+
+      # QEMU lets the arm64 build run in an arm64 Debian container on the
+      # x86_64 runner. The x86_64 build also runs in a container so both arches
+      # use the identical Debian toolchain.
+      - name: Set up QEMU (for aarch64 emulation)
+        if: matrix.arch == 'aarch64'
+        uses: docker/setup-qemu-action@v3
+
+      - name: Build static proot in Debian
+        env:
+          ARCH: ${{ matrix.arch }}
+          DOCKER_PLATFORM: ${{ matrix.docker_platform }}
+        run: |
+          set -euo pipefail
+          # The build script and support files (ashmem.h stub, openat2 probe)
+          # are committed under .github/proot-build/ and bind-mounted into the
+          # container. This deliberately avoids nesting heredocs inside a
+          # docker `bash -c '...'` inline script, where multi-layer YAML+shell
+          # quoting silently corrupts the payload.
+          docker run --rm --platform "$DOCKER_PLATFORM" \
+            -e TERMUX_PROOT_REF="$TERMUX_PROOT_REF" \
+            -e ARCH="$ARCH" \
+            -v "$PWD:/work" \
+            debian:bookworm \
+            bash -euxo pipefail /work/.github/proot-build/build.sh
+
+      - name: Verify static + record checksum
+        run: |
+          set -euo pipefail
+          file "proot-${{ matrix.arch }}" | tee /dev/stderr | grep -q "statically linked" \
+            || { echo "ERROR: proot-${{ matrix.arch }} is not statically linked"; exit 1; }
+          sha256sum "proot-${{ matrix.arch }}" | tee "proot-${{ matrix.arch }}.sha256"
+
+      # openat2 smoke test (x86_64 only — the arm64 binary runs under QEMU where
+      # syscall probing is unreliable). A rootfs file opened via syscall 437
+      # (openat2) must return a valid fd, not ENOENT. This is the exact failure
+      # #248 hit; a regression here must fail the build, never ship silently.
+      - name: openat2 smoke test
+        if: matrix.arch == 'x86_64'
+        run: |
+          set -euo pipefail
+          # Probe source is committed at .github/proot-build/openat2_probe.c.
+          cc -static -o /tmp/openat2_probe .github/proot-build/openat2_probe.c
+          # Run the probe UNDER the freshly built proot on a minimal rootfs (/).
+          # If proot cannot translate openat2, the probe exits non-zero and the
+          # build fails — exactly the #248 signature.
+          ./proot-x86_64 -0 -r / /tmp/openat2_probe
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: proot-${{ matrix.arch }}
+          path: |
+            proot-${{ matrix.arch }}
+            proot-${{ matrix.arch }}.sha256
+          if-no-files-found: error
+
+  publish:
+    name: Publish proot release
+    needs: build
+    runs-on: ubuntu-latest
+    # Only publish when a tag was pushed or a release_tag input was given;
+    # a bare workflow_dispatch with no tag builds + smoke-tests only.
+    if: startsWith(github.ref, 'refs/tags/proot-openat2-v') || inputs.release_tag != ''
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Stage release assets
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          cp artifacts/proot-x86_64/proot-x86_64 dist/
+          cp artifacts/proot-x86_64/proot-x86_64.sha256 dist/
+          cp artifacts/proot-aarch64/proot-aarch64 dist/
+          cp artifacts/proot-aarch64/proot-aarch64.sha256 dist/
+          ls -l dist
+
+      - name: Resolve tag
+        id: tag
+        run: |
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ inputs.release_tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to GitHub release
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: "openat2-capable proot (${{ steps.tag.outputs.tag }})"
+          body: |
+            Static, openat2-capable `proot` for the BlackArch sandbox (fixes #248).
+            Built from termux/proot @ `${{ env.TERMUX_PROOT_REF }}`.
+            Verify with the published `.sha256` files before use.
+          files: |
+            dist/proot-x86_64
+            dist/proot-x86_64.sha256
+            dist/proot-aarch64
+            dist/proot-aarch64.sha256

--- a/.github/workflows/build-proot.yml
+++ b/.github/workflows/build-proot.yml
@@ -91,19 +91,29 @@ jobs:
           sha256sum "proot-${{ matrix.arch }}" | tee "proot-${{ matrix.arch }}.sha256"
 
       # openat2 smoke test (x86_64 only — the arm64 binary runs under QEMU where
-      # syscall probing is unreliable). A rootfs file opened via syscall 437
-      # (openat2) must return a valid fd, not ENOENT. This is the exact failure
-      # #248 hit; a regression here must fail the build, never ship silently.
+      # syscall probing is unreliable). This must reproduce the EXACT #248
+      # signature: the broken proot does not fail openat2 outright — it executes
+      # openat2 but returns a bogus ENOENT because it fails to translate the
+      # guest path to the rootfs path. So the probe MUST run under a real,
+      # NON-identity rootfs: the probe opens `/etc/hostname`, which a correct
+      # proot rewrites to `<rootfs>/etc/hostname` (present here) and returns a
+      # valid fd; a proot with the #248 path-translation bug leaves the path
+      # untranslated -> ENOENT -> probe exits non-zero -> build fails.
+      #
+      # (An identity rootfs `-r /` would false-pass: guest /etc/hostname maps to
+      # the host's real /etc/hostname whether or not translation happens.)
       - name: openat2 smoke test
         if: matrix.arch == 'x86_64'
         run: |
           set -euo pipefail
           # Probe source is committed at .github/proot-build/openat2_probe.c.
           cc -static -o /tmp/openat2_probe .github/proot-build/openat2_probe.c
-          # Run the probe UNDER the freshly built proot on a minimal rootfs (/).
-          # If proot cannot translate openat2, the probe exits non-zero and the
-          # build fails — exactly the #248 signature.
-          ./proot-x86_64 -0 -r / /tmp/openat2_probe
+          # Minimal non-identity rootfs whose /etc/hostname differs from the
+          # host, so only correct path-translation can open it.
+          mkdir -p /tmp/rootfs/etc /tmp/rootfs/tmp
+          echo "proot-rootfs-marker" > /tmp/rootfs/etc/hostname
+          cp /tmp/openat2_probe /tmp/rootfs/tmp/openat2_probe
+          ./proot-x86_64 -0 -r /tmp/rootfs /tmp/openat2_probe
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/build-proot.yml
+++ b/.github/workflows/build-proot.yml
@@ -34,11 +34,14 @@ permissions:
   contents: write
 
 env:
-  # Pinned termux/proot commit that carries the openat2 rewrite. Pin by SHA so
-  # the build is reproducible and an upstream force-push can't change what we
-  # ship. TODO(#252): replace with the exact commit verified during the spike
-  # before this workflow is relied upon.
-  TERMUX_PROOT_REF: "master"
+  # Pinned termux/proot commit that carries the openat2 handling (#248 fix).
+  # Pinned by full SHA so the build is reproducible and an upstream force-push
+  # can't change what we ship. Verified at pin time: this ref references
+  # `openat2` across 13 files, including the syscall rewrite in
+  # src/syscall/enter.c and the per-arch sysnums-*.h tables — the code the old
+  # proot-me v5.3.0 lacks. Bump deliberately (and re-verify) when adopting a
+  # newer termux/proot.
+  TERMUX_PROOT_REF: "6c09638b65797997e33b218a42e5e2c7645cb788"
 
 jobs:
   build:


### PR DESCRIPTION
## Summary

First step of #252, which productionizes the fix for **#248** (the sandbox bug blocking all pacman tool installs — and, downstream, #263's live BlackArch tier and #275's uninstall end-to-end test).

**#248 root cause** (already diagnosed in #252): the bundled `proot-me v5.3.0` can't translate the `openat2` syscall, so libalpm (pacman 7) can't read the sync DBs under the sandbox — every install fails `target not found` even though the `.db` files are on disk. The verified fix is a static, **openat2-capable** proot built from `termux/proot`.

This PR adds the workflow that **builds and hosts that binary**, so the downloader can later point at it.

## What's here
- **`.github/workflows/build-proot.yml`** — matrix build (x86_64 + aarch64) in a `debian:bookworm` container (aarch64 via QEMU). x86_64 runs an **openat2 smoke test**: a probe compiled and run *under the freshly built proot* must open a file via syscall 437, or the build fails — so a proot that reintroduces #248 can never ship. Per-artifact SHA-256 recorded. A `publish` job (gated on a `proot-openat2-v*` tag or a `release_tag` input) uploads the binaries + checksums to a GitHub release.
- **`.github/proot-build/build.sh`** — the recipe recorded during the #248 spike (glibc-static; strip the lld-only `--rosegment` flag; stub `linux/ashmem.h`), as a committed script bind-mounted into the container.
- **`.github/proot-build/{ashmem.h, openat2_probe.c}`** — the ashmem stub + smoke-test probe as committed files.

### A deliberate robustness choice
The build recipe is a **committed script + support files**, not a nested heredoc inside a docker `bash -c '...'` inline block. Multi-layer YAML+shell quoting around nested heredocs silently corrupts the payload — I hit exactly that while drafting this, so I moved the C header and probe out to real files. (Verified: `openat2_probe.c` compiles/links, `build.sh` passes `bash -n`, the workflow is valid YAML with zero heredocs.)

## What this PR does NOT do (honest scope)
- It does not repoint `download_proot` or add SHA-256 verification yet (that's #252 steps 3-4) — those are done **after** a release exists with a known checksum, so they can be verified rather than shipped against a placeholder.
- I **cannot** run the actual cross-compile or publish the release from here (needs the CI runner + a release). This PR is the workflow that lets CI do it.

## Action required to make it usable
1. ~~Pin `TERMUX_PROOT_REF`~~ **DONE** — pinned to termux/proot @ `6c09638` (full SHA), verified at pin time to carry the openat2 handling (references `openat2` across 13 files incl. the `src/syscall/enter.c` rewrite + per-arch `sysnums-*.h` tables). If the spike used a different commit, bump + re-verify.
2. Merge, then run the workflow (dispatch with a `release_tag`, or push a `proot-openat2-v1` tag) so it builds + publishes.
3. Follow-up PR: repoint `download_proot` at the release + SHA-256 verify + `XferCommand=curl`.

## Test plan
- [x] `TERMUX_PROOT_REF` pinned to a verified openat2-capable commit (termux/proot @ `6c09638`).
- [ ] Workflow dispatched; x86_64 + aarch64 build green.
- [ ] openat2 smoke test passes (proot translates syscall 437).
- [ ] Release published with both binaries + `.sha256` files.
- [ ] (follow-up) downloader repointed + checksum-verified; fresh sandbox installs a tool end-to-end (closes #248).

Part of #252. I cannot validate the build end-to-end locally (no CI runner / static libc on this host); the workflow YAML, the build script (`bash -n`), and the probe (compiles) are validated as far as possible without a run.
