### PR TITLE
fix: OS-aware capability guardrails - fail loudly, no silent empties (#197 #198 #202 #208)

### DIFF
--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -380,7 +380,28 @@ impl ToolSchema {
 
     /// Restrict the desktop OSes this tool runs on (e.g. `[DesktopOs::Linux]`
     /// for tools that shell out to Linux-only binaries). See #183.
+    ///
+    /// An empty vec is almost certainly a mistake: `is_supported()` would then
+    /// return false for *every* desktop OS, so the tool is advertised nowhere
+    /// and silently vanishes from the host tool list. (A likely cause is
+    /// reaching for `.os(vec![])` when `.platforms(vec![])` was meant.) We warn
+    /// loudly rather than change the value — the "supported nowhere" footgun in
+    /// #197. Tools that should run everywhere simply omit `.os(...)` and take
+    /// the [`ALL_DESKTOP_OS`] default.
     pub fn os(mut self, os: Vec<DesktopOs>) -> Self {
+        if os.is_empty() {
+            debug_assert!(
+                false,
+                "ToolSchema::os(vec![]) leaves '{}' supported on no desktop OS; \
+                 omit .os(...) for all-OS, or did you mean .platforms(vec![])?",
+                self.name
+            );
+            tracing::warn!(
+                tool = %self.name,
+                "ToolSchema::os(vec![]) sets an empty supported_os: this tool will be \
+                 advertised on NO desktop OS. Omit .os(...) for the all-OS default."
+            );
+        }
         self.supported_os = os;
         self
     }
@@ -835,9 +856,27 @@ impl ToolRegistry {
     pub fn supported_schemas(&self) -> Vec<ToolSchema> {
         self.tools
             .values()
-            .filter(|t| t.is_supported())
+            .filter(|t| self.is_supported_logged(t.as_ref()))
             .map(|t| t.schema())
             .collect()
+    }
+
+    /// `is_supported()` with an observability side-effect: when a tool is
+    /// filtered *out* of the advertised set, emit a `debug` line naming the
+    /// tool and the host platform/OS. Per the epic's "fail loudly, no silent
+    /// empties" principle (#198), an operator debugging a missing capability can
+    /// then see *why* it was excluded instead of it silently disappearing.
+    fn is_supported_logged(&self, tool: &dyn PentestTool) -> bool {
+        let supported = tool.is_supported();
+        if !supported {
+            tracing::debug!(
+                tool = %tool.name(),
+                platform = ?Platform::current(),
+                desktop_os = ?DesktopOs::current(),
+                "tool filtered from advertised set (unsupported on this host)"
+            );
+        }
+        supported
     }
 
     /// Get tool names
@@ -850,7 +889,7 @@ impl ToolRegistry {
     pub fn supported_names(&self) -> Vec<&str> {
         self.tools
             .values()
-            .filter(|t| t.is_supported())
+            .filter(|t| self.is_supported_logged(t.as_ref()))
             .map(|t| t.name())
             .collect()
     }
@@ -863,6 +902,26 @@ impl ToolRegistry {
         ctx: &ToolContext,
     ) -> Result<ToolResult> {
         match self.get(name) {
+            Some(tool) if !tool.is_supported() => {
+                // The tool is registered but not supported on this host's OS
+                // (tools are registered unconditionally; the OS gate is at
+                // advertise/execute time — see #183). Without this arm, an
+                // OS-incompatible tool would run and fail cryptically deep in
+                // its own logic. Fail early with a message that says *why*
+                // (required OS vs current OS), not a generic "not found" (#208).
+                let required = tool.supported_os();
+                let current = DesktopOs::current();
+                tracing::error!(
+                    tool = %name,
+                    ?required,
+                    ?current,
+                    "tool exists but is not supported on this OS"
+                );
+                Err(crate::error::Error::PlatformNotSupported(format!(
+                    "Tool '{name}' exists but is not supported on this OS \
+                     (required: {required:?}, current: {current:?})"
+                )))
+            }
             Some(tool) => tool.execute(params, ctx).await,
             None => {
                 // Find similar tool names for suggestions
@@ -1357,6 +1416,90 @@ mod os_capability_tests {
         assert_eq!(tool.supported_os(), vec![DesktopOs::Linux]);
         let expect_supported = matches!(DesktopOs::current(), Some(DesktopOs::Linux) | None);
         assert_eq!(tool.is_supported(), expect_supported);
+    }
+
+    /// A registered tool supported on no desktop OS a CI runner ever reports
+    /// (`Other` = BSD/unknown; Linux/macOS/Windows all map to their own
+    /// variant). Lets us exercise the unsupported-on-this-OS execute path
+    /// deterministically on Linux, macOS, and Windows CI alike.
+    struct NowhereTool;
+    #[async_trait]
+    impl PentestTool for NowhereTool {
+        fn name(&self) -> &str {
+            "nowhere"
+        }
+        fn description(&self) -> &str {
+            "supported only on DesktopOs::Other"
+        }
+        fn supported_os(&self) -> Vec<DesktopOs> {
+            vec![DesktopOs::Other]
+        }
+        async fn execute(&self, _params: Value, _ctx: &ToolContext) -> Result<ToolResult> {
+            // Must NOT be reached on a Linux/macOS/Windows host: the registry
+            // gate should reject before dispatch. Panics prove the gate ran.
+            panic!("execute() must not run for an OS-unsupported tool");
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_rejects_os_unsupported_tool_with_clear_error() {
+        // #208: a registered-but-unsupported tool must fail early with a
+        // PlatformNotSupported error that names the required + current OS,
+        // NOT run its body and NOT return a generic "not found".
+        // (Skip on an exotic Other host, where `nowhere` would be supported.)
+        if matches!(DesktopOs::current(), Some(DesktopOs::Other)) {
+            return;
+        }
+        let mut registry = ToolRegistry::new();
+        registry.register(NowhereTool);
+
+        let err = registry
+            .execute("nowhere", Value::Null, &ToolContext::default())
+            .await
+            .expect_err("OS-unsupported tool must not execute");
+
+        match err {
+            crate::error::Error::PlatformNotSupported(msg) => {
+                assert!(
+                    msg.contains("nowhere") && msg.contains("not supported on this OS"),
+                    "message should explain the OS incompatibility, got: {msg}"
+                );
+            }
+            other => panic!("expected PlatformNotSupported, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_unknown_tool_still_reports_not_found() {
+        // Guard the discriminator: a genuinely absent tool must remain a
+        // ToolNotFound, not get reclassified as an OS problem (#208).
+        let registry = ToolRegistry::new();
+        let err = registry
+            .execute("does_not_exist", Value::Null, &ToolContext::default())
+            .await
+            .expect_err("unknown tool must error");
+        assert!(
+            matches!(err, crate::error::Error::ToolNotFound(_)),
+            "unknown tool should be ToolNotFound, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn empty_supported_os_is_advertised_nowhere() {
+        // #197: an empty supported_os is the "supported nowhere" footgun. The
+        // builder warns (and debug_asserts), but the resulting schema must at
+        // least be observably unsupported so it can't masquerade as all-OS.
+        // Build the schema directly to bypass the debug_assert in `.os()` (which
+        // would panic this test in debug builds) while still asserting the
+        // is_supported() consequence the guard is protecting against.
+        let schema = ToolSchema {
+            supported_os: Vec::new(),
+            ..ToolSchema::new("empty_os", "no OS")
+        };
+        assert!(
+            !schema.is_supported(),
+            "empty supported_os must be supported on no desktop OS"
+        );
     }
 
     #[test]

--- a/crates/platform/src/desktop/network.rs
+++ b/crates/platform/src/desktop/network.rs
@@ -215,8 +215,14 @@ pub async fn mdns_discover(service_type: &str, timeout_ms: u64) -> Result<Vec<Md
 
     #[cfg(not(feature = "mdns-sd"))]
     {
-        tracing::warn!("mDNS discovery requires the 'desktop-mdns' feature");
-        Ok(Vec::new())
+        // Match the sibling ssdp_discover compiled-out arm: a silent empty Vec
+        // reads as "no services found", masking that discovery never ran. Fail
+        // loudly with a typed error instead (#202).
+        Err(Error::PlatformNotSupported(
+            "mDNS discovery requires the 'mdns-sd' feature (enabled by the default \
+             'desktop' feature)"
+                .into(),
+        ))
     }
 }
 

--- a/crates/platform/src/desktop/system.rs
+++ b/crates/platform/src/desktop/system.rs
@@ -143,7 +143,17 @@ async fn get_network_interfaces_fallback() -> Result<Vec<NetworkInterface>> {
 
     #[cfg(not(target_os = "linux"))]
     {
-        Ok(Vec::new())
+        // Reachable only in a misconfigured build: the default `desktop` feature
+        // ships the cross-platform `network-interface` impl. Returning an empty
+        // Vec here is a silent lie — an empty interface list flows into
+        // check_wifi_connection_status -> total_adapters=0 -> safe_to_scan=true,
+        // a wrong "not on WiFi" negative the agent trusts. Fail loudly instead,
+        // mirroring ssdp_discover's compiled-out arm (#202).
+        Err(Error::PlatformNotSupported(
+            "network interface enumeration on non-Linux requires the 'network-interface' \
+             feature (enabled by the default 'desktop' feature)"
+                .into(),
+        ))
     }
 }
 

--- a/crates/tools/src/autopwn/toolchain/engine.rs
+++ b/crates/tools/src/autopwn/toolchain/engine.rs
@@ -235,8 +235,18 @@ impl ToolchainEngine {
         let start = Instant::now();
 
         match self.registry.get(&step.tool) {
-            Some(tool) => {
-                match tool.execute(params, &self.context).await {
+            Some(_) => {
+                // Dispatch through registry.execute() rather than calling
+                // tool.execute() directly, so an OS-incompatible tool hits the
+                // #208 PlatformNotSupported guard and fails loudly (flowing into
+                // the alternatives path below) instead of running and failing
+                // cryptically deep in its own body. The tool is known-present
+                // (we matched Some), so this never takes execute()'s None arm.
+                match self
+                    .registry
+                    .execute(&step.tool, params, &self.context)
+                    .await
+                {
                     Ok(result) => {
                         let duration_ms = start.elapsed().as_millis() as u64;
                         execution.complete(result.data.clone(), duration_ms);


### PR DESCRIPTION
## Summary

Four follow-ups from the #196 review (epic #183, Child A: OS-aware capability gating). All apply the epic's "fail loudly, no silent empties" principle. Closes #197, #198, #202, #208.

### #197 - empty `supported_os` footgun
`ToolSchema::os(vec![])` compiles and leaves a tool supported on *no* desktop OS (`is_supported()` false for every OS), so it silently vanishes from the advertised set - the likely cause being `.os(vec![])` where `.platforms(vec![])` was meant. The builder now `debug_assert!`s and `tracing::warn!`s on an empty vec (value left unchanged for back-compat). Test locks in that an empty `supported_os` is observably unsupported.

### #198 - observable filtering
`supported_schemas()`/`supported_names()` filtered unsupported tools out silently. New shared `is_supported_logged()` helper emits a `tracing::debug!` (tool name, `Platform::current()`, `DesktopOs::current()`) when a tool is excluded. No change to the advertised set itself.

### #208 - clear OS-incompatibility error (corrects the issue's suggested fix)
Tools are registered **unconditionally**, so on an unsupported host `get()` returns `Some` and `execute()` ran the tool anyway, failing cryptically deep in its body. The issue proposed a fix in the `None` arm, but that's **dead code** - `contains_key` is false exactly when `get()` returned `None`. The real fix is a `Some(tool) if !is_supported()` guard that returns `Error::PlatformNotSupported` naming the required + current OS *before* dispatch. A genuinely-absent tool still returns `ToolNotFound` (guarded by a separate test).

### #202 - typed errors for compiled-out fallbacks
Two feature-gated fallbacks returned `Ok(Vec::new())` - a silent lie:
- `get_network_interfaces` (non-Linux, `network-interface` off) fed an empty list into `check_wifi_connection_status` -> `total_adapters=0` -> `safe_to_scan=true` (a wrong "not on WiFi" negative the agent trusts).
- `mdns_discover` (`mdns-sd` off) read as "no services found."

Both now return `Error::PlatformNotSupported`, matching the sibling `ssdp_discover`. Shipping behavior is unchanged: the default `desktop` feature ships the real cross-platform impls. Note that both fallback arms are currently **unreachable in any buildable configuration** - `pub mod desktop` is `#[cfg(feature = "desktop")]`, and the `desktop` feature force-enables `network-interface` and `mdns-sd` (via `desktop-mdns`), so the arm needs the feature OFF while its module needs it ON. The change is directionally correct (matches `ssdp_discover`) and kept for a future feature-split, but it is dead code today, not exercised by any build.

## Test plan

- [x] 3 new `pentest-core` tests: execute rejects OS-unsupported tool with a clear error; unknown tool still `ToolNotFound`; empty `supported_os` unsupported
- [x] Mutation-verified per Lens 1: disabling the #208 gate makes the unsupported tool's `execute()` body panic fire (test goes RED); restoring is GREEN
- [x] `cargo test -p pentest-core -p pentest-platform --lib` - 271 + 45 passed
- [x] `cargo clippy -p pentest-core -p pentest-platform --all-targets -- -D warnings` - clean
- [x] `cargo fmt` - clean
- [x] Autopwn dispatch (`autopwn/toolchain/engine.rs`) now routes through `registry.execute()` so an OS-gated chain step (e.g. Linux-only `AutoPwnCrackTool` on macOS/Windows) hits the #208 guard instead of failing deep in the tool body; consumes the already-tested `execute()` path.
- [ ] The #202 fallback arms could not be compiled: as noted above, neither `#[cfg(not(feature = "mdns-sd"))]` (network.rs) nor `#[cfg(not(target_os = "linux"))]` (system.rs) is reachable in any feature configuration the workspace can build (the `desktop` module force-enables the features they gate off). Verified by reading + poison-token probe, not by compiling.

## Reviewer notes (honest scope)

- Both #202 arms are unreachable in any buildable feature config (see the #202 section): the `desktop` module gate force-enables the very features (`mdns-sd`, `network-interface`) the fallback arms require to be OFF. They are directionally-correct dead code matching `ssdp_discover`, verified by reading and a poison-token compile probe (an injected token in each arm never triggered a compile error under `desktop-pcap` or `--no-default-features`, while poisoning the compiled `mdns-sd`-ON arm did). Not verified by executing.
- #197's test constructs the schema via struct literal to bypass the new `debug_assert!` in `.os()` (which would otherwise panic the test in debug builds) while still asserting the `is_supported()` consequence.
