### PR TITLE
feat(#252): verify + repoint proot download; curl XferCommand

### DIFF
--- a/.github/proot-build/build.sh
+++ b/.github/proot-build/build.sh
@@ -35,8 +35,14 @@ git checkout "$TERMUX_PROOT_REF"
 mkdir -p /usr/include/linux
 cp /work/.github/proot-build/ashmem.h /usr/include/linux/ashmem.h
 
-# Static glibc build.
-make -C src LDFLAGS="-static" V=1
+# Static glibc build. Pass LDFLAGS through the ENVIRONMENT, not as a make
+# argument: `make LDFLAGS=-static` is a command-line assignment that OVERRIDES
+# the makefile's `LDFLAGS += -ltalloc -Wl,-z,noexecstack` (src/GNUmakefile:19),
+# dropping -ltalloc and failing the final link with `undefined reference to
+# _talloc_*`. Setting it in the environment lets the makefile's `+=` append, so
+# both -static and -ltalloc reach the link. (Verified: GNU make gives env vars
+# lower precedence than `+=`, command-line vars higher.)
+LDFLAGS="-static" make -C src V=1
 /src/src/proot --version
 
 cp /src/src/proot "/work/proot-${ARCH}"

--- a/.github/proot-build/build.sh
+++ b/.github/proot-build/build.sh
@@ -35,14 +35,23 @@ git checkout "$TERMUX_PROOT_REF"
 mkdir -p /usr/include/linux
 cp /work/.github/proot-build/ashmem.h /usr/include/linux/ashmem.h
 
-# Static glibc build. Pass LDFLAGS through the ENVIRONMENT, not as a make
-# argument: `make LDFLAGS=-static` is a command-line assignment that OVERRIDES
-# the makefile's `LDFLAGS += -ltalloc -Wl,-z,noexecstack` (src/GNUmakefile:19),
-# dropping -ltalloc and failing the final link with `undefined reference to
-# _talloc_*`. Setting it in the environment lets the makefile's `+=` append, so
-# both -static and -ltalloc reach the link. (Verified: GNU make gives env vars
-# lower precedence than `+=`, command-line vars higher.)
-LDFLAGS="-static" make -C src V=1
+# Static glibc build.
+#
+# LDFLAGS via the ENVIRONMENT, not as a make argument: `make LDFLAGS=-static` is
+# a command-line assignment that OVERRIDES the makefile's
+# `LDFLAGS += -ltalloc -Wl,-z,noexecstack` (src/GNUmakefile:19), dropping
+# -ltalloc and failing the final link with `undefined reference to _talloc_*`.
+# In the environment, the makefile's `+=` appends, so both -static and -ltalloc
+# reach the link. (GNU make: env vars have lower precedence than `+=`.)
+#
+# HAS_LOADER_32BIT= (command-line, empty) disables the 32-bit compat loader. The
+# makefile derives it from arch.h and, on aarch64, tries to build loader-m32 with
+# `cc -m32` — which the aarch64 toolchain has no notion of (`unrecognized
+# command-line option '-m32'`). The sandbox only runs native-arch tools, so the
+# 32-bit guest loader is dead weight; disable it on every arch for a uniform,
+# reproducible build. (GNU make: a command-line `VAR=` overrides the makefile's
+# `:=`, and `ifdef` on the resulting empty value is false.)
+LDFLAGS="-static" make -C src HAS_LOADER_32BIT= V=1
 /src/src/proot --version
 
 cp /src/src/proot "/work/proot-${ARCH}"

--- a/.github/proot-build/build.sh
+++ b/.github/proot-build/build.sh
@@ -5,7 +5,12 @@
 # bind-mounted at /work. Reads $TERMUX_PROOT_REF and $ARCH from the env.
 # Recipe verified A/B during the #248 spike:
 #   - glibc-static (musl fails on `struct rlimit64`)
-#   - strip the lld-only `--rosegment` linker flag (GNU ld rejects it)
+#   - let the makefile auto-detect the lld-only `--rosegment` flag: its src/GNUmakefile
+#     probe test-links with `-Wl,--rosegment` and only enables it if the linker
+#     accepts it, so on GNU ld (which rejects it) it is skipped automatically.
+#     Do NOT sed it out — the flag's only literal occurrence is inside that probe,
+#     so editing it breaks detection and forces `--rosegment` onto the real link
+#     line, which GNU ld then rejects (the loader/loader link fails).
 #   - stub <linux/ashmem.h> so the Android-only ashmem_memfd extension compiles
 #     (do NOT delete the object — cli/proot.c references ashmem_memfd_callback)
 set -euo pipefail
@@ -22,12 +27,11 @@ git clone https://github.com/termux/proot /src
 cd /src
 git checkout "$TERMUX_PROOT_REF"
 
-# Patch 1: strip the lld-only --rosegment flag (GNU ld rejects it).
-if grep -rl -- "--rosegment" . >/dev/null 2>&1; then
-  grep -rl -- "--rosegment" . | xargs sed -i "s/-Wl,--rosegment//g"
-fi
+# NOTE: no --rosegment patch. The makefile's own probe (src/GNUmakefile) disables
+# the flag on GNU ld automatically; sed-ing it out corrupts that probe and forces
+# the flag on, breaking the loader link (#252, first live run of this workflow).
 
-# Patch 2: install the committed linux/ashmem.h stub.
+# Patch: install the committed linux/ashmem.h stub.
 mkdir -p /usr/include/linux
 cp /work/.github/proot-build/ashmem.h /usr/include/linux/ashmem.h
 

--- a/.github/proot-build/build.sh
+++ b/.github/proot-build/build.sh
@@ -19,9 +19,13 @@ set -euo pipefail
 : "${ARCH:?ARCH must be set}"
 
 apt-get update
+# gawk (not the default mawk): the makefile's loader-info.awk uses strtonum(),
+# a gawk extension. Under mawk the loader-info.c generation step dies with
+# "function strtonum never defined" (GNUmakefile:246). Installing gawk points
+# Debian's `awk` alternative at gawk, so `awk` resolves strtonum on every arch.
 apt-get install -y --no-install-recommends \
   git ca-certificates build-essential libc6-dev \
-  pkg-config uthash-dev libtalloc-dev python3 gzip file
+  pkg-config uthash-dev libtalloc-dev python3 gzip file gawk
 
 git clone https://github.com/termux/proot /src
 cd /src

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,14 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    # CI runners have no BlackArch sandbox backend (no bwrap/proot installed).
+    # With the sandbox enabled, tests that run a real command fall through to
+    # download_proot + rootfs extraction, which hangs a non-root runner (tar
+    # cannot create the CA-cert symlinks) until the 6-hour job timeout. Disable
+    # the sandbox for the whole run so command execution takes the host path —
+    # the same reason the pentest-core integration tests call set_use_sandbox(false).
+    env:
+      DISABLE_SANDBOX: "true"
     steps:
       - uses: actions/checkout@v5
       - name: Install system dependencies
@@ -68,6 +76,10 @@ jobs:
   check-macos:
     name: Check (macOS)
     runs-on: macos-latest
+    # Same rationale as the Test job: no sandbox backend on the runner, so keep
+    # command execution on the host path and out of download_proot/rootfs.
+    env:
+      DISABLE_SANDBOX: "true"
     steps:
       - uses: actions/checkout@v5
       - name: Install protobuf

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -873,15 +873,16 @@ impl AppSettings {
 mod tests {
     use super::*;
 
-    /// Serialises the tenant-env-var tests. These mutate process-global env
-    /// vars (`TENANT_ENV_VARS`), so they must not run concurrently or one
-    /// test's `set_var` leaks into another's view. A SINGLE shared lock is
-    /// required: two separate per-test locks (the previous state) provide no
-    /// mutual exclusion between the tests and let them race — on a busy runner
-    /// `..._prefers_matrix_tenant_id` (which sets MATRIX_TENANT_ID to a UUID)
-    /// could interleave with `..._returns_none_when_only_slugs_present` and
-    /// flip its `got.is_none()` assertion (seen flaking on macOS CI).
-    static TENANT_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    /// Serialises every test that mutates a process-global env var — the
+    /// tenant vars (`TENANT_ENV_VARS`) AND `HOME` (the credential-file tests set
+    /// it to a tempdir). All must share ONE lock: env vars are process-global,
+    /// so a `HOME`-mutating test racing a tenant test (or the two `HOME` tests
+    /// racing each other) lets one test's `set_var`/`remove_var` leak into
+    /// another's view. Per-test locks provide no mutual exclusion. Symptoms seen
+    /// on CI: `..._prefers_matrix_tenant_id` flipping `..._returns_none...`'s
+    /// assertion, and `read_credentials_tenant_id_extracts_uuid`'s `HOME` being
+    /// cleared mid-read by a sibling's restore (its `assert_eq!` on the UUID).
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
     #[test]
     fn preserves_explicit_wss_with_port() {
@@ -1030,7 +1031,7 @@ mod tests {
     fn tenant_uuid_from_env_prefers_matrix_tenant_id() {
         // Serialise all tenant-env manipulation on the shared lock so parallel
         // tests can't leak into each other's env-var view.
-        let _guard = TENANT_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
         let previous: Vec<(&str, Option<String>)> = ConnectorConfig::TENANT_ENV_VARS
             .iter()
@@ -1062,7 +1063,7 @@ mod tests {
 
     #[test]
     fn tenant_uuid_from_env_returns_none_when_only_slugs_present() {
-        let _guard = TENANT_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
         let previous: Vec<(&str, Option<String>)> = ConnectorConfig::TENANT_ENV_VARS
             .iter()
@@ -1090,6 +1091,10 @@ mod tests {
 
     #[test]
     fn read_credentials_tenant_id_extracts_uuid() {
+        // Serialise with every other env-mutating config test: this test sets
+        // HOME (process-global), and a concurrent test's set/remove of HOME (or
+        // the tenant tests) would otherwise flip the read below. See ENV_LOCK.
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         // Isolate HOME so the test doesn't touch the real credentials dir.
         let tmp = tempfile::tempdir().expect("tempdir");
         let creds_dir = tmp.path().join(".strike48").join("credentials");
@@ -1115,6 +1120,8 @@ mod tests {
 
     #[test]
     fn read_credentials_tenant_id_returns_none_when_missing() {
+        // Serialise with every other env-mutating config test (sets HOME). See ENV_LOCK.
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let tmp = tempfile::tempdir().expect("tempdir");
         let prev = std::env::var("HOME").ok();
         unsafe { std::env::set_var("HOME", tmp.path()) };

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -873,6 +873,16 @@ impl AppSettings {
 mod tests {
     use super::*;
 
+    /// Serialises the tenant-env-var tests. These mutate process-global env
+    /// vars (`TENANT_ENV_VARS`), so they must not run concurrently or one
+    /// test's `set_var` leaks into another's view. A SINGLE shared lock is
+    /// required: two separate per-test locks (the previous state) provide no
+    /// mutual exclusion between the tests and let them race — on a busy runner
+    /// `..._prefers_matrix_tenant_id` (which sets MATRIX_TENANT_ID to a UUID)
+    /// could interleave with `..._returns_none_when_only_slugs_present` and
+    /// flip its `got.is_none()` assertion (seen flaking on macOS CI).
+    static TENANT_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn preserves_explicit_wss_with_port() {
         let n = ConnectorConfig::normalize_host("wss://studio.example.com:443").unwrap();
@@ -1018,10 +1028,9 @@ mod tests {
 
     #[test]
     fn tenant_uuid_from_env_prefers_matrix_tenant_id() {
-        // Serialise all tenant-env manipulation on a single lock so parallel
+        // Serialise all tenant-env manipulation on the shared lock so parallel
         // tests can't leak into each other's env-var view.
-        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = TENANT_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
         let previous: Vec<(&str, Option<String>)> = ConnectorConfig::TENANT_ENV_VARS
             .iter()
@@ -1053,8 +1062,7 @@ mod tests {
 
     #[test]
     fn tenant_uuid_from_env_returns_none_when_only_slugs_present() {
-        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = TENANT_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
         let previous: Vec<(&str, Option<String>)> = ConnectorConfig::TENANT_ENV_VARS
             .iter()

--- a/crates/platform/Cargo.toml
+++ b/crates/platform/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 
 [features]
 default = ["desktop"]
-desktop = ["sysinfo", "local-ip-address", "dns-lookup", "network-interface", "dep:lazy_static", "dep:uuid", "dep:image", "desktop-mdns", "wifi_scan", "ssdp-client", "dep:reqwest", "dep:portable-pty", "dep:libc"]
+desktop = ["sysinfo", "local-ip-address", "dns-lookup", "network-interface", "dep:lazy_static", "dep:uuid", "dep:image", "desktop-mdns", "wifi_scan", "ssdp-client", "dep:reqwest", "dep:portable-pty", "dep:libc", "dep:sha2"]
 desktop-all = ["desktop", "desktop-screenshots"]
 desktop-screenshots = ["desktop", "screenshots"]
 desktop-mdns = ["desktop", "mdns-sd"]

--- a/crates/platform/src/desktop/sandbox/mod.rs
+++ b/crates/platform/src/desktop/sandbox/mod.rs
@@ -421,7 +421,15 @@ impl SandboxManager {
 mod tests {
     use super::*;
 
+    // Ignored: this touches the network. On a host without bwrap/proot (e.g. a
+    // CI runner), `detect_backend` falls through to `download_proot`, which now
+    // that the SHA pins are populated actually fetches the binary over HTTP.
+    // The test has no assertions (it only prints the detected backend), so it
+    // provides no regression value in CI while risking a slow/stalled download.
+    // Run explicitly (`--ignored`) on a machine where a real backend probe is
+    // wanted. The timeout added to `download_proot` bounds the stall regardless.
     #[tokio::test]
+    #[ignore = "hits the network via download_proot; no assertions — run with --ignored"]
     async fn test_sandbox_backend_detection() {
         let config = SandboxConfig::default();
         let result = SandboxManager::detect_backend(&config).await;

--- a/crates/platform/src/desktop/sandbox/proot.rs
+++ b/crates/platform/src/desktop/sandbox/proot.rs
@@ -161,8 +161,20 @@ impl ProotExecutor {
                 PROOT_RELEASE_TAG
             );
 
-            // Download using reqwest
-            let response = reqwest::get(download.url)
+            // Download using reqwest with explicit timeouts. A bare
+            // `reqwest::get` has no timeout, so a stalled connect or read hangs
+            // the caller forever (fail-hang) — it manifested as a 6-hour CI
+            // hang once the pins were filled and this path actually ran. Bound
+            // both the connect and the whole request so a stall fails closed
+            // (SandboxError::Download) instead of blocking indefinitely (#294).
+            let client = reqwest::Client::builder()
+                .connect_timeout(Duration::from_secs(15))
+                .timeout(Duration::from_secs(120))
+                .build()
+                .map_err(|e| SandboxError::Download(e.to_string()))?;
+            let response = client
+                .get(download.url)
+                .send()
                 .await
                 .map_err(|e| SandboxError::Download(e.to_string()))?;
 

--- a/crates/platform/src/desktop/sandbox/proot.rs
+++ b/crates/platform/src/desktop/sandbox/proot.rs
@@ -12,12 +12,8 @@ use tokio::process::Command;
 
 /// Release tag hosting the openat2-capable proot binaries (#248/#252). The
 /// `build-proot.yml` workflow publishes `proot-<arch>` + `proot-<arch>.sha256`
-/// under this tag on Strike48-public/pick.
-///
-/// TODO(#252): set this to the tag the build workflow actually publishes, and
-/// fill in the SHA-256 values below from the published `.sha256` files, once
-/// the build has run. Until then `download_proot` fails closed (see
-/// [`PROOT_DOWNLOADS`] placeholders).
+/// under this tag on Strike48-public/pick. Bump this (and the SHA-256 values in
+/// [`PROOT_DOWNLOADS`]) when republishing under a new `proot-openat2-vN` tag.
 #[cfg(target_os = "linux")]
 const PROOT_RELEASE_TAG: &str = "proot-openat2-v1";
 
@@ -41,14 +37,16 @@ const PROOT_DOWNLOADS: &[ProotDownload] = &[
     ProotDownload {
         arch: "x86_64",
         url: "https://github.com/Strike48-public/pick/releases/download/proot-openat2-v1/proot-x86_64",
-        // TODO(#252): fill from proot-x86_64.sha256 published by build-proot.yml.
-        sha256: "",
+        // Published by build-proot.yml (run 29788507360); verified against the
+        // release's proot-x86_64.sha256 and the binary itself.
+        sha256: "2b5e31b7da36b7319eb82483d176cf5ffd6ffbd89480934deb1eb258aca521c4",
     },
     ProotDownload {
         arch: "aarch64",
         url: "https://github.com/Strike48-public/pick/releases/download/proot-openat2-v1/proot-aarch64",
-        // TODO(#252): fill from proot-aarch64.sha256 published by build-proot.yml.
-        sha256: "",
+        // Published by build-proot.yml (run 29788507360); verified against the
+        // release's proot-aarch64.sha256 and the binary itself.
+        sha256: "fddb92926ed9384bedd67db532518d5284fa6bbd7cc2d530672801b871288473",
     },
 ];
 
@@ -353,5 +351,44 @@ mod tests {
     fn verify_sha256_refuses_empty_pin() {
         // An unpinned checksum must fail closed, never run unverified.
         assert!(verify_sha256(b"hello", "", "x86_64").is_err());
+    }
+
+    // Guard the shipped pins: every PROOT_DOWNLOADS entry must carry a
+    // well-formed (64-hex-char, lowercase) SHA-256. Catches a regression to the
+    // empty placeholder or a truncated/typo'd hash at test time — before it
+    // degrades the connector to "refuses to run an unverified binary" in the
+    // field. (Does not fetch the network; it only asserts the pins are shaped
+    // like real digests.)
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn every_proot_download_has_a_wellformed_pinned_sha256() {
+        assert!(!PROOT_DOWNLOADS.is_empty(), "no proot downloads configured");
+        for d in PROOT_DOWNLOADS {
+            assert_eq!(
+                d.sha256.len(),
+                64,
+                "proot ({}) SHA-256 must be 64 hex chars, got {}",
+                d.arch,
+                d.sha256.len()
+            );
+            assert!(
+                d.sha256.chars().all(|c| c.is_ascii_hexdigit()),
+                "proot ({}) SHA-256 has non-hex chars: {}",
+                d.arch,
+                d.sha256
+            );
+            assert!(
+                d.sha256.chars().all(|c| !c.is_ascii_uppercase()),
+                "proot ({}) SHA-256 should be lowercase hex",
+                d.arch
+            );
+            // And it must actually satisfy verify_sha256's own well-formedness
+            // path (non-empty pin) — i.e. it would not fail closed.
+            let mismatch = verify_sha256(b"not the real binary", d.sha256, d.arch);
+            assert!(
+                matches!(mismatch, Err(SandboxError::Download(_))),
+                "expected a mismatch error (pin is well-formed but data differs)"
+            );
+        }
     }
 }

--- a/crates/platform/src/desktop/sandbox/proot.rs
+++ b/crates/platform/src/desktop/sandbox/proot.rs
@@ -10,18 +10,68 @@ use std::process::Stdio;
 use std::time::{Duration, Instant};
 use tokio::process::Command;
 
-/// URLs for downloading static proot binaries (Linux only)
+/// Release tag hosting the openat2-capable proot binaries (#248/#252). The
+/// `build-proot.yml` workflow publishes `proot-<arch>` + `proot-<arch>.sha256`
+/// under this tag on Strike48-public/pick.
+///
+/// TODO(#252): set this to the tag the build workflow actually publishes, and
+/// fill in the SHA-256 values below from the published `.sha256` files, once
+/// the build has run. Until then `download_proot` fails closed (see
+/// [`PROOT_DOWNLOADS`] placeholders).
 #[cfg(target_os = "linux")]
-const PROOT_DOWNLOAD_URLS: &[(&str, &str)] = &[
-    (
-        "x86_64",
-        "https://github.com/proot-me/proot/releases/download/v5.3.0/proot-v5.3.0-x86_64-static",
-    ),
-    (
-        "aarch64",
-        "https://github.com/proot-me/proot/releases/download/v5.3.0/proot-v5.3.0-aarch64-static",
-    ),
+const PROOT_RELEASE_TAG: &str = "proot-openat2-v1";
+
+/// Per-architecture proot download: (arch, url, expected SHA-256 hex).
+///
+/// The SHA-256 is verified after download and before the binary is made
+/// executable; a mismatch (or an empty placeholder) fails the download rather
+/// than running an unverified binary — closing the supply-chain gap the old
+/// unchecked `reqwest::get -> write -> chmod` had.
+#[cfg(target_os = "linux")]
+struct ProotDownload {
+    arch: &'static str,
+    url: &'static str,
+    /// Lowercase hex SHA-256. EMPTY = not yet filled from a published build;
+    /// treated as "unverifiable" and refused by `verify_sha256`.
+    sha256: &'static str,
+}
+
+#[cfg(target_os = "linux")]
+const PROOT_DOWNLOADS: &[ProotDownload] = &[
+    ProotDownload {
+        arch: "x86_64",
+        url: "https://github.com/Strike48-public/pick/releases/download/proot-openat2-v1/proot-x86_64",
+        // TODO(#252): fill from proot-x86_64.sha256 published by build-proot.yml.
+        sha256: "",
+    },
+    ProotDownload {
+        arch: "aarch64",
+        url: "https://github.com/Strike48-public/pick/releases/download/proot-openat2-v1/proot-aarch64",
+        // TODO(#252): fill from proot-aarch64.sha256 published by build-proot.yml.
+        sha256: "",
+    },
 ];
+
+/// Verify `bytes` hashes to the expected lowercase-hex SHA-256. An empty
+/// `expected` means the checksum has not been pinned yet (see #252); we refuse
+/// rather than run an unverified binary.
+#[cfg(target_os = "linux")]
+fn verify_sha256(bytes: &[u8], expected: &str, arch: &str) -> SandboxResult<()> {
+    if expected.is_empty() {
+        return Err(SandboxError::Download(format!(
+            "no pinned SHA-256 for proot ({arch}); refusing to run an unverified binary. \
+             See #252: fill PROOT_DOWNLOADS[{arch}].sha256 from the published build."
+        )));
+    }
+    use sha2::{Digest, Sha256};
+    let actual = format!("{:x}", Sha256::digest(bytes));
+    if !actual.eq_ignore_ascii_case(expected) {
+        return Err(SandboxError::Download(format!(
+            "proot ({arch}) SHA-256 mismatch: expected {expected}, got {actual}"
+        )));
+    }
+    Ok(())
+}
 
 /// Proot executor for universal sandbox support
 pub struct ProotExecutor {
@@ -92,12 +142,11 @@ impl ProotExecutor {
         #[cfg(target_os = "linux")]
         {
             let arch = std::env::consts::ARCH;
-            let url = PROOT_DOWNLOAD_URLS
+            let download = PROOT_DOWNLOADS
                 .iter()
-                .find(|(a, _)| *a == arch)
-                .map(|(_, url)| *url)
+                .find(|d| d.arch == arch)
                 .ok_or_else(|| {
-                    SandboxError::Download(format!("No proot binary available for arch: {}", arch))
+                    SandboxError::Download(format!("No proot binary available for arch: {arch}"))
                 })?;
 
             let dest = config.proot_binary_path();
@@ -107,10 +156,15 @@ impl ProotExecutor {
                 tokio::fs::create_dir_all(parent).await?;
             }
 
-            tracing::info!("Downloading proot from {}", url);
+            tracing::info!(
+                "Downloading openat2-capable proot ({}) from {} [{}]",
+                arch,
+                download.url,
+                PROOT_RELEASE_TAG
+            );
 
             // Download using reqwest
-            let response = reqwest::get(url)
+            let response = reqwest::get(download.url)
                 .await
                 .map_err(|e| SandboxError::Download(e.to_string()))?;
 
@@ -126,6 +180,10 @@ impl ProotExecutor {
                 .await
                 .map_err(|e| SandboxError::Download(e.to_string()))?;
 
+            // Verify the SHA-256 BEFORE writing/executing. Fails closed on an
+            // unpinned or mismatched checksum — never run an unverified binary.
+            verify_sha256(&bytes, download.sha256, arch)?;
+
             // Write to file
             tokio::fs::write(&dest, &bytes).await?;
 
@@ -138,7 +196,7 @@ impl ProotExecutor {
                 tokio::fs::set_permissions(&dest, perms).await?;
             }
 
-            tracing::info!("Downloaded proot to {}", dest.display());
+            tracing::info!("Downloaded + verified proot to {}", dest.display());
 
             Ok(dest)
         }
@@ -268,5 +326,32 @@ mod tests {
         let config = SandboxConfig::default();
         let available = ProotExecutor::is_available(&config).await;
         println!("proot available: {}", available);
+    }
+
+    // SHA-256 of the 5 bytes "hello", precomputed:
+    //   printf 'hello' | sha256sum
+    #[cfg(target_os = "linux")]
+    const HELLO_SHA256: &str = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824";
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn verify_sha256_accepts_matching_digest() {
+        assert!(verify_sha256(b"hello", HELLO_SHA256, "x86_64").is_ok());
+        // Case-insensitive hex comparison.
+        assert!(verify_sha256(b"hello", &HELLO_SHA256.to_uppercase(), "x86_64").is_ok());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn verify_sha256_rejects_mismatch() {
+        let bad = "0000000000000000000000000000000000000000000000000000000000000000";
+        assert!(verify_sha256(b"hello", bad, "x86_64").is_err());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn verify_sha256_refuses_empty_pin() {
+        // An unpinned checksum must fail closed, never run unverified.
+        assert!(verify_sha256(b"hello", "", "x86_64").is_err());
     }
 }

--- a/crates/platform/src/desktop/sandbox/rootfs.rs
+++ b/crates/platform/src/desktop/sandbox/rootfs.rs
@@ -312,9 +312,29 @@ set -e
             changed = true;
         }
 
+        // Force an external downloader (#248/#252). pacman 7's internal parallel
+        // downloader is a silent no-op under proot — it reports success but the
+        // synced DBs are never usable — so DB/package fetches must go through
+        // curl to be deterministic. Only add it once, under [options].
+        if !content.contains("XferCommand") {
+            let xfer = "XferCommand = /usr/bin/curl -L -f -o %o %u";
+            if let Some(idx) = content.find("[options]") {
+                // Insert right after the [options] header line.
+                let insert_at = content[idx..]
+                    .find('\n')
+                    .map(|nl| idx + nl + 1)
+                    .unwrap_or(content.len());
+                content.insert_str(insert_at, &format!("{xfer}\n"));
+            } else {
+                // No [options] section (unexpected) — append a minimal one.
+                content.push_str(&format!("\n[options]\n{xfer}\n"));
+            }
+            changed = true;
+        }
+
         if changed {
             tokio::fs::write(&pacman_conf, content).await?;
-            tracing::info!("pacman.conf updated");
+            tracing::info!("pacman.conf updated (DownloadUser + curl XferCommand)");
         }
 
         Ok(())

--- a/crates/tools/src/catalog.rs
+++ b/crates/tools/src/catalog.rs
@@ -802,6 +802,12 @@ mod tests {
 
     #[tokio::test]
     async fn build_catalog_produces_entries_with_used_by() {
+        // Probe install-state on the host, not the sandbox. build_catalog runs
+        // `command -v` per tool via execute_command; with the sandbox enabled
+        // and no system proot, that triggers a proot download + rootfs setup
+        // that hangs on a CI runner (no backend, no rootfs). The host probe is
+        // equally valid for the catalog-shape assertions here.
+        pentest_platform::set_use_sandbox(false);
         let catalog = build_catalog().await;
         assert!(!catalog.is_empty());
         let nmap = catalog.iter().find(|e| e.binary_name == "nmap");
@@ -961,6 +967,9 @@ mod tests {
         // python3 / playwright are install prerequisites, not operator-facing
         // tools; they must not appear as catalog entries even though tools
         // (webwright) declare them as dependencies.
+        // Host probe: avoid the sandbox proot-download hang on CI (see
+        // build_catalog_produces_entries_with_used_by).
+        pentest_platform::set_use_sandbox(false);
         let catalog = build_catalog().await;
         for hidden in HIDDEN_CATALOG_BINARIES {
             assert!(
@@ -979,6 +988,9 @@ mod tests {
         // install. The set can legitimately be empty (e.g. everything already
         // installed, or nothing auto-installable in native mode), so we assert
         // the scoping property, not a fixed count.
+        // Host probe: avoid the sandbox proot-download hang on CI (see
+        // build_catalog_produces_entries_with_used_by).
+        pentest_platform::set_use_sandbox(false);
         let full = build_catalog().await;
         let pending = pending_installs_in_category("network").await;
         for (bin, _secs) in &pending {
@@ -1116,6 +1128,9 @@ mod tests {
     async fn ad_suite_is_not_in_recommended_default_set() {
         // Specialized AD-engagement tooling must not be swept in by the bulk
         // "install all recommended" action (the operator installs it on demand).
+        // Host probe: avoid the sandbox proot-download hang on CI (see
+        // build_catalog_produces_entries_with_used_by).
+        pentest_platform::set_use_sandbox(false);
         let catalog = build_catalog().await;
         for bin in ["bloodhound-python", "certipy", "kerbrute", "nxc"] {
             // Assert the entry EXISTS before checking its flag: without this the
@@ -1134,6 +1149,9 @@ mod tests {
 
     #[tokio::test]
     async fn build_catalog_items_is_sorted_and_nonempty() {
+        // Host probe: avoid the sandbox proot-download hang on CI (see
+        // build_catalog_produces_entries_with_used_by).
+        pentest_platform::set_use_sandbox(false);
         let items = build_catalog_items().await;
         assert!(!items.is_empty());
         // Sorted by (category, display_name).

--- a/crates/tools/src/execute_command.rs
+++ b/crates/tools/src/execute_command.rs
@@ -272,10 +272,17 @@ mod tests {
     #[tokio::test]
     async fn execute_emits_provenance_structure() {
         // Verifies the provenance contract: structure is always present when
-        // the tool runs, regardless of whether the underlying sandbox lets
-        // the command succeed. Output content is inherently environment-
-        // dependent (sandbox may reject, binary may be absent, etc.), so we
-        // assert on the reproducibility metadata itself, not the payload.
+        // the tool runs. Output content is inherently environment-dependent
+        // (binary may be absent, etc.), so we assert on the reproducibility
+        // metadata itself, not the payload.
+        //
+        // Run host-direct (sandbox disabled). With the sandbox enabled and no
+        // system proot, execute_command now DOWNLOADS the pinned proot binary
+        // and sets up the BlackArch rootfs — on a CI runner that path hangs
+        // (multi-GB rootfs / stalled fetch), timing the job out after hours.
+        // Disabling the sandbox takes the explicit host path, matching the
+        // pentest-core integration tests (connector_execute.rs).
+        pentest_platform::set_use_sandbox(false);
         let tool = ExecuteCommandTool;
         let ctx = ToolContext::default();
         let params = json!({ "command": "echo", "args": ["hello-provenance"] });
@@ -296,6 +303,10 @@ mod tests {
 
     #[tokio::test]
     async fn execute_redacts_secrets_in_effective_command() {
+        // Host-direct: same rationale as execute_emits_provenance_structure —
+        // with the sandbox enabled and no system proot, execute_command would
+        // download proot + set up the rootfs and hang on a CI runner.
+        pentest_platform::set_use_sandbox(false);
         let tool = ExecuteCommandTool;
         let ctx = ToolContext::default();
         let params = json!({

--- a/crates/ui/tests/evidence_pipeline.rs
+++ b/crates/ui/tests/evidence_pipeline.rs
@@ -347,6 +347,12 @@ fn drain_is_safe_under_concurrent_tool_execution() {
 /// second passed the gate silently.
 #[tokio::test]
 async fn failed_tool_is_flagged_and_ungrounded_finding_cannot_reach_report() {
+    // Run host-direct. With the sandbox enabled and no backend (CI runner), the
+    // command below falls through to download_proot + rootfs extraction, which
+    // hangs a non-root runner. Disabling the sandbox takes the host path — CI
+    // also sets DISABLE_SANDBOX=true, this covers a bare local `cargo test`.
+    pentest_platform::set_use_sandbox(false);
+
     // (1) Run a real command that exits nonzero with empty stdout. On a host
     // without command exec this returns Skipped; either way the outcome must
     // NOT be a trustworthy `Ran`, and `success` must be false. This half


### PR DESCRIPTION
Part of #252. Completes the code for the #248 fix. **Now live** - the release
exists and the checksums are pinned, so this closes #248.

Stacked on #285 (the build workflow), which is now merged; rebased onto main.

## What's here

### Downloader (the original scope of this PR)
- **`proot.rs`**: replace the hardcoded proot-me v5.3.0 URLs with a
  `PROOT_DOWNLOADS` table `(arch, url, sha256)` pointing at the
  `proot-openat2-v1` release. `download_proot` verifies the SHA-256 before
  writing/chmod (`verify_sha256`), closing the supply-chain gap in the old
  unchecked `get -> write -> chmod` path. Fails closed on an unpinned or
  mismatched checksum.
- **`Cargo.toml`**: add `dep:sha2` to the `desktop` feature.
- **`rootfs.rs`** (`fix_pacman_config`): force
  `XferCommand = /usr/bin/curl -L -f -o %o %u` - pacman 7's internal parallel
  downloader is a silent no-op under proot (#248, step 4).

### Build-script fixes (found by actually running #285's workflow)
#285 merged the build workflow but it had never been run. Running it surfaced
four real bugs in `build.sh`, each fixed here (see individual commits):
1. **`--rosegment`**: the sed to strip the lld-only flag corrupted termux/proot's
   own feature-detection probe, forcing the flag on -> loader link failed on GNU ld.
   Removed it; the makefile already auto-detects.
2. **`LDFLAGS`**: `make LDFLAGS=-static` overrode the makefile's `-ltalloc`,
   failing the main link with `undefined reference to _talloc_*`. Pass it via the
   environment so the makefile's `+=` appends.
3. **`-m32`**: the 32-bit compat loader can't build on aarch64 (`cc -m32`
   unrecognized). Disabled with `make HAS_LOADER_32BIT=`; the sandbox only runs
   native-arch tools.
4. **`gawk`**: `loader-info.awk` uses `strtonum()`, a gawk extension; Debian
   defaults to mawk. Install gawk so `awk` resolves it.

### Checksum pin (makes it live)
- Ran build-proot.yml (run 29788507360): both arches built, openat2 smoke test
  passed, `proot-openat2-v1` published with proot-{x86_64,aarch64} + `.sha256`.
- Pinned both verified digests into `PROOT_DOWNLOADS`. Verified three ways:
  against the release `.sha256` files, by recomputing `sha256sum` over the
  downloaded binaries, and by running the x86_64 binary locally.

## Test plan
- [x] `verify_sha256` unit tests: match (case-insensitive) / mismatch / empty-pin-refused.
- [x] New guard test: every `PROOT_DOWNLOADS` entry has a well-formed 64-hex
      lowercase SHA-256 (regression to the empty placeholder fails at test time).
      Mutation-checked - emptying a pin turns it red.
- [x] `cargo fmt --all --check`, `clippy --workspace -D warnings`, full
      `cargo test --workspace` - all green.
- [x] build-proot.yml ran green end-to-end on both arches incl. the openat2
      smoke test (the exact #248 signature); release published.
- [x] Published binaries verified static ELF + correct arch; x86_64 proot runs
      locally.
- [ ] Live end-to-end in a fresh connector sandbox: proot downloaded + verified,
      `pacman -Sy` yields readable DBs, a tool installs (the on-device proof of
      #248). Requires a Linux sandbox host with a real BlackArch rootfs; not run
      from here.

Closes #248 (pending the on-device confirmation above).
