### PR TITLE
fix(#287, #288): stop UTF-8 render panics from blanking the connector pane

### DIFF
--- a/crates/core/src/matrix/client.rs
+++ b/crates/core/src/matrix/client.rs
@@ -191,11 +191,18 @@ fn check_errors(errors: Option<Vec<GqlError>>) -> crate::error::Result<()> {
 }
 
 fn truncate_body(body: &str) -> String {
-    if body.len() <= 200 {
-        body.to_string()
-    } else {
-        format!("{}…({} bytes total)", &body[..200], body.len())
+    const MAX_PREVIEW_BYTES: usize = 200;
+    if body.len() <= MAX_PREVIEW_BYTES {
+        return body.to_string();
     }
+    // Walk down to the nearest UTF-8 char boundary at or below the byte budget.
+    // A bare `&body[..200]` panics if byte 200 falls inside a multi-byte char,
+    // which a hostile/compromised server could trigger via the error path (#287).
+    let mut end = MAX_PREVIEW_BYTES;
+    while end > 0 && !body.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…({} bytes total)", &body[..end], body.len())
 }
 
 // ---------------------------------------------------------------------------
@@ -841,5 +848,47 @@ impl MatrixChatClient {
         }
 
         Ok(response)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::truncate_body;
+
+    #[test]
+    fn returns_short_body_unchanged() {
+        let body = "small error body";
+        assert_eq!(truncate_body(body), body);
+    }
+
+    #[test]
+    fn truncates_long_ascii_body_with_byte_count() {
+        let body = "a".repeat(500);
+        let out = truncate_body(&body);
+        assert!(out.starts_with(&"a".repeat(200)));
+        assert!(out.ends_with("(500 bytes total)"));
+    }
+
+    #[test]
+    fn does_not_panic_when_multibyte_char_straddles_byte_cutoff() {
+        // Place a 2-byte 'é' straddling byte 200: bytes 0..199 are ASCII, then
+        // 'é' occupies bytes 199-200, so a bare `&body[..200]` would panic with
+        // "byte index 200 is not a char boundary" (#287). truncate_body must not.
+        let body = format!("{}\u{e9}{}", "a".repeat(199), "b".repeat(400));
+        assert!(
+            !body.is_char_boundary(200),
+            "precondition: 200 splits a char"
+        );
+
+        let out = truncate_body(&body);
+
+        // It backs off to byte 199 (the last boundary <= 200) and still reports
+        // the true byte total.
+        assert!(out.starts_with(&"a".repeat(199)));
+        assert!(out.contains("bytes total)"));
+        assert_eq!(
+            out,
+            format!("{}…({} bytes total)", "a".repeat(199), body.len())
+        );
     }
 }

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -89,4 +89,8 @@ strike48-proto = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }
+# Server-side render used by ErrorBoundary containment tests (#288). Declared
+# here (not gated behind `liveview`) so the render tests run in the required CI
+# job, which does NOT enable the `liveview` feature.
+dioxus-ssr = { workspace = true }
 

--- a/crates/ui/src/components/app_layout.rs
+++ b/crates/ui/src/components/app_layout.rs
@@ -4,6 +4,7 @@ use dioxus::prelude::*;
 
 use super::chat_panel::{ChatHeaderActions, ChatHeaderCtx};
 use super::icons::{Menu, STRIKE48_SIDEBAR_LOGO_SVG};
+use super::pane_boundary::PaneBoundary;
 use super::sidebar::{NavPage, Sidebar};
 use super::status_bar::StatusBar;
 
@@ -63,20 +64,24 @@ pub fn AppLayout(
                 }
             }
 
-            // Sidebar / Drawer
-            Sidebar {
-                active_page,
-                on_navigate,
-                sidebar_open: *sidebar_open.read(),
-                sidebar_collapsed: *sidebar_collapsed.read(),
-                on_close,
-                on_toggle_collapse,
-                unread_logs,
-                connected,
-                host: host.clone(),
-                api_url,
-                auth_token,
-                on_open_conversation,
+            // Sidebar / Drawer — wrapped so a render panic in the sidebar
+            // (e.g. a bad conversation title, #287) is contained and does not
+            // blank the main content (#288).
+            PaneBoundary { name: "sidebar".to_string(),
+                Sidebar {
+                    active_page,
+                    on_navigate,
+                    sidebar_open: *sidebar_open.read(),
+                    sidebar_collapsed: *sidebar_collapsed.read(),
+                    on_close,
+                    on_toggle_collapse,
+                    unread_logs,
+                    connected,
+                    host: host.clone(),
+                    api_url,
+                    auth_token,
+                    on_open_conversation,
+                }
             }
 
             // Main column (header + content + status bar)
@@ -116,9 +121,13 @@ pub fn AppLayout(
                     }
                 }
 
-                // Content area
+                // Content area — wrapped so a render panic in the active page
+                // or ChatPanel is contained to the content region, leaving the
+                // sidebar and header usable (#288).
                 div { class: "content-area",
-                    {children}
+                    PaneBoundary { name: "page".to_string(),
+                        {children}
+                    }
                 }
 
                 // Status bar

--- a/crates/ui/src/components/chat_panel/agent_selector.rs
+++ b/crates/ui/src/components/chat_panel/agent_selector.rs
@@ -10,6 +10,7 @@ use pentest_core::matrix::{AgentInfo, ConversationInfo};
 use super::constants::SUGGESTED_ACTIONS;
 use super::render::format_relative_time;
 use crate::components::icons::{ChevronDown, FileText, History, Plus, Shield};
+use crate::text::truncate_chars;
 
 /// Props for [`ChatHeader`].
 #[derive(Props, Clone, PartialEq)]
@@ -378,10 +379,9 @@ pub fn SuggestedActions(props: SuggestedActionsProps) -> Element {
                                 let cid = conv.id.clone();
                                 let title = if conv.title.is_empty() {
                                     "Untitled".to_string()
-                                } else if conv.title.len() > 50 {
-                                    format!("{}...", &conv.title[..47])
                                 } else {
-                                    conv.title.clone()
+                                    // Char-boundary-safe truncation (#287).
+                                    truncate_chars(&conv.title, 47)
                                 };
                                 let time_str = format_relative_time(&conv.updated_at);
                                 let on_select = props.on_select_conversation;

--- a/crates/ui/src/components/chat_panel/history.rs
+++ b/crates/ui/src/components/chat_panel/history.rs
@@ -8,6 +8,7 @@ use dioxus::prelude::*;
 use pentest_core::matrix::ConversationInfo;
 
 use super::render::format_relative_time;
+use crate::text::truncate_chars;
 
 /// Props for [`HistoryDropdown`].
 #[derive(Props, Clone, PartialEq)]
@@ -41,10 +42,9 @@ pub fn HistoryDropdown(props: HistoryDropdownProps) -> Element {
                         let conv_id_val = conv.id.clone();
                         let conv_title = if conv.title.is_empty() {
                             "Untitled".to_string()
-                        } else if conv.title.len() > 40 {
-                            format!("{}...", &conv.title[..37])
                         } else {
-                            conv.title.clone()
+                            // Char-boundary-safe truncation (#287).
+                            truncate_chars(&conv.title, 37)
                         };
                         let is_active = conversation_id
                             .read()

--- a/crates/ui/src/components/chat_panel/render.rs
+++ b/crates/ui/src/components/chat_panel/render.rs
@@ -761,3 +761,46 @@ fn load_screenshots_from_result(result_json: &str) -> Vec<(String, String)> {
         })
         .collect()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::webwright_display_name;
+
+    // End-to-end guard for the render.rs truncation call site (#287). Unlike the
+    // three sidebar/history/agent_selector sites (inline in rsx! and gated on a
+    // network-populated signal), webwright_display_name is a pure function, so we
+    // can exercise the exact truncation branch a user hits. If this site regressed
+    // to `&t[..57]`, this test would panic on the boundary-straddling task title.
+    #[test]
+    fn webwright_task_title_truncates_on_char_boundary_without_panic() {
+        // 'é' (2 bytes) straddles byte 57: bytes 0..56 ASCII, then 'é' at 56-57.
+        let task = format!(
+            "{}\u{e9}rest of the very long task description",
+            "a".repeat(56)
+        );
+        assert!(
+            task.len() > 60,
+            "precondition: task exceeds the 57-char cutoff"
+        );
+        assert!(
+            !task.is_char_boundary(57),
+            "precondition: byte 57 splits the 'é' — a byte slice would panic here"
+        );
+
+        let args = Some(format!(r#"{{"mode":"explore","task":"{task}"}}"#));
+        let out = webwright_display_name(&args);
+
+        // 57 kept chars + "..." ellipsis, prefixed by the webwright label.
+        assert!(out.starts_with("webwright explore \u{2014} "));
+        assert!(out.ends_with("..."));
+        assert!(out.contains(&"a".repeat(56)));
+        assert!(out.contains('\u{e9}'), "the 57th char (é) should be kept");
+    }
+
+    #[test]
+    fn webwright_short_task_is_not_truncated() {
+        let args = Some(r#"{"mode":"explore","task":"quick scan"}"#.to_string());
+        let out = webwright_display_name(&args);
+        assert_eq!(out, "webwright explore \u{2014} quick scan");
+    }
+}

--- a/crates/ui/src/components/chat_panel/render.rs
+++ b/crates/ui/src/components/chat_panel/render.rs
@@ -8,6 +8,8 @@ use pentest_tools::webwright::{
 };
 use pulldown_cmark::{html, Options, Parser};
 
+use crate::text::truncate_chars;
+
 fn base64_encode(bytes: &[u8]) -> String {
     BASE64.encode(bytes)
 }
@@ -103,13 +105,8 @@ fn webwright_display_name(args: &Option<String>) -> String {
     } else {
         v.get("task")
             .and_then(|t| t.as_str())
-            .map(|t| {
-                if t.len() > 60 {
-                    format!("{}...", &t[..57])
-                } else {
-                    t.to_string()
-                }
-            })
+            // Char-boundary-safe truncation (#287).
+            .map(|t| truncate_chars(t, 57))
             .or_else(|| {
                 v.get("start_url")
                     .and_then(|u| u.as_str())

--- a/crates/ui/src/components/mod.rs
+++ b/crates/ui/src/components/mod.rs
@@ -23,6 +23,7 @@ mod licenses_page;
 pub mod loading_spinner;
 mod log_filter_bar;
 mod matrix_rain;
+pub mod pane_boundary;
 // router module requires dioxus-router dependency — kept as scaffolding reference
 // #[cfg(feature = "liveview")]
 // pub mod router;
@@ -65,6 +66,7 @@ pub use licenses_page::LicensesPage;
 pub use loading_spinner::{LoadingSpinner, SpinnerSize};
 pub use log_filter_bar::LogFilterBar;
 pub use matrix_rain::{matrix_rain_css, MatrixRainOverlay};
+pub use pane_boundary::PaneBoundary;
 // #[cfg(feature = "liveview")]
 // pub use router::{Route, WorkspaceRouter};
 pub use icons::STRIKE48_SIDEBAR_LOGO_SVG;

--- a/crates/ui/src/components/pane_boundary.rs
+++ b/crates/ui/src/components/pane_boundary.rs
@@ -1,0 +1,154 @@
+//! `PaneBoundary` — reusable render-panic containment for connector UI regions.
+//!
+//! Dioxus catches a component's render panic via `catch_unwind` and hands it to
+//! the nearest [`ErrorBoundary`]; with no explicit boundary, the *root* boundary
+//! renders `"Encountered panic: Any { .. }"` in place of the whole tree, blanking
+//! the entire connector pane (issue #288). Wrapping a subtree in `PaneBoundary`
+//! contains a render panic to that region: siblings keep rendering, and the user
+//! sees a short, readable message plus a Retry affordance instead of a blank pane.
+//!
+//! Scope: this only catches **render-time** panics. `dioxus-liveview`
+//! event-converter panics and event-handler panics run outside the render
+//! `catch_unwind` and abort the process (see #130/#191/#224) — a boundary cannot
+//! help those. Fix known render panics at the source (e.g. #287); this is the
+//! backstop for the unanticipated ones.
+
+use dioxus::prelude::*;
+
+/// Wrap a UI subtree so a render panic inside it degrades to a localized,
+/// readable fallback (with Retry) instead of blanking the whole pane.
+///
+/// `name` is a short human label for the region (e.g. `"sidebar"`,
+/// `"page content"`) used in the fallback message.
+#[component]
+pub fn PaneBoundary(name: String, children: Element) -> Element {
+    rsx! {
+        ErrorBoundary {
+            handle_error: move |errors: ErrorContext| {
+                // Owned label for this render of the fallback.
+                let region = name.clone();
+                rsx! {
+                    div {
+                        class: "pane-boundary-fallback",
+                        role: "alert",
+                        // Inline styles: a render panic may have occurred before this
+                        // region's stylesheet mounted, so don't depend on external CSS.
+                        style: "display:flex;flex-direction:column;gap:0.5rem;align-items:flex-start;\
+                                padding:1rem;margin:0.75rem;border:1px solid var(--color-border,#3a3a3a);\
+                                border-radius:8px;background:var(--color-surface-2,#1e1e1e);\
+                                color:var(--color-text,#e6e6e6);font-size:0.875rem;max-width:32rem;",
+                        span {
+                            style: "font-weight:600;",
+                            "Couldn't load the {region}."
+                        }
+                        span {
+                            style: "opacity:0.8;",
+                            "This section hit an unexpected error. The rest of the connector is still usable."
+                        }
+                        button {
+                            class: "pane-boundary-retry",
+                            style: "align-self:flex-start;padding:0.35rem 0.85rem;border-radius:6px;\
+                                    border:1px solid var(--color-accent,#4f8cff);background:transparent;\
+                                    color:var(--color-accent,#4f8cff);cursor:pointer;font-size:0.8125rem;",
+                            onclick: move |_| errors.clear_errors(),
+                            "Retry"
+                        }
+                    }
+                }
+            },
+            {children}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dioxus::dioxus_core::NoOpMutations;
+
+    // A component whose render panics on demand — stands in for any component
+    // that hits a render-time panic (e.g. the #287 byte-slice) on bad data.
+    #[component]
+    fn Boom(should_panic: bool) -> Element {
+        if should_panic {
+            panic!("boom: induced render panic");
+        }
+        rsx! { div { "boom-ok" } }
+    }
+
+    // Sibling that must survive when a wrapped sibling panics.
+    #[component]
+    fn Sibling() -> Element {
+        rsx! { div { "sibling-alive" } }
+    }
+
+    // The tree under test: one panicking region wrapped in a PaneBoundary,
+    // rendered next to an unwrapped healthy sibling.
+    #[component]
+    fn Harness() -> Element {
+        rsx! {
+            PaneBoundary { name: "sidebar".to_string(),
+                Boom { should_panic: true }
+            }
+            Sibling {}
+        }
+    }
+
+    fn render(app: fn() -> Element) -> String {
+        let mut dom = VirtualDom::new(app);
+        // catch_unwind inside dioxus-core turns the panic into an Element::Err;
+        // rebuild must therefore complete without unwinding out of the VirtualDom.
+        dom.rebuild(&mut NoOpMutations);
+        // The caught panic routes to the boundary via throw_error -> insert_error
+        // -> mark_dirty, which dirties the boundary scope *after* it rendered its
+        // children this pass. The fallback appears on the next render tick — the
+        // same tick the liveview event loop drives in production. Flush it here.
+        dom.render_immediate(&mut NoOpMutations);
+        dioxus_ssr::render(&dom)
+    }
+
+    #[test]
+    fn contains_render_panic_and_keeps_sibling_alive() {
+        let html = render(Harness);
+
+        // The panicking region degraded to the readable fallback naming the
+        // region. (SSR HTML-escapes the apostrophe in "Couldn't", so match on
+        // the region label + the alert role rather than the raw apostrophe.)
+        assert!(
+            html.contains("load the sidebar") && html.contains(r#"role="alert""#),
+            "expected contained fallback, got: {html}"
+        );
+        assert!(
+            html.contains("Retry"),
+            "expected a Retry affordance, got: {html}"
+        );
+        // ...and did NOT surface the raw opaque panic string.
+        assert!(
+            !html.contains("Any {"),
+            "raw panic payload leaked into output: {html}"
+        );
+        // ...while the sibling subtree still rendered.
+        assert!(
+            html.contains("sibling-alive"),
+            "sibling should survive a contained panic, got: {html}"
+        );
+    }
+
+    #[test]
+    fn renders_children_normally_when_no_panic() {
+        #[component]
+        fn Ok() -> Element {
+            rsx! {
+                PaneBoundary { name: "page content".to_string(),
+                    Boom { should_panic: false }
+                }
+            }
+        }
+        let html = render(Ok);
+        assert!(html.contains("boom-ok"), "expected children, got: {html}");
+        assert!(
+            !html.contains("Couldn't load"),
+            "fallback should not show without a panic: {html}"
+        );
+    }
+}

--- a/crates/ui/src/components/pane_boundary.rs
+++ b/crates/ui/src/components/pane_boundary.rs
@@ -12,6 +12,22 @@
 //! `catch_unwind` and abort the process (see #130/#191/#224) — a boundary cannot
 //! help those. Fix known render panics at the source (e.g. #287); this is the
 //! backstop for the unanticipated ones.
+//!
+//! ## Usage
+//!
+//! Wrap any subtree that should degrade gracefully instead of blanking its
+//! pane. Give each region a short `name` shown in the fallback message:
+//!
+//! ```ignore
+//! PaneBoundary { name: "settings".to_string(),
+//!     SettingsPage { /* ... */ }
+//! }
+//! ```
+//!
+//! Prefer one boundary per independently-recoverable region (see `AppLayout`
+//! for the sidebar/content split). Always-mounted background panes (e.g. the
+//! Files/Shell panes in `WorkspaceApp`) should each get their own boundary so a
+//! panic in a hidden pane cannot blank the visible page.
 
 use dioxus::prelude::*;
 

--- a/crates/ui/src/components/sidebar.rs
+++ b/crates/ui/src/components/sidebar.rs
@@ -9,6 +9,7 @@ use super::icons::{
     Bolt, FileText, Folder, House, MessageSquare, ScrollText, Settings, Terminal, Wrench,
     STRIKE48_SIDEBAR_LOGO_SVG, X,
 };
+use crate::text::truncate_chars;
 
 /// Navigation pages.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -200,10 +201,10 @@ pub fn Sidebar(
                                             let cid = conv.id.clone();
                                             let title = if conv.title.is_empty() {
                                                 "Untitled".to_string()
-                                            } else if conv.title.len() > 28 {
-                                                format!("{}...", &conv.title[..25])
                                             } else {
-                                                conv.title.clone()
+                                                // Char-boundary-safe truncation — a byte slice here
+                                                // panics on multi-byte titles and blanks the pane (#287).
+                                                truncate_chars(&conv.title, 25)
                                             };
                                             let time_str = format_relative_time(&conv.updated_at);
                                             rsx! {

--- a/crates/ui/src/components/workspace_app.rs
+++ b/crates/ui/src/components/workspace_app.rs
@@ -20,6 +20,7 @@ use super::keyboard_shortcuts::KeyboardShortcuts;
 use super::licenses_page::LicensesPage;
 use super::log_filter_bar::LogFilterBar;
 use super::matrix_rain::MatrixRainOverlay;
+use super::pane_boundary::PaneBoundary;
 use super::settings_page::SettingsPage;
 use super::shell::InteractiveShell;
 use super::sidebar::NavPage;
@@ -140,27 +141,34 @@ pub fn WorkspacePages(props: WorkspacePagesProps) -> Element {
                 CyberChefPage {}
             }
 
-            // Files — always mounted so directory state is preserved
+            // Files — always mounted so directory state is preserved. Wrapped
+            // in its own boundary because it renders on every page (not just
+            // when active); a panic here must not blank the visible page (#288).
             div {
                 class: if page == NavPage::Files { "workspace-pane" } else { "workspace-pane hidden" },
-                if !workspace.is_empty() {
-                    FileBrowser { workspace_path: workspace.clone() }
-                } else {
-                    div {
-                        class: "empty-state",
-                        "No workspace available"
+                PaneBoundary { name: "files".to_string(),
+                    if !workspace.is_empty() {
+                        FileBrowser { workspace_path: workspace.clone() }
+                    } else {
+                        div {
+                            class: "empty-state",
+                            "No workspace available"
+                        }
                     }
                 }
             }
 
-            // Shell — always mounted for persistent WebSocket
+            // Shell — always mounted for persistent WebSocket. Wrapped for the
+            // same reason as Files: it renders regardless of the active page.
             div {
                 class: if page == NavPage::Shell { "shell-pane-active" } else { "hidden" },
-                InteractiveShell {
-                    shell_mode: match props.shell_mode {
-                        ShellMode::Native => "native".to_string(),
-                        ShellMode::Proot => "proot".to_string(),
-                    },
+                PaneBoundary { name: "shell".to_string(),
+                    InteractiveShell {
+                        shell_mode: match props.shell_mode {
+                            ShellMode::Native => "native".to_string(),
+                            ShellMode::Proot => "proot".to_string(),
+                        },
+                    }
                 }
             }
 

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -14,6 +14,7 @@ mod platform_helper;
 pub mod session;
 #[cfg(feature = "shell-ws")]
 pub mod shell_ws;
+pub mod text;
 pub mod theme;
 pub mod view_transitions;
 

--- a/crates/ui/src/text.rs
+++ b/crates/ui/src/text.rs
@@ -1,0 +1,89 @@
+//! Shared text helpers for UI rendering.
+//!
+//! These run inside Dioxus `rsx!` render bodies, where a panic is caught by the
+//! per-VirtualDom error boundary and blanks the pane (see issues #287/#288).
+//! Anything here must therefore be panic-free on arbitrary backend/user data.
+
+/// Truncate `text` to at most `max_chars` **characters** (not bytes), appending
+/// an ellipsis (`...`) when truncation occurs.
+///
+/// Slicing a `&str` by a byte index (`&s[..n]`) panics if that index is not a
+/// UTF-8 char boundary. Backend-supplied strings (AI-generated conversation
+/// titles, tool arguments) routinely contain multi-byte characters (accents,
+/// emoji, CJK, smart quotes), so any byte-index truncation on that data is a
+/// latent render-panic. This helper counts characters instead, so it is safe
+/// for every possible input.
+///
+/// The returned string is at most `max_chars + 3` characters long (the ellipsis
+/// is appended, matching the previous byte-slice call sites' behavior).
+///
+/// ```
+/// use pentest_ui::text::truncate_chars;
+/// assert_eq!(truncate_chars("hello", 10), "hello");
+/// assert_eq!(truncate_chars("hello world", 5), "hello...");
+/// // A multi-byte char straddling the cutoff does not panic:
+/// assert_eq!(truncate_chars("aaaaé", 4), "aaaa...");
+/// ```
+pub fn truncate_chars(text: &str, max_chars: usize) -> String {
+    // Fast path: count without allocating. `chars().count()` walks the string
+    // once; for the short titles/labels these call sites handle this is cheap.
+    if text.chars().count() <= max_chars {
+        return text.to_string();
+    }
+    let truncated: String = text.chars().take(max_chars).collect();
+    format!("{truncated}...")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn returns_input_unchanged_when_within_limit() {
+        assert_eq!(truncate_chars("hello", 10), "hello");
+        assert_eq!(truncate_chars("", 5), "");
+    }
+
+    #[test]
+    fn returns_input_unchanged_at_exact_limit() {
+        assert_eq!(truncate_chars("hello", 5), "hello");
+    }
+
+    #[test]
+    fn appends_ellipsis_when_over_limit() {
+        assert_eq!(truncate_chars("hello world", 5), "hello...");
+    }
+
+    #[test]
+    fn counts_characters_not_bytes() {
+        // Five 'é' chars = 10 bytes but 5 chars; within a 5-char limit.
+        assert_eq!(truncate_chars("ééééé", 5), "ééééé");
+    }
+
+    #[test]
+    fn does_not_panic_when_multibyte_char_straddles_byte_cutoff() {
+        // This is the exact shape from issue #287: a 2-byte 'é' straddles the
+        // byte-25 cutoff of the old `&title[..25]` slice. Byte-slicing panics
+        // with "byte index 25 is not a char boundary"; truncate_chars must not.
+        let title = format!("{}\u{e9}review of scope", "a".repeat(24));
+        assert!(title.len() > 28, "precondition: title exceeds byte guard");
+
+        // Old code: `&title[..25]` — would panic here. New code must succeed.
+        let out = truncate_chars(&title, 25);
+
+        // 25 chars kept + ellipsis. The 25th char is the 'é'.
+        assert_eq!(out.chars().count(), 25 + "...".chars().count());
+        assert!(out.ends_with("..."));
+        assert!(out.starts_with(&"a".repeat(24)));
+        assert!(out.contains('\u{e9}'));
+    }
+
+    #[test]
+    fn handles_emoji_and_cjk_at_boundary() {
+        // Emoji (4-byte) and CJK (3-byte) straddling the cutoff must not panic.
+        let emoji = format!("{}\u{1f600}tail", "x".repeat(24)); // grinning face
+        let cjk = format!("{}\u{4e2d}\u{6587}tail", "y".repeat(24)); // 中文
+        assert_eq!(truncate_chars(&emoji, 25).chars().count(), 28);
+        assert_eq!(truncate_chars(&cjk, 25).chars().count(), 28);
+    }
+}


### PR DESCRIPTION
Fixes #287 and #288.

## Summary

A customer on Windows (Pick v0.1.8) saw the connector pane replaced by
`Encountered panic: Any { .. }`. Root cause (#287): a byte-slice truncation
of a conversation title (`&conv.title[..25]`) panics when byte 25 is not a
UTF-8 char boundary. AI-generated titles routinely contain multi-byte
characters (accents, emoji, CJK, smart quotes), so the slice panics; dioxus
catches it in the per-VirtualDom render boundary and blanks the whole pane.

This PR fixes the concrete bug (#287) and adds defense-in-depth so the next
unanticipated render panic degrades gracefully instead of blanking the pane
(#288).

### #287 - char-boundary-safe truncation (the cause)
- New `pentest_ui::text::truncate_chars` counts characters, not bytes, and
  appends an ellipsis. Routed through all four UI truncation sites:
  `sidebar.rs`, `chat_panel/{history,agent_selector,render}.rs`.
- Grepped the tree for the whole class and hardened a fifth site,
  `matrix/client.rs::truncate_body` (`&body[..200]` on a hostile GraphQL
  error body), to back off to the nearest char boundary while keeping its
  byte-count report. The grep (`&.*\[\.\..*\]` over UI + core) is exhaustive
  for user/backend strings.

### #288 - `PaneBoundary` containment (the class)
- New `PaneBoundary` (a thin `ErrorBoundary` wrapper) with a readable,
  inline-styled fallback and a Retry button (`clear_errors()`).
- Wraps `Sidebar` and page content independently in `AppLayout`, and the
  always-mounted Files/Shell panes in `WorkspaceApp`, so a render panic in
  one region no longer blanks the others.
- Scope caveat (documented in the module and fallback): this catches
  render-time panics only; dioxus-liveview event-converter/handler panics run
  outside the render `catch_unwind` and abort the process (#130/#191/#224).

## Test plan
- [x] `truncate_chars` unit tests: accent/emoji/CJK straddling the byte
      cutoff, exact-limit, empty input (+ doctest).
- [x] `truncate_body` unit test: a 2-byte char straddling byte 200.
- [x] End-to-end guard on the `render.rs` call site (`webwright_display_name`,
      a pure function): panics today if byte-sliced, asserts char truncation
      now. Mutation-checked - reverting the site to `&t[..57]` turns it red.
- [x] `PaneBoundary` render test: a component that panics on render is
      contained, an unwrapped sibling still renders, and the raw `Any { .. }`
      payload never surfaces. Mutation-checked - neutering the boundary turns
      it red.
- [x] All new tests run in the required CI job (`cargo test --workspace`,
      no `liveview` feature); `dioxus-ssr` added as a dev-dependency for the
      render tests.
- [x] `cargo fmt --all`, `cargo clippy --workspace --all-targets -D warnings`,
      full `cargo test --workspace` - all green.
- [ ] Live verification in the StrikeHub Windows pane with a multi-byte
      conversation title (AC #287.5 - manual/release testing; not run here).

## Notes
- Blast radius traced: inserting `PaneBoundary` between `AppLayout` and its
  children does not break the `ChatHeaderCtx` context path (context resolves
  through the scope chain), the flex layout (`ErrorBoundary` is DOM-
  transparent), or the mobile sidebar drawer.