### PR TITLE
fix(#256): fail closed when an enabled sandbox errors, don't run on host

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -873,6 +873,16 @@ impl AppSettings {
 mod tests {
     use super::*;
 
+    /// Serialises the tenant-env-var tests. These mutate process-global env
+    /// vars (`TENANT_ENV_VARS`), so they must not run concurrently or one
+    /// test's `set_var` leaks into another's view. A SINGLE shared lock is
+    /// required: two separate per-test locks (the previous state) provide no
+    /// mutual exclusion between the tests and let them race — on a busy runner
+    /// `..._prefers_matrix_tenant_id` (which sets MATRIX_TENANT_ID to a UUID)
+    /// could interleave with `..._returns_none_when_only_slugs_present` and
+    /// flip its `got.is_none()` assertion (seen flaking on macOS CI).
+    static TENANT_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn preserves_explicit_wss_with_port() {
         let n = ConnectorConfig::normalize_host("wss://studio.example.com:443").unwrap();
@@ -1018,10 +1028,9 @@ mod tests {
 
     #[test]
     fn tenant_uuid_from_env_prefers_matrix_tenant_id() {
-        // Serialise all tenant-env manipulation on a single lock so parallel
+        // Serialise all tenant-env manipulation on the shared lock so parallel
         // tests can't leak into each other's env-var view.
-        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = TENANT_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
         let previous: Vec<(&str, Option<String>)> = ConnectorConfig::TENANT_ENV_VARS
             .iter()
@@ -1053,8 +1062,7 @@ mod tests {
 
     #[test]
     fn tenant_uuid_from_env_returns_none_when_only_slugs_present() {
-        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-        let _guard = LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = TENANT_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
 
         let previous: Vec<(&str, Option<String>)> = ConnectorConfig::TENANT_ENV_VARS
             .iter()

--- a/crates/platform/src/desktop/command.rs
+++ b/crates/platform/src/desktop/command.rs
@@ -88,12 +88,24 @@ pub async fn execute_command_in_dir(
         full_cmd
     );
 
-    // Try sandboxed execution first
+    // Try sandboxed execution. The sandbox is enabled, so the operator expects
+    // the command to run *inside* it. We fail closed: a sandbox init or execution
+    // error is surfaced to the caller rather than silently retried on the host.
+    // Dropping to the host here would be a fail-open — a command the operator
+    // believed was contained could run against the host with only a `warn!` as
+    // signal (GitHub issue #256). The deliberate host path lives above, behind
+    // the `!is_sandbox_enabled()` check (Native shell mode / DISABLE_SANDBOX).
+    //
+    // Note the executors return `Ok(CommandResult)` even for a nonzero exit or a
+    // timeout (a command that *ran* but failed); `Err(SandboxError)` is reserved
+    // for infrastructure failures (rootfs missing, spawn failure, no backend). So
+    // failing closed here only rejects genuine sandbox breakage, never a
+    // legitimate tool run that exited nonzero.
     tracing::info!(
         "[execute_command] Sandbox enabled, attempting to get sandbox manager for: {}",
         cmd
     );
-    match sandbox::get_sandbox_manager().await {
+    let attempt = match sandbox::get_sandbox_manager().await {
         Ok(manager) => {
             tracing::info!("[execute_command] Sandbox manager obtained, backend={}, is_ready={}, executing: {}",
                 manager.backend(), manager.is_ready(), cmd);
@@ -101,42 +113,77 @@ pub async fn execute_command_in_dir(
                 .execute(&full_cmd, timeout_duration, working_dir)
                 .await
             {
-                Ok(result) => {
-                    tracing::info!("[execute_command] Sandbox execution succeeded for: {}", cmd);
-                    return Ok(result);
-                }
-                Err(e) => {
-                    tracing::warn!("[execute_command] Sandbox execution failed for '{}': {}, falling back to direct", cmd, e);
-                    // Fall through to direct execution as last resort
-                }
+                Ok(result) => SandboxAttempt::Executed(result),
+                Err(e) => SandboxAttempt::ExecFailed(e.to_string()),
             }
         }
-        Err(e) => {
-            tracing::warn!(
-                "[execute_command] Sandbox manager initialization failed for '{}': {}, falling back to direct execution",
-                cmd, e
-            );
-            // Fall through to direct execution
-        }
-    }
+        Err(e) => SandboxAttempt::InitFailed(e.to_string()),
+    };
 
-    // Fallback: direct execution (only if sandbox fails)
-    tracing::warn!(
-        "[execute_command] Using direct host execution fallback for: {}",
-        cmd
-    );
-    execute_command_direct(cmd, args, timeout_duration, working_dir).await
+    resolve_enabled_attempt(cmd, attempt)
 }
 
-/// Direct command execution (used as fallback or for internal operations).
+/// Outcome of a sandboxed execution attempt when the sandbox is enabled.
+enum SandboxAttempt {
+    /// The sandbox ran the command (the `CommandResult` may still carry a
+    /// nonzero exit code or a timeout — that is a *successful* sandbox run).
+    Executed(CommandResult),
+    /// The sandbox manager was obtained but executing the command failed
+    /// (rootfs not set up, backend spawn failure, ...).
+    ExecFailed(String),
+    /// The sandbox manager could not be initialized (no backend available, ...).
+    InitFailed(String),
+}
+
+/// Decide the result of an enabled-sandbox attempt, failing closed.
 ///
-/// This always runs on the **host**, so the Linux-only `which` binary-probe is
+/// A successful sandbox run (even one that exited nonzero) is returned as-is.
+/// An init or execution *failure* is surfaced as an [`Error::ToolExecution`]
+/// rather than falling back to host execution. This is the fail-closed
+/// containment guarantee for issue #256; the corresponding fail-open behavior
+/// used to `warn!` and run `execute_command_direct` on the host.
+fn resolve_enabled_attempt(cmd: &str, attempt: SandboxAttempt) -> Result<CommandResult> {
+    match attempt {
+        SandboxAttempt::Executed(result) => {
+            tracing::info!("[execute_command] Sandbox execution succeeded for: {}", cmd);
+            Ok(result)
+        }
+        SandboxAttempt::ExecFailed(e) => {
+            tracing::error!(
+                "[execute_command] Sandbox execution failed for '{}': {} — failing closed (not running on host)",
+                cmd, e
+            );
+            Err(Error::ToolExecution(format!(
+                "sandbox execution failed for '{cmd}': {e}. Refusing to run on the host; \
+                 switch to Native shell mode (or set DISABLE_SANDBOX=true) to run unsandboxed."
+            )))
+        }
+        SandboxAttempt::InitFailed(e) => {
+            tracing::error!(
+                "[execute_command] Sandbox manager initialization failed for '{}': {} — failing closed (not running on host)",
+                cmd, e
+            );
+            Err(Error::ToolExecution(format!(
+                "sandbox unavailable for '{cmd}': {e}. Refusing to run on the host; \
+                 switch to Native shell mode (or set DISABLE_SANDBOX=true) to run unsandboxed."
+            )))
+        }
+    }
+}
+
+/// Direct command execution on the **host**.
+///
+/// Reached only via the deliberate host path in [`execute_command_in_dir`]:
+/// when the sandbox is disabled (Native shell mode / `DISABLE_SANDBOX=true`).
+/// A sandbox *failure* no longer falls back here — the enabled path fails closed
+/// (see [`resolve_enabled_attempt`] and GitHub issue #256), so this function is
+/// never a silent host escape hatch for an enabled sandbox.
+///
+/// Because it always runs on the host, the Linux-only `which` binary-probe is
 /// rewritten to the host-appropriate command (`where` on Windows) via
 /// [`crate::common::host_which_command`]. The sandbox *success* path does not
 /// come through here — it sends the command into a Linux environment
-/// (WSL2/proot/bwrap) where `which` is correct. A sandbox *failure* does fall
-/// back to this function (see [`execute_command_in_dir`]), but that fallback
-/// executes on the host, so the rewrite is still correct. See GitHub issue #183.
+/// (WSL2/proot/bwrap) where `which` is correct. See GitHub issue #183.
 pub(crate) async fn execute_command_direct(
     cmd: &str,
     args: &[&str],
@@ -219,5 +266,68 @@ mod tests {
         assert_eq!(shell_escape("with'quote"), "'with'\\''quote'");
         assert_eq!(shell_escape("-flag"), "-flag");
         assert_eq!(shell_escape("path/to/file.txt"), "path/to/file.txt");
+    }
+
+    // ── Fail-closed containment (GitHub issue #256) ──────────────────────
+    //
+    // These guard the enabled-sandbox decision: an init or execution failure
+    // must be surfaced to the caller, never silently retried on the host.
+    // Guard check: replacing either error arm below with a host result (the
+    // old fail-open behavior) turns `sandbox_exec_failure_fails_closed` and
+    // `sandbox_init_failure_fails_closed` red.
+
+    #[test]
+    fn sandbox_exec_failure_fails_closed() {
+        let result = resolve_enabled_attempt(
+            "nmap",
+            SandboxAttempt::ExecFailed("rootfs not initialized".to_string()),
+        );
+        let err = result.expect_err("sandbox exec failure must not run on the host");
+        // Fail-closed: surfaced as a tool-execution error, not an Ok result.
+        assert!(matches!(err, Error::ToolExecution(_)));
+        let msg = err.to_string();
+        assert!(
+            msg.contains("nmap") && msg.contains("Refusing to run on the host"),
+            "error should name the command and state host refusal, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn sandbox_init_failure_fails_closed() {
+        let result = resolve_enabled_attempt(
+            "masscan",
+            SandboxAttempt::InitFailed("No sandbox backend available".to_string()),
+        );
+        let err = result.expect_err("sandbox init failure must not run on the host");
+        assert!(matches!(err, Error::ToolExecution(_)));
+        assert!(err.to_string().contains("masscan"));
+    }
+
+    #[test]
+    fn successful_sandbox_run_passes_through() {
+        let cr = CommandResult::success("out".into(), String::new(), 0, 5);
+        let result = resolve_enabled_attempt("id", SandboxAttempt::Executed(cr));
+        let out = result.expect("a successful sandbox run must pass through");
+        assert_eq!(out.exit_code, 0);
+        assert_eq!(out.stdout, "out");
+    }
+
+    #[test]
+    fn nonzero_exit_is_a_successful_run_not_a_sandbox_failure() {
+        // A command that *ran* in the sandbox but exited nonzero (or timed out)
+        // is a successful sandbox run: the executor returns Ok(CommandResult),
+        // so it must pass through unchanged and NOT be treated as a fail-closed
+        // error. This is why the enabled path keys off Err(SandboxError), not
+        // the exit code.
+        let cr = CommandResult::success(String::new(), "boom".into(), 2, 5);
+        let result = resolve_enabled_attempt("false", SandboxAttempt::Executed(cr));
+        let out = result.expect("nonzero-exit run is still a successful sandbox run");
+        assert_eq!(out.exit_code, 2);
+        assert!(!out.timed_out);
+
+        let timed_out = CommandResult::timeout(String::new(), "slow".into(), 100);
+        let result = resolve_enabled_attempt("sleep", SandboxAttempt::Executed(timed_out));
+        let out = result.expect("a sandbox timeout is still a successful sandbox run");
+        assert!(out.timed_out);
     }
 }

--- a/crates/tools/src/execute_command.rs
+++ b/crates/tools/src/execute_command.rs
@@ -272,10 +272,16 @@ mod tests {
     #[tokio::test]
     async fn execute_emits_provenance_structure() {
         // Verifies the provenance contract: structure is always present when
-        // the tool runs, regardless of whether the underlying sandbox lets
-        // the command succeed. Output content is inherently environment-
-        // dependent (sandbox may reject, binary may be absent, etc.), so we
-        // assert on the reproducibility metadata itself, not the payload.
+        // the tool runs. Output content is inherently environment-dependent
+        // (binary may be absent, etc.), so we assert on the reproducibility
+        // metadata itself, not the payload.
+        //
+        // Run host-direct (sandbox disabled): CI has no BlackArch sandbox
+        // backend, and since #256 an enabled-but-unavailable sandbox fails
+        // closed (Err, no provenance) instead of silently falling back to the
+        // host. Disabling the sandbox is the explicit host path these unit
+        // tests want — same precedent as the pentest-core integration tests.
+        pentest_platform::set_use_sandbox(false);
         let tool = ExecuteCommandTool;
         let ctx = ToolContext::default();
         let params = json!({ "command": "echo", "args": ["hello-provenance"] });
@@ -296,6 +302,10 @@ mod tests {
 
     #[tokio::test]
     async fn execute_redacts_secrets_in_effective_command() {
+        // Host-direct: same rationale as execute_emits_provenance_structure —
+        // CI has no sandbox backend, and since #256 that fails closed with no
+        // provenance rather than falling back to the host.
+        pentest_platform::set_use_sandbox(false);
         let tool = ExecuteCommandTool;
         let ctx = ToolContext::default();
         let params = json!({


### PR DESCRIPTION
## Summary

Closes #256.

The non-interactive tool path (`execute_command_in_dir` in
`crates/platform/src/desktop/command.rs`) fell back to running commands
**directly on the host** when the sandbox failed to initialize or execute,
emitting only a `warn!`. For a pentest connector, "run this tool" implicitly
means "run it in the sandbox", so a sandbox failure silently downgrading to
host execution is a **fail-open**: a command the operator believed was
contained could execute against the host with no surfaced signal.

This change makes the enabled-sandbox path **fail closed**.

## What changed

- When the sandbox is *enabled*, a sandbox init or execution failure is now
  returned as `Error::ToolExecution(...)` instead of retried on the host. The
  tool-run wrapper (`crates/core/src/tools.rs`) maps that to
  `ToolOutcome::Failed`, so the operator and the model see an honest failure
  rather than host output posing as a sandboxed result.
- The fail-open/fail-closed decision is extracted into a pure
  `resolve_enabled_attempt(cmd, SandboxAttempt)` function so it is unit-testable
  without global sandbox state.
- Refreshed the stale doc comment on `execute_command_direct`, which claimed a
  sandbox failure falls back to it (no longer true).

## What is deliberately unchanged

- The `!is_sandbox_enabled()` branch (Native shell mode / `DISABLE_SANDBOX=true`)
  still runs on the host. That is the **explicit, logged opt-in** the issue asks
  for. The `pentest-core` integration tests call `set_use_sandbox(false)` and take
  this branch, so they are unaffected (their green CI signal is meaningful, not
  incidental).
- A command that *ran* in the sandbox but exited nonzero or timed out is a
  **successful sandbox run** (the executor returns `Ok(CommandResult)`);
  `Err(SandboxError)` is reserved for infrastructure failures. Failing closed on
  `Err` therefore rejects only genuine sandbox breakage, never a legitimate tool
  run that exited nonzero. Guarded by a regression test.

## Blast radius (consumer trace)

- `crates/tools/src/execute_command.rs` and the network/installer tool wrappers
  all propagate via `.await?`, so a broken sandbox now surfaces as a `Failed`
  tool result instead of host output. Verified `tools.rs` maps closure `Err` ->
  `ToolResult::error` -> `ToolOutcome::Failed`.
- The `which`-probe availability checks (`external/zap.rs`, `external/burp.rs`)
  use `.map(|r| r.exit_code == 0).unwrap_or(false)`. Under this change a broken
  sandbox makes them report "tool not available" -> **fail-safe** (nothing runs
  on the host), and they are pre-existing, not introduced here.
- **Headless connector IS affected, and this is intended.** Headless never calls
  `set_use_sandbox` (only desktop/web/UI wire the toggle) and sets no
  `DISABLE_SANDBOX` in `run-pentest.sh` or the `Dockerfile`, so `USE_SANDBOX`
  keeps its `true` default: headless runs **sandboxed**. The container image is
  `debian:bookworm-slim` as a non-root user with no bwrap/proot bundled, so it
  relies on the proot download (see #252/#286). Previously, if that download
  failed, headless silently ran tools **directly in the container** (the
  fail-open this PR closes); now it fails closed with a surfaced error. A headless
  carve-out would reintroduce the exact fail-open #256 is about, so headless is
  deliberately not exempted.

## Operator-facing behavior change (disclosed)

In a headless container where no sandbox backend is available and the proot
download fails, every tool run now returns a surfaced error instead of silently
executing in-container. This is the intended fail-closed direction, and it lands
alongside the proot-download hardening in #252/#286 that makes that backend
reliable. Operators who deliberately want unsandboxed execution set
`DISABLE_SANDBOX=true` (or Native shell mode), which is untouched.

## Acceptance criteria

- [x] With the sandbox enabled, a sandbox execution/init error does not result in
      silent host execution.
- [x] The failure is surfaced to the caller (returned `Err`), not just
      `warn!`-logged.
- [x] Test coverage for the enabled-sandbox-errors path.

## Test plan

- [x] `cargo test -p pentest-platform --lib desktop::command` (5 pass)
- [x] Mutation guard: neutering an error arm to a host result turns
      `sandbox_exec_failure_fails_closed` red; restored -> green.
- [x] `cargo test -p pentest-platform --lib` (42 pass)
- [x] `cargo test -p pentest-tools -p pentest-core --lib` (308 pass)
- [x] `cargo clippy --package pentest-platform --package pentest-core --lib --features pentest-platform/desktop-pcap --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all`
