### PR TITLE
feat(health): report real connector transport/heartbeat state on /hea…

### DIFF
--- a/crates/ui/src/liveview_connector/api_routes.rs
+++ b/crates/ui/src/liveview_connector/api_routes.rs
@@ -75,7 +75,9 @@ use pentest_core::aggression::AggressionLevel;
 use pentest_core::config::ConnectorConfig;
 use pentest_core::matrix::MatrixChatClient;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::sync::Arc;
+use strike48_connector::ConnectorRunner;
 use tokio::sync::RwLock;
 
 use super::ScanState;
@@ -86,6 +88,21 @@ pub struct ApiState {
     pub scan_state: Arc<RwLock<Option<ScanState>>>,
     pub config: Arc<RwLock<ConnectorConfig>>,
     pub matrix_client: Arc<RwLock<Option<MatrixChatClient>>>,
+}
+
+/// State for the unauthenticated `/health` route.
+///
+/// Deliberately separate from [`ApiState`] and its Bearer-token `auth_middleware`:
+/// a health/readiness probe must be reachable without credentials, and this state
+/// carries no secrets — only the shared handle to the SDK connector runner, whose
+/// `get_stats()` snapshot is the source of transport/heartbeat truth.
+///
+/// The runner is created later (inside `LiveViewConnector::connect_and_run`), so the
+/// `Option` is `None` from server start until the connection loop populates the SAME
+/// `Arc` this state holds — the pre-connect window reports `status: "starting"`.
+#[derive(Clone)]
+pub struct HealthState {
+    pub runner: Arc<RwLock<Option<Arc<ConnectorRunner>>>>,
 }
 
 /// Request body for aggression level adjustment
@@ -236,6 +253,150 @@ async fn get_status(
 ) -> Result<Json<Option<ScanState>>, ErrorResponse> {
     let scan_guard = state.scan_state.read().await;
     Ok(Json(scan_guard.clone()))
+}
+
+/// Classify connector health from a `ConnectorRunner::get_stats()` snapshot.
+///
+/// Pure and side-effect-free so it is unit-testable without constructing a real
+/// runner: the handler does the impure work (locking the runner Arc, awaiting
+/// `get_stats()`, reading session globals) and hands the resulting `Value` here.
+///
+/// `stats == None` means the runner has not been created yet (the window between
+/// the LiveView server starting and `connect_and_run` populating the shared Arc).
+///
+/// Returns the HTTP status the probe should see plus the JSON body. Only a
+/// currently-live transport is `200`; every not-ready state is `503` so a
+/// `curl -f` / readiness probe treats the connector as unavailable.
+///
+/// # Boundary (see pick#295)
+/// This reflects TRANSPORT + heartbeat state only — `get_stats()` does not expose
+/// registration/approval/JWT-session state (private SDK fields, no accessor in
+/// strike48-connector 0.4.4), so `/health` cannot distinguish "approved but idle"
+/// from "pending approval" or a "post-approval JWT wedge". A future revision can,
+/// once the SDK exposes those (tracked as an sdk-rs follow-up, relates to sdk-rs#59);
+/// until then the Studio Gateways UI / connector registry remain the source of
+/// truth for approval state.
+fn classify_health(
+    stats: Option<&Value>,
+    tools_loaded: usize,
+    tenant: &str,
+    connector: &str,
+) -> (StatusCode, Value) {
+    // Identity + local tool count are always available (set at connector
+    // construction, before the server starts). tools_loaded reflects tools LOADED
+    // into the local registry, NOT tools registered with the server.
+    let base = |status: &str, transport_up: bool, stats: Option<&Value>| {
+        let get_u64 = |k: &str| stats.and_then(|s| s.get(k)).and_then(Value::as_u64);
+        let get_f64 = |k: &str| stats.and_then(|s| s.get(k)).and_then(Value::as_f64);
+        serde_json::json!({
+            "status": status,
+            "grpc_transport": if transport_up { "up" } else { "down" },
+            // Match the classifier's notion of "connected" exactly: it keys on
+            // `as_u64()`, so a present-but-non-u64 value must NOT read as
+            // ever_connected here (else the body could say ever_connected:true
+            // while status is "connecting"/503 — a self-contradictory payload).
+            "ever_connected": get_u64("last_connected_at_ms").is_some(),
+            "running": stats
+                .and_then(|s| s.get("running"))
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            "last_disconnect_reason": stats
+                .and_then(|s| s.get("last_disconnect_reason"))
+                .cloned()
+                .unwrap_or(Value::Null),
+            "reconnection_attempts": get_u64("reconnection_attempts").unwrap_or(0),
+            "total_disconnects": get_u64("total_disconnects").unwrap_or(0),
+            "heartbeat_rtt_last_ms": get_f64("heartbeat_rtt_last_ms")
+                .map(|v| serde_json::json!(v))
+                .unwrap_or(Value::Null),
+            "uptime_seconds": get_u64("uptime_seconds").unwrap_or(0),
+            "tools_loaded": tools_loaded,
+            "tenant": tenant,
+            "connector": connector,
+        })
+    };
+
+    // Runner not yet created — server is up but the connection loop hasn't started.
+    let Some(stats) = stats else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            base("starting", false, None),
+        );
+    };
+
+    let running = stats
+        .get("running")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    if !running {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            base("stopped", false, Some(stats)),
+        );
+    }
+
+    let last_connected = stats.get("last_connected_at_ms").and_then(Value::as_u64);
+    let Some(connected_at) = last_connected else {
+        // running but never established a transport (DNS/TLS/connect failing).
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            base("connecting", false, Some(stats)),
+        );
+    };
+
+    // A disconnect timestamp NEWER than the last connect means we dropped and have
+    // not re-established — mid-reconnect. Equal-or-older (or absent) means the
+    // current session is the live one.
+    let last_disconnected = stats.get("last_disconnected_at_ms").and_then(Value::as_u64);
+    match last_disconnected {
+        Some(disconnected_at) if disconnected_at > connected_at => (
+            StatusCode::SERVICE_UNAVAILABLE,
+            base("reconnecting", false, Some(stats)),
+        ),
+        _ => (StatusCode::OK, base("healthy", true, Some(stats))),
+    }
+}
+
+/// GET /health — connector transport/heartbeat health (unauthenticated).
+///
+/// Reads the SDK runner's `get_stats()` snapshot and the process-global connector
+/// identity, then classifies via [`classify_health`]. Returns `200` only when the
+/// gRPC transport to Strike48 is currently live; `503` for starting / stopped /
+/// connecting / reconnecting so a readiness probe holds the pod out of rotation.
+///
+/// # Probe wiring (recommendation; no manifest change ships with pick#295)
+/// A k8s **readiness** probe SHOULD consume this (503 correctly de-routes a
+/// not-connected pod; `initialDelaySeconds` must cover the connect+register window).
+/// A **liveness** probe should NOT gate on this — a transient `reconnecting` (503)
+/// would restart the pod while the SDK is already retrying with backoff — so keep
+/// liveness on a plain process check.
+async fn get_health(State(state): State<HealthState>) -> impl IntoResponse {
+    // Hold the outer lock only long enough to clone the inner runner Arc; drop the
+    // guard before awaiting get_stats() so /health never blocks a runner swap.
+    let runner = state.runner.read().await.clone();
+    let stats: Option<Value> = match runner {
+        Some(r) => Some(r.get_stats().await),
+        None => None,
+    };
+
+    let tools_loaded = crate::session::get_tool_names().len();
+    let tenant = crate::session::get_tenant_id();
+    let connector = crate::session::get_connector_name();
+
+    let (status, body) = classify_health(stats.as_ref(), tools_loaded, &tenant, &connector);
+    (status, Json(body))
+}
+
+/// Build the unauthenticated `/health` router.
+///
+/// Kept as a sibling of [`create_api_routes`] (rather than a route on it) so it
+/// never inherits the Bearer-token `auth_middleware` — a health/readiness probe
+/// must work without credentials. The returned router is fully-stated (`with_state`)
+/// so it merges into the base liveview router like the API router does.
+pub fn create_health_route(state: HealthState) -> Router {
+    Router::new()
+        .route("/health", get(get_health))
+        .with_state(state)
 }
 
 /// POST /api/aggression - Adjust aggression level mid-scan.
@@ -664,5 +825,221 @@ mod tests {
         let total_backoff: u64 = (1..=MAX_RETRIES).map(|i| BASE_BACKOFF_MS << i).sum();
         assert!(total_backoff > 2000); // Over 2 seconds of retry window
         assert_eq!(MAX_RETRIES, 10);
+    }
+
+    // --- /health classification (pick#295) ---
+    //
+    // classify_health is pure, so these feed hand-built get_stats() JSON directly —
+    // no ConnectorRunner, no HTTP server. Each row of the state table is asserted for
+    // both the HTTP status and the load-bearing body fields.
+
+    fn status_of(body: &Value) -> &str {
+        body.get("status").and_then(Value::as_str).unwrap_or("")
+    }
+
+    #[test]
+    fn health_starting_when_runner_absent() {
+        let (code, body) = classify_health(None, 0, "non-prod", "pick-local");
+        assert_eq!(code, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(status_of(&body), "starting");
+        assert_eq!(body["grpc_transport"], "down");
+        assert_eq!(body["ever_connected"], false);
+        assert_eq!(body["running"], false);
+        // Identity is available even before the runner exists.
+        assert_eq!(body["tenant"], "non-prod");
+        assert_eq!(body["connector"], "pick-local");
+    }
+
+    #[test]
+    fn health_stopped_when_not_running() {
+        let stats = serde_json::json!({ "running": false });
+        let (code, body) = classify_health(Some(&stats), 3, "non-prod", "pick-local");
+        assert_eq!(code, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(status_of(&body), "stopped");
+        assert_eq!(body["grpc_transport"], "down");
+    }
+
+    #[test]
+    fn health_connecting_when_running_never_connected() {
+        let stats = serde_json::json!({ "running": true, "last_connected_at_ms": null });
+        let (code, body) = classify_health(Some(&stats), 3, "non-prod", "pick-local");
+        assert_eq!(code, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(status_of(&body), "connecting");
+        assert_eq!(body["ever_connected"], false);
+    }
+
+    #[test]
+    fn health_healthy_when_running_and_connected() {
+        let stats = serde_json::json!({
+            "running": true,
+            "last_connected_at_ms": 1000,
+            "last_disconnected_at_ms": null
+        });
+        let (code, body) = classify_health(Some(&stats), 116, "non-prod", "pick-local");
+        assert_eq!(code, StatusCode::OK);
+        assert_eq!(status_of(&body), "healthy");
+        assert_eq!(body["grpc_transport"], "up");
+        assert_eq!(body["ever_connected"], true);
+        assert_eq!(body["tools_loaded"], 116);
+    }
+
+    #[test]
+    fn health_healthy_when_reconnected_after_earlier_drop() {
+        // A drop OLDER than the last connect means the current session is live.
+        let stats = serde_json::json!({
+            "running": true,
+            "last_connected_at_ms": 2000,
+            "last_disconnected_at_ms": 1000
+        });
+        let (code, body) = classify_health(Some(&stats), 116, "non-prod", "pick-local");
+        assert_eq!(code, StatusCode::OK);
+        assert_eq!(status_of(&body), "healthy");
+    }
+
+    #[test]
+    fn health_reconnecting_when_dropped() {
+        // A drop NEWER than the last connect means we're mid-reconnect.
+        let stats = serde_json::json!({
+            "running": true,
+            "last_connected_at_ms": 1000,
+            "last_disconnected_at_ms": 2000,
+            "last_disconnect_reason": "transport closed"
+        });
+        let (code, body) = classify_health(Some(&stats), 116, "non-prod", "pick-local");
+        assert_eq!(code, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(status_of(&body), "reconnecting");
+        assert_eq!(body["last_disconnect_reason"], "transport closed");
+    }
+
+    #[test]
+    fn health_body_includes_identity_and_metrics() {
+        let stats = serde_json::json!({
+            "running": true,
+            "last_connected_at_ms": 5000,
+            "last_disconnected_at_ms": null,
+            "reconnection_attempts": 2,
+            "total_disconnects": 1,
+            "heartbeat_rtt_last_ms": 12.5,
+            "uptime_seconds": 842
+        });
+        let (code, body) = classify_health(Some(&stats), 5, "non-prod", "pentest-connector");
+        assert_eq!(code, StatusCode::OK);
+        assert_eq!(body["reconnection_attempts"], 2);
+        assert_eq!(body["total_disconnects"], 1);
+        assert_eq!(body["heartbeat_rtt_last_ms"], 12.5);
+        assert_eq!(body["uptime_seconds"], 842);
+        assert_eq!(body["tools_loaded"], 5);
+        assert_eq!(body["tenant"], "non-prod");
+        assert_eq!(body["connector"], "pentest-connector");
+    }
+
+    #[test]
+    fn health_handles_missing_optional_fields() {
+        // Connected but heartbeat/uptime/counters absent — must not panic; nulls/zeros.
+        let stats = serde_json::json!({ "running": true, "last_connected_at_ms": 1000 });
+        let (code, body) = classify_health(Some(&stats), 0, "non-prod", "pick-local");
+        assert_eq!(code, StatusCode::OK);
+        assert_eq!(status_of(&body), "healthy");
+        assert_eq!(body["heartbeat_rtt_last_ms"], Value::Null);
+        assert_eq!(body["reconnection_attempts"], 0);
+        assert_eq!(body["uptime_seconds"], 0);
+    }
+
+    #[tokio::test]
+    async fn get_health_returns_503_when_runner_absent() {
+        // Exercises the real handler (not just classify_health) through the None branch.
+        let state = HealthState {
+            runner: Arc::new(RwLock::new(None)),
+        };
+        let response = get_health(State(state)).await.into_response();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[test]
+    fn health_equal_timestamps_are_healthy() {
+        // Pins the `==` boundary (disconnect == connect). The classifier uses
+        // `disconnected_at > connected_at` for reconnecting, so an equal pair is
+        // the live session (healthy). This test makes a future flip to `>=` a
+        // CONSCIOUS change rather than a silent one.
+        let stats = serde_json::json!({
+            "running": true,
+            "last_connected_at_ms": 1000,
+            "last_disconnected_at_ms": 1000
+        });
+        let (code, body) = classify_health(Some(&stats), 1, "non-prod", "pick-local");
+        assert_eq!(code, StatusCode::OK);
+        assert_eq!(status_of(&body), "healthy");
+    }
+
+    #[test]
+    fn health_malformed_running_fails_safe_to_stopped() {
+        // A non-bool `running` must degrade to stopped/503 (fail safe), and the
+        // body's `running` field must agree.
+        let stats = serde_json::json!({ "running": 1 });
+        let (code, body) = classify_health(Some(&stats), 0, "non-prod", "pick-local");
+        assert_eq!(code, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(status_of(&body), "stopped");
+        assert_eq!(body["running"], false);
+    }
+
+    #[test]
+    fn health_malformed_connected_ts_is_consistent_body_and_status() {
+        // Regression: `ever_connected` must track the classifier's `as_u64()` view,
+        // not a type-agnostic present-check. A string timestamp is NOT a valid
+        // connect → status "connecting" AND ever_connected false (no contradiction).
+        let stats = serde_json::json!({ "running": true, "last_connected_at_ms": "1000" });
+        let (code, body) = classify_health(Some(&stats), 0, "non-prod", "pick-local");
+        assert_eq!(code, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(status_of(&body), "connecting");
+        assert_eq!(body["ever_connected"], false);
+    }
+
+    #[test]
+    fn health_503_state_asserts_full_body() {
+        // Full-contract assertion for a non-starting 503 state: the `grpc_transport`
+        // field (never asserted for 503 states elsewhere) must read "down".
+        let stats = serde_json::json!({
+            "running": true,
+            "last_connected_at_ms": 1000,
+            "last_disconnected_at_ms": 2000,
+            "last_disconnect_reason": "transport closed"
+        });
+        let (code, body) = classify_health(Some(&stats), 3, "non-prod", "pick-local");
+        assert_eq!(code, StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(status_of(&body), "reconnecting");
+        assert_eq!(body["grpc_transport"], "down");
+        assert_eq!(body["ever_connected"], true);
+        assert_eq!(body["running"], true);
+    }
+
+    #[test]
+    fn health_full_shape_get_stats_payload_is_healthy() {
+        // Production-shape fixture: the exact key set + types ConnectorRunner::get_stats()
+        // emits when connected (all optional metrics PRESENT, not absent — e.g.
+        // heartbeat_rtt_last_ms is 0.0 on a fresh connect, never null). Guards against
+        // fixture-vs-runtime drift: if the SDK renamed/retyped a key this would break.
+        let stats = serde_json::json!({
+            "requests_received": 0, "requests_processed": 0, "requests_failed": 0,
+            "avg_latency_ms": 0.0, "total_duration_ms": 0, "bytes_received": 0, "bytes_sent": 0,
+            "uptime_ms": 5000, "uptime_seconds": 5,
+            "running": true,
+            "connector_type": "pentest", "instance_id": "pick-local", "version": "0.1.0",
+            "host": "connectors-studio-grpc.default.svc:50061", "tenant_id": "non-prod",
+            "use_tls": false, "transport_type": "Grpc",
+            "reconnection_attempts": 0, "total_disconnects": 0, "successful_reconnects": 0,
+            "last_disconnect_reason": null,
+            "last_connected_at_ms": 1000, "last_disconnected_at_ms": null,
+            "current_backoff_ms": 0, "last_request_at_ms": 0,
+            "heartbeat_rtt_avg_ms": 0.0, "heartbeat_rtt_last_ms": 0.0,
+            "heartbeat_rtt_min_ms": 0.0, "heartbeat_rtt_max_ms": 0.0, "heartbeat_rtt_count": 0
+        });
+        let (code, body) = classify_health(Some(&stats), 116, "non-prod", "pick-local");
+        assert_eq!(code, StatusCode::OK);
+        assert_eq!(status_of(&body), "healthy");
+        assert_eq!(body["grpc_transport"], "up");
+        assert_eq!(body["ever_connected"], true);
+        // heartbeat present-and-zero (not null) on a fresh connect — production shape.
+        assert_eq!(body["heartbeat_rtt_last_ms"], 0.0);
+        assert_eq!(body["uptime_seconds"], 5);
     }
 }

--- a/crates/ui/src/liveview_connector/mod.rs
+++ b/crates/ui/src/liveview_connector/mod.rs
@@ -198,6 +198,12 @@ pub struct LiveViewConnector {
     pub(crate) matrix_client: Arc<RwLock<Option<pentest_core::matrix::MatrixChatClient>>>,
     /// Total specialists spawned across reconnects (persists across ScanState resets)
     pub(crate) total_specialists_spawned: Arc<AtomicUsize>,
+    /// Shared handle to the SDK connector runner, populated in `connect_and_run`.
+    /// Created up front (empty) so the `/health` route — built in
+    /// `start_liveview_server`, BEFORE `connect_and_run` — can hold the SAME Arc and
+    /// observe the runner once it exists. `None` until connected (reported as
+    /// `status: "starting"`). See `api_routes::HealthState` (pick#295).
+    pub(crate) runner: Arc<RwLock<Option<Arc<strike48_connector::ConnectorRunner>>>>,
 }
 
 impl LiveViewConnector {
@@ -238,6 +244,7 @@ impl LiveViewConnector {
             active_scan: Arc::new(RwLock::new(None)),
             matrix_client: Arc::new(RwLock::new(None)),
             total_specialists_spawned: Arc::new(AtomicUsize::new(0)),
+            runner: Arc::new(RwLock::new(None)),
         }
     }
 
@@ -606,6 +613,13 @@ impl LiveViewConnector {
         };
         let api_routes_router = api_routes::create_api_routes(api_state);
 
+        // Unauthenticated /health route (pick#295). Built here so it can hold the
+        // shared runner Arc; kept OFF the api router so it never inherits the
+        // Bearer-token auth middleware (a readiness probe must work uncredentialed).
+        let health_router = api_routes::create_health_route(api_routes::HealthState {
+            runner: self.runner.clone(),
+        });
+
         // Start LLM proxy on its own TCP port (webwright in proot needs TCP access).
         // Bind to port 0 to let the OS pick an available port, then store it.
         let llm_state = llm_proxy::LlmProxyState {
@@ -631,8 +645,8 @@ impl LiveViewConnector {
             tracing::warn!("Failed to start LLM proxy (could not bind TCP port)");
         }
 
-        // Merge API routes with extra routes
-        let combined_routes = extra_routes.merge(api_routes_router);
+        // Merge API routes + the health route with extra routes
+        let combined_routes = extra_routes.merge(api_routes_router).merge(health_router);
 
         let lv_config = LiveViewConfig {
             port: DEFAULT_LIVEVIEW_PORT,
@@ -729,7 +743,10 @@ impl LiveViewConnector {
             instance_id: self.config.instance_id.clone(),
             aggression_level: Arc::new(RwLock::new(self.config.aggression_level)),
             ipc_addr: ipc_addr.clone(),
-            runner: Arc::new(RwLock::new(None)),
+            // Share the SAME runner Arc the /health route holds (self.runner), so the
+            // write below populates it for both PickConnector's invoke_capability AND
+            // the health handler. Starts None → /health reports "starting" until set.
+            runner: self.runner.clone(),
             matrix_api_url: self.derive_matrix_api_url(),
         });
 

--- a/crates/ui/src/liveview_server.rs
+++ b/crates/ui/src/liveview_server.rs
@@ -315,7 +315,10 @@ pub async fn start_liveview_server(
     // event handlers to work in the LiveView context.
     let router = Router::new()
         .with_app("/", LiveViewApp)
-        .route("/health", get(|| async { "OK" }))
+        // NOTE: /health is registered on a separate state-carrying router merged in
+        // via `extra_routes` (see api_routes::create_health_route, pick#295) so it can
+        // report real connector transport state. It MUST NOT also be defined here —
+        // axum panics on duplicate routes at merge time.
         .route(
             "/connector/info",
             get(|| async {


### PR DESCRIPTION
…lth (#295)

  ## What & why

  Closes #295. Pick's `/health` returned a static `"OK"` — it only proved the LiveView HTTP
  server was up, not whether the connector was actually functional. This enriches `/health` to
  report the connector's real **transport/heartbeat state** from the SDK's
  `ConnectorRunner::get_stats()`, so polling it (or a k8s probe / `newdev:status`) gives an
  accurate picture instead of a false green. **No connector behavior changes** — the endpoint
  only reads existing SDK state.

  ## What `/health` now returns
  
  `GET /health` (unauthenticated; served over the connector's Unix socket, reached via
  `curl --unix-socket /tmp/pentest-agent-1.sock http://x/health`):

  - **`200`** `{"status":"healthy", "grpc_transport":"up", ...}` when the gRPC transport is live.
  - **`503`** with `status` ∈ `starting` / `stopped` / `connecting` / `reconnecting` otherwise.
  - Body also carries `ever_connected`, `last_disconnect_reason`, `reconnection_attempts`,
    `total_disconnects`, `heartbeat_rtt_last_ms`, `uptime_seconds`, `tools_loaded`, `tenant`,
    `connector`.

  Classification (pure `classify_health`, fully unit-tested):
  
  | Condition (from `get_stats()`) | status | HTTP |
  |---|---|---|
  | runner not yet created | `starting` | 503 |
  | `running == false` | `stopped` | 503 |
  | running, never connected (`last_connected_at_ms` null) | `connecting` | 503 |
  | running, connected, no newer disconnect | `healthy` | **200** |
  | running, `last_disconnected_at_ms > last_connected_at_ms` | `reconnecting` | 503 |

  ## Implementation

  - `api_routes.rs`: new `HealthState`, pure `classify_health(stats, tools_loaded, tenant, connector) -> (StatusCode, Value)`, `get_health` handler, `create_health_route` — on a **separate
  un-authed router** (a probe must work without the Bearer token), merged as a sibling so it never inherits `/api/*`'s auth middleware.
  - `mod.rs`: added a shared `runner: Arc<RwLock<Option<Arc<ConnectorRunner>>>>` on `LiveViewConnector`, reused in the `PickConnector` literal so the existing write populates the same Arc
  `/health` reads. Health route built before the runner exists → reports `starting` until connected.
  - `liveview_server.rs`: removed the static `/health` from the base router (now provided by the merged health route; a duplicate would panic axum at merge).

  ## Probe wiring (recommendation; NOT shipped here)
  
  Readiness SHOULD consume `/health` (503 de-routes a not-connected pod). **Liveness should NOT**
  — a transient `reconnecting`/503 would crash-loop a pod the SDK is already recovering. The
  init-dev consumer wiring (readiness probe + `newdev:status`) is tracked in **Strike48/init-dev#335**.

  ## Testing
  
  **Unit:** 14 `classify_health` tests (all 5 states + malformed-input fail-safe + a
  production-shape `get_stats()` fixture to catch SDK key/type drift + the `==` timestamp
  boundary + a body/status consistency regression). `cargo fmt --check`, `cargo clippy -D warnings`,
  full `pentest-ui` suite (93 tests) all green.

  **Live (deployed on newdev k3s via `build:pick`, verified end-to-end):**
  - `healthy`/200 with real SDK data (`heartbeat_rtt_last_ms`, `tools_loaded: 115`, identity). ✅
  - **Controlled drop** (scaled Studio to 0): `/health` → `reconnecting`/503, `grpc_transport: down`,
    real `last_disconnect_reason`, climbing disconnect counts. ✅
  - **Recovery** (Studio back, Pick untouched): `503 → 200`; transport reconnected AND tools
    re-registered on their own (`total_connectors 0 → 1`, ~50–60s). ✅
  - `/api/status` still returns `401` without token — confirms moving `/health` off the base
    router did NOT leak auth-bypass to `/api/*`. ✅

  ## Known boundaries (intentional; documented in code)

  - `/health` reflects **transport/heartbeat only**. It cannot report registration/approval/JWT
    state (private SDK fields, no accessor in `strike48-connector` 0.4.4), so it can't distinguish
    *approved-active* from *pending-approval* — the Studio Gateways UI / connector registry remain
    the source of truth for approval. `tools_loaded` is honestly named ("loaded locally", not
    "registered with server").
  - **Silent-stall blind spot:** a connector whose stream is dead but not marked disconnected keeps
    `running == true`, so `/health` would read `healthy`. `get_stats()` exposes heartbeat *RTT*, not
    *staleness*. Detecting this needs an SDK accessor — folded into **Strike48/sdk-rs#59** (which
    also covers the silent-stall auto-recovery; the *clean-drop* recovery already works, verified above).
  - `bin/file_browser_connector.rs`'s `/health` is left as static `"OK"` — separate binary, no
    connector/runner state.

  ## Related
  - Parent hub: matrix#3216
  - init-dev#335 — wire the k8s readiness probe + `newdev:status` to consume `/health`
  - sdk-rs#59 — SDK silent-stall recovery + `get_stats()` heartbeat-staleness/session accessors

