### PR TITLE
fix(safety_check): derive sweep subnet from real netmask, not hardcoded /24 (#182)

### DIFF
--- a/crates/tools/src/safety_check/network_map.rs
+++ b/crates/tools/src/safety_check/network_map.rs
@@ -5,7 +5,7 @@ use super::types::{Device, NetworkMap, ThreatLevel};
 use anyhow::Context;
 use pentest_platform::NetworkOps;
 use std::collections::HashMap;
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv4Addr};
 use std::process::Stdio;
 use tokio::process::Command;
 
@@ -16,6 +16,16 @@ use tokio::process::Command;
 /// box). Kept conservative to avoid alarming a non-technical user over a
 /// normal NAS or printer.
 const SUSPICIOUS_PORT_THRESHOLD: usize = 10;
+
+/// Narrowest (largest) prefix we will ever widen a discovery sweep to.
+///
+/// The interface may legitimately report a very wide prefix (e.g. /8 on some
+/// VPN or container setups). Sweeping a /8 is 16M addresses - a netmask fix
+/// (#182) must never silently turn into "scan the whole /8". When the real
+/// prefix is wider than this, we clamp the sweep subnet to `/16` (still large,
+/// but bounded) and log the clamp so the narrowing is observable. The full
+/// host-count bounding for sizing lives in `cap_for_network_size` (mod.rs).
+const MIN_SUBNET_PREFIX: u8 = 16;
 
 /// Enrichment data for a single host, keyed by IP, drawn from the ARP table.
 struct ArpInfo {
@@ -39,7 +49,7 @@ pub async fn discover_network() -> anyhow::Result<NetworkMap> {
 
     // Get gateway and local IP
     let gateway_info = get_gateway_and_local_ip().await?;
-    let (gateway_ip, local_ip) = gateway_info;
+    let (gateway_ip, local_ip, local_prefix) = gateway_info;
 
     tracing::info!("Discovered: gateway={}, local={}", gateway_ip, local_ip);
 
@@ -52,7 +62,7 @@ pub async fn discover_network() -> anyhow::Result<NetworkMap> {
     // Discovery source 1: an nmap ping sweep of the local /24. Fast and finds
     // hosts we have not yet talked to. Best-effort - on a larger network this
     // only covers our own /24, which is why we also merge the ARP table.
-    let subnet = determine_subnet(&local_ip)?;
+    let subnet = determine_subnet(&local_ip, local_prefix)?;
     let nmap_ips = match run_nmap_arp_scan(&subnet).await {
         Ok(ips) => {
             tracing::info!("nmap discovered {} hosts in {}", ips.len(), subnet);
@@ -172,8 +182,14 @@ async fn collect_arp_info() -> HashMap<IpAddr, ArpInfo> {
     map
 }
 
-/// Get gateway and local IP address.
-async fn get_gateway_and_local_ip() -> anyhow::Result<(IpAddr, IpAddr)> {
+/// Get gateway and local IP address, plus the local IPv4 prefix length.
+///
+/// The prefix comes from `default_net`'s `Ipv4Net` (which carries `prefix_len`
+/// / `netmask` alongside the address); it is threaded out here so the sweep
+/// subnet reflects the real netmask instead of an assumed /24 (#182). `None`
+/// when there is no IPv4 (should not happen given the `.context` below, but the
+/// type keeps the IPv6-only future honest).
+async fn get_gateway_and_local_ip() -> anyhow::Result<(IpAddr, IpAddr, Option<u8>)> {
     let interface = tokio::task::spawn_blocking(default_net::get_default_interface)
         .await
         .context("Failed to spawn interface detection task")?
@@ -184,29 +200,62 @@ async fn get_gateway_and_local_ip() -> anyhow::Result<(IpAddr, IpAddr)> {
         .context("No gateway found on default interface")?;
     let gateway_ip = gateway.ip_addr;
 
-    let local_ip = interface
+    let local_net = interface
         .ipv4
         .first()
-        .map(|net| IpAddr::V4(net.addr))
         .context("No IPv4 address on default interface")?;
+    let local_ip = IpAddr::V4(local_net.addr);
+    let prefix_len = Some(local_net.prefix_len);
 
-    Ok((gateway_ip, local_ip))
+    Ok((gateway_ip, local_ip, prefix_len))
 }
 
-/// Determine the subnet CIDR notation from a local IP.
+/// Determine the subnet CIDR notation from a local IP and its prefix length.
 ///
-/// Assumes /24 subnet for simplicity. In production, we'd use the netmask
-/// from the interface.
-fn determine_subnet(local_ip: &IpAddr) -> anyhow::Result<String> {
+/// Uses the interface's real prefix instead of assuming /24 (#182). The network
+/// base address is computed by applying the netmask (`addr & mask`), so a /25
+/// host `.130` yields `.128/25`, not `.0/24`. A missing prefix (e.g. a future
+/// IPv6-only path) falls back to /24 for IPv4 to preserve prior behavior.
+///
+/// Safety cap: a prefix wider than [`MIN_SUBNET_PREFIX`] is clamped up to it, so
+/// the discovery sweep is never silently widened to a /8-scale range.
+fn determine_subnet(local_ip: &IpAddr, prefix_len: Option<u8>) -> anyhow::Result<String> {
     match local_ip {
-        IpAddr::V4(ipv4) => {
-            let octets = ipv4.octets();
-            Ok(format!("{}.{}.{}.0/24", octets[0], octets[1], octets[2]))
-        }
+        IpAddr::V4(ipv4) => Ok(subnet_cidr_v4(*ipv4, prefix_len.unwrap_or(24))),
         IpAddr::V6(_) => {
             anyhow::bail!("IPv6 subnets not yet supported");
         }
     }
+}
+
+/// Pure helper: compute the sweep-subnet CIDR for an IPv4 host + prefix.
+///
+/// * Clamps a `0` prefix and anything wider than [`MIN_SUBNET_PREFIX`] to the
+///   cap (and clamps a nonsensical `>32` to `32`), logging when it narrows a
+///   real sweep, so a wide interface prefix can't become an implicit huge scan.
+/// * Computes the network base via the netmask, not by zeroing octets.
+///
+/// Kept free of any interface/I/O so the subnet math is unit-testable.
+fn subnet_cidr_v4(addr: Ipv4Addr, prefix_len: u8) -> String {
+    let effective = if prefix_len == 0 || prefix_len < MIN_SUBNET_PREFIX {
+        tracing::info!(
+            "Interface prefix /{} is wider than the /{} sweep cap; clamping discovery \
+             subnet to /{} to avoid an oversized scan",
+            prefix_len,
+            MIN_SUBNET_PREFIX,
+            MIN_SUBNET_PREFIX
+        );
+        MIN_SUBNET_PREFIX
+    } else {
+        prefix_len.min(32)
+    };
+
+    // Netmask for the effective prefix. `effective` is in 16..=32 here, so the
+    // shift is well-defined (a /0 would need the all-zero mask special-case,
+    // but the clamp above guarantees effective >= 16).
+    let mask: u32 = u32::MAX << (32 - effective as u32);
+    let network = u32::from(addr) & mask;
+    format!("{}/{}", Ipv4Addr::from(network), effective)
 }
 
 /// Run nmap ARP scan to discover hosts on the subnet.
@@ -275,9 +324,87 @@ mod tests {
 
     #[test]
     fn test_determine_subnet() {
+        // A /24 host still derives the /24 network (backward-compat).
         let ip = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 100));
-        let subnet = determine_subnet(&ip).unwrap();
+        let subnet = determine_subnet(&ip, Some(24)).unwrap();
         assert_eq!(subnet, "192.168.1.0/24");
+    }
+
+    #[test]
+    fn test_determine_subnet_no_prefix_defaults_to_24() {
+        // A missing prefix falls back to /24, preserving the old behavior.
+        let ip = IpAddr::V4(Ipv4Addr::new(10, 20, 30, 40));
+        assert_eq!(determine_subnet(&ip, None).unwrap(), "10.20.30.0/24");
+    }
+
+    #[test]
+    fn test_determine_subnet_ipv6_is_explicitly_unsupported() {
+        let ip: IpAddr = "fe80::1".parse().unwrap();
+        assert!(determine_subnet(&ip, Some(64)).is_err());
+    }
+
+    #[test]
+    fn derives_subnet_from_real_prefix_not_assumed_24() {
+        // #182: the derived subnet must reflect the real prefix, not /24.
+        assert_eq!(
+            subnet_cidr_v4(Ipv4Addr::new(172, 16, 5, 9), 23),
+            "172.16.4.0/23"
+        );
+        assert_eq!(
+            subnet_cidr_v4(Ipv4Addr::new(192, 168, 1, 130), 25),
+            "192.168.1.128/25"
+        );
+    }
+
+    #[test]
+    fn computes_network_address_via_netmask_not_by_zeroing_octet() {
+        // /25 of .130 -> .128 (bit 7 of the last octet is part of the network),
+        // NOT .0 as a "zero the last octet" shortcut would give.
+        assert_eq!(
+            subnet_cidr_v4(Ipv4Addr::new(192, 168, 1, 130), 25),
+            "192.168.1.128/25"
+        );
+        // /26 of .200 -> .192.
+        assert_eq!(
+            subnet_cidr_v4(Ipv4Addr::new(10, 0, 0, 200), 26),
+            "10.0.0.192/26"
+        );
+        // /30 of .6 -> .4.
+        assert_eq!(
+            subnet_cidr_v4(Ipv4Addr::new(10, 0, 0, 6), 30),
+            "10.0.0.4/30"
+        );
+    }
+
+    #[test]
+    fn exact_host_prefix_32_is_single_address() {
+        assert_eq!(
+            subnet_cidr_v4(Ipv4Addr::new(203, 0, 113, 7), 32),
+            "203.0.113.7/32"
+        );
+    }
+
+    #[test]
+    fn very_wide_prefix_is_capped_not_silently_swept() {
+        // #182 safety cap: a prefix wider than /16 must clamp to /16, never
+        // expand the sweep to a /8-scale range. The network base is recomputed
+        // at the clamped prefix.
+        assert_eq!(subnet_cidr_v4(Ipv4Addr::new(10, 1, 2, 3), 8), "10.1.0.0/16");
+        assert_eq!(
+            subnet_cidr_v4(Ipv4Addr::new(172, 20, 30, 40), 12),
+            "172.20.0.0/16"
+        );
+        // A degenerate /0 also clamps to /16 (guards the shift, too).
+        assert_eq!(subnet_cidr_v4(Ipv4Addr::new(10, 1, 2, 3), 0), "10.1.0.0/16");
+    }
+
+    #[test]
+    fn exactly_16_is_not_clamped() {
+        // Boundary: /16 is the cap itself, so it passes through unchanged.
+        assert_eq!(
+            subnet_cidr_v4(Ipv4Addr::new(10, 1, 2, 3), 16),
+            "10.1.0.0/16"
+        );
     }
 
     #[test]

--- a/crates/tools/src/safety_check/network_map.rs
+++ b/crates/tools/src/safety_check/network_map.rs
@@ -35,8 +35,9 @@ struct ArpInfo {
 
 /// Discover devices on the local network and enrich them.
 ///
-/// Merges two host sources: an nmap `-sn` ping sweep of the local /24 (fast,
-/// finds hosts not yet contacted) and the system ARP/neighbor table (instant,
+/// Merges two host sources: an nmap `-sn` ping sweep of the local subnet
+/// (derived from the interface netmask, capped at /16 - fast, finds hosts not
+/// yet contacted) and the system ARP/neighbor table (instant,
 /// cross-subnet, carries MACs). Each host is then enriched with MAC address and
 /// hostname from the ARP table and a vendor name via OUI lookup. nmap is
 /// best-effort - if it is unavailable, the ARP table alone is used.
@@ -59,9 +60,11 @@ pub async fn discover_network() -> anyhow::Result<NetworkMap> {
     // MACs. A failure here just yields a less-detailed map, never a failure.
     let arp_info = collect_arp_info().await;
 
-    // Discovery source 1: an nmap ping sweep of the local /24. Fast and finds
-    // hosts we have not yet talked to. Best-effort - on a larger network this
-    // only covers our own /24, which is why we also merge the ARP table.
+    // Discovery source 1: an nmap ping sweep of the local subnet, derived from
+    // the interface netmask (capped at /16). Fast and finds hosts we have not
+    // yet talked to. Best-effort - on a wider network the /16 cap means the
+    // sweep may not cover the whole segment, which is why we also merge the
+    // ARP table.
     let subnet = determine_subnet(&local_ip, local_prefix)?;
     let nmap_ips = match run_nmap_arp_scan(&subnet).await {
         Ok(ips) => {
@@ -231,8 +234,9 @@ fn determine_subnet(local_ip: &IpAddr, prefix_len: Option<u8>) -> anyhow::Result
 /// Pure helper: compute the sweep-subnet CIDR for an IPv4 host + prefix.
 ///
 /// * Clamps a `0` prefix and anything wider than [`MIN_SUBNET_PREFIX`] to the
-///   cap (and clamps a nonsensical `>32` to `32`), logging when it narrows a
-///   real sweep, so a wide interface prefix can't become an implicit huge scan.
+///   cap - logging the narrowing - so a wide interface prefix can't become an
+///   implicit huge scan. A nonsensical `>32` is defensively clamped to `32`
+///   (unreachable from a real `Ipv4Net`, so it is not logged).
 /// * Computes the network base via the netmask, not by zeroing octets.
 ///
 /// Kept free of any interface/I/O so the subnet math is unit-testable.


### PR DESCRIPTION
## Summary

Closes #182. `determine_subnet` always returned `<a>.<b>.<c>.0/24` regardless of the interface's actual prefix, corrupting network discovery and the host-count/size signal (#181 consumer).

- On a wider net (e.g. /16), discovery swept only 1/256th of the real subnet.
- On a narrower net (e.g. /25), the assumed /24 spanned two real segments, potentially probing addresses outside the agent's own subnet.

## Root cause

The real prefix was already fetched but thrown away: `interface.ipv4.first()` yields a `default_net` `Ipv4Net` that carries `prefix_len` / `netmask`, but `get_gateway_and_local_ip` mapped it straight to a bare `IpAddr` (`net.addr`), dropping the prefix before `determine_subnet` ever saw it.

## Fix

- Thread the local IPv4 `prefix_len` out of `get_gateway_and_local_ip`.
- New pure `subnet_cidr_v4(addr, prefix)` computes the network base **via the netmask** (`addr & mask`), so `/25` of `.130` -> `.128/25`, not `.0/24`.
- **Wide-prefix safety cap:** a prefix wider than `/16` (`MIN_SUBNET_PREFIX`), or a degenerate `/0`, is clamped to `/16` and logged - a netmask fix must never silently widen a sweep to a `/8`-scale range. Host-count bounding for sizing still lives in `cap_for_network_size`.
- Missing prefix falls back to `/24` (prior behavior preserved); IPv6 keeps its explicit "not yet supported" bail rather than a silently-wrong assumption.

## Test plan (all AC covered)

- [x] Derivation for /16, /23, /24, /25, /26, /30, /32
- [x] Network address computed via netmask, not octet-zeroing (`.130 /25 -> .128`)
- [x] Very-wide prefix capped: /8 and /12 -> /16; /0 -> /16; /16 boundary unchanged
- [x] IPv6 explicitly unsupported; no-prefix falls back to /24
- [x] Mutation-verified per Lens 1: removing the cap fails the cap test; reverting to octet-zeroing fails 5 netmask-math tests
- [x] `cargo test -p pentest-tools --lib safety_check` - 40 passed
- [x] `cargo clippy -p pentest-tools --all-targets -- -D warnings` - clean
- [x] `cargo fmt` - clean

## Note

`subnet_cidr_v4` is a pure function (no interface/I/O), so the subnet math is fully unit-tested without touching real network state. Unblocks #181 (network-size detection), which depends on an accurate subnet.