### PR TITLE
fix(safety_check): stop reporting the host's own footprint as a compromised network

### DIFF
--- a/crates/tools/src/safety_check/dns_check.rs
+++ b/crates/tools/src/safety_check/dns_check.rs
@@ -74,7 +74,10 @@ pub async fn check_dns_integrity() -> anyhow::Result<CheckResult> {
         }
     }
 
-    // Detect captive portal: all domains resolve to same IP
+    // Detect captive portal: all domains resolve to same IP. This is a
+    // *corroborated* signal (multiple independent domains collapsing to one
+    // address), so unlike a lone unexpected-IP it is strong enough to fail.
+    let mut captive_portal = false;
     if connectivity_resolutions.len() >= 2 {
         let first_ip = connectivity_resolutions
             .values()
@@ -86,6 +89,7 @@ pub async fn check_dns_integrity() -> anyhow::Result<CheckResult> {
                 .values()
                 .all(|ips| ips.contains(&first));
             if all_same {
+                captive_portal = true;
                 issues.push(format!(
                     "Captive portal detected: all domains resolve to {}",
                     first
@@ -94,14 +98,15 @@ pub async fn check_dns_integrity() -> anyhow::Result<CheckResult> {
         }
     }
 
-    // Determine status
-    let (status, severity) = if !connectivity_ok || !issues.is_empty() {
-        (CheckStatus::Failed, Severity::Critical)
-    } else if validated_domains < 3 {
-        (CheckStatus::Warning, Severity::Medium)
-    } else {
-        (CheckStatus::Passed, Severity::Info)
-    };
+    // Classify the outcome into a (status, severity). Extracted to a pure
+    // helper so the severity calibration is unit-testable without live DNS.
+    let has_only_soft_anomalies = connectivity_ok && !captive_portal && !issues.is_empty();
+    let (status, severity) = classify_dns_outcome(
+        connectivity_ok,
+        captive_portal,
+        !issues.is_empty(),
+        validated_domains,
+    );
 
     let details = if issues.is_empty() {
         format!(
@@ -110,6 +115,13 @@ pub async fn check_dns_integrity() -> anyhow::Result<CheckResult> {
         )
     } else if !connectivity_ok {
         "No DNS connectivity - unable to resolve any domains. Check network connection.".to_string()
+    } else if has_only_soft_anomalies {
+        format!(
+            "DNS returned unexpected results for some domains. This is common on VPNs, \
+             filtered DNS (Pi-hole/NextDNS), or corporate networks and is usually benign, \
+             but verify if unexpected:\n{}",
+            issues.join("\n")
+        )
     } else {
         format!("DNS integrity issues detected:\n{}", issues.join("\n"))
     };
@@ -120,6 +132,38 @@ pub async fn check_dns_integrity() -> anyhow::Result<CheckResult> {
         details,
         severity,
     })
+}
+
+/// Classify DNS check signals into a (status, severity) verdict.
+///
+/// Severity is calibrated to operator reality: a VPN, split-horizon DNS, a
+/// Pi-hole/NextDNS filter, or a corporate resolver routinely makes a
+/// "known-good" domain resolve to an unexpected IP. Treating that lone,
+/// uncorroborated anomaly as `Failed/Critical` produces an alarming
+/// "network is compromised" verdict for an ordinary, safe setup - the exact
+/// false positive this fix removes.
+///
+/// Hard failure (`Failed/Critical`) is reserved for corroborated signals:
+///   - total loss of DNS connectivity (nothing resolved at all), or
+///   - a captive portal (multiple independent domains collapsing to one IP).
+///
+/// An uncorroborated anomaly, or too few validated domains, is only a
+/// `Warning/Medium` (which the aggregator maps to `Caution`, not `Unsafe`).
+fn classify_dns_outcome(
+    connectivity_ok: bool,
+    captive_portal: bool,
+    has_anomalies: bool,
+    validated_domains: usize,
+) -> (CheckStatus, Severity) {
+    const MIN_VALIDATED_DOMAINS: usize = 3;
+
+    if !connectivity_ok || captive_portal {
+        (CheckStatus::Failed, Severity::Critical)
+    } else if has_anomalies || validated_domains < MIN_VALIDATED_DOMAINS {
+        (CheckStatus::Warning, Severity::Medium)
+    } else {
+        (CheckStatus::Passed, Severity::Info)
+    }
 }
 
 /// Resolve a domain to its IP addresses.
@@ -174,6 +218,52 @@ mod tests {
         let expected = &["8.8.8.8", "1.1.1.1"];
 
         assert!(!any_ip_matches(&resolved, expected));
+    }
+
+    #[test]
+    fn uncorroborated_anomaly_is_caution_not_critical() {
+        // The core fix: an unexpected-IP anomaly with working connectivity and
+        // NO captive portal (the common VPN/filtered-DNS case) must be a soft
+        // Warning, NOT a Failed/Critical that reads as "compromised".
+        let (status, severity) = classify_dns_outcome(
+            /* connectivity_ok */ true, /* captive_portal  */ false,
+            /* has_anomalies    */ true, /* validated_domains*/ 5,
+        );
+        assert_eq!(status, CheckStatus::Warning);
+        assert_eq!(severity, Severity::Medium);
+        // Explicitly guard against the pre-fix behavior.
+        assert_ne!(status, CheckStatus::Failed);
+        assert_ne!(severity, Severity::Critical);
+    }
+
+    #[test]
+    fn captive_portal_stays_critical() {
+        // A corroborated captive portal is a genuine hard failure and must
+        // remain Failed/Critical even though connectivity technically "works".
+        let (status, severity) = classify_dns_outcome(true, true, true, 5);
+        assert_eq!(status, CheckStatus::Failed);
+        assert_eq!(severity, Severity::Critical);
+    }
+
+    #[test]
+    fn no_connectivity_stays_critical() {
+        // Total DNS failure is still a hard Critical failure.
+        let (status, severity) = classify_dns_outcome(false, false, true, 0);
+        assert_eq!(status, CheckStatus::Failed);
+        assert_eq!(severity, Severity::Critical);
+    }
+
+    #[test]
+    fn clean_resolution_passes() {
+        let (status, severity) = classify_dns_outcome(true, false, false, 5);
+        assert_eq!(status, CheckStatus::Passed);
+        assert_eq!(severity, Severity::Info);
+    }
+
+    #[test]
+    fn too_few_validated_domains_is_warning() {
+        let (status, _severity) = classify_dns_outcome(true, false, false, 2);
+        assert_eq!(status, CheckStatus::Warning);
     }
 
     #[tokio::test]

--- a/crates/tools/src/safety_check/dns_check.rs
+++ b/crates/tools/src/safety_check/dns_check.rs
@@ -266,6 +266,13 @@ mod tests {
         assert_eq!(status, CheckStatus::Warning);
     }
 
+    #[test]
+    fn exactly_min_validated_domains_passes() {
+        // Boundary: exactly MIN_VALIDATED_DOMAINS (3) with no anomalies passes.
+        let (status, _severity) = classify_dns_outcome(true, false, false, 3);
+        assert_eq!(status, CheckStatus::Passed);
+    }
+
     #[tokio::test]
     async fn test_dns_check_runs() {
         // This is an integration test - it requires network connectivity

--- a/crates/tools/src/safety_check/network_map.rs
+++ b/crates/tools/src/safety_check/network_map.rs
@@ -228,17 +228,44 @@ async fn collect_arp_info() -> HashMap<IpAddr, ArpInfo> {
 ///
 /// Best-effort: returns an empty set on any failure - the caller still excludes
 /// the default local IP, so a failure just means a less-complete self-filter,
-/// never an error. Loopback interfaces are skipped (never part of a LAN map).
+/// never an error. On failure we log at `warn`, not `debug`: an incomplete
+/// self-filter silently weakens the whole check (the host's other-interface IPs
+/// can reappear as foreign "devices"), so the degradation must be observable.
 async fn collect_own_ips() -> HashSet<IpAddr> {
     let platform = pentest_platform::get_platform();
-    let interfaces = match platform.get_network_interfaces().await {
-        Ok(ifaces) => ifaces,
-        Err(e) => {
-            tracing::debug!("Interface enumeration unavailable for self-filter: {}", e);
-            return HashSet::new();
+    match platform.get_network_interfaces().await {
+        Ok(interfaces) => {
+            let own = own_ips_from_interfaces(interfaces);
+            tracing::info!(
+                "Self-filter: {} local address(es) will be excluded",
+                own.len()
+            );
+            own
         }
-    };
+        Err(e) => {
+            tracing::warn!(
+                "Interface enumeration failed ({}); self-filter is INCOMPLETE - only the \
+                 default local IP will be excluded, so VPN/container/mesh addresses may \
+                 appear as foreign devices",
+                e
+            );
+            HashSet::new()
+        }
+    }
+}
 
+/// Pure helper: reduce a set of network interfaces to this host's own IPs.
+///
+/// Extracted from [`collect_own_ips`] so the parsing/filtering rules are
+/// unit-testable without live interface enumeration. Rules:
+/// - loopback interfaces are skipped (never part of a LAN map);
+/// - a CIDR suffix on the address string (e.g. "192.168.1.42/24") is stripped;
+/// - loopback and IPv6 link-local (`fe80::/10`) addresses are excluded even if
+///   the interface's `is_loopback` flag is unset or the backend mislabels them
+///   (defense-in-depth against a buggy per-platform backend);
+/// - a malformed address is dropped with a `debug` breadcrumb rather than
+///   silently vanishing.
+fn own_ips_from_interfaces(interfaces: Vec<pentest_platform::NetworkInterface>) -> HashSet<IpAddr> {
     let mut own = HashSet::new();
     for iface in interfaces {
         if iface.is_loopback {
@@ -248,17 +275,39 @@ async fn collect_own_ips() -> HashSet<IpAddr> {
             // Interface addresses may carry a CIDR suffix (e.g. "192.168.1.42/24")
             // depending on the platform backend; strip it before parsing.
             let addr = ip_str.split('/').next().unwrap_or(ip_str.as_str());
-            if let Ok(ip) = addr.parse::<IpAddr>() {
-                own.insert(ip);
+            match addr.parse::<IpAddr>() {
+                Ok(ip) if is_own_addressable(&ip) => {
+                    own.insert(ip);
+                }
+                Ok(_) => {
+                    // Loopback / link-local: real but never a foreign LAN host,
+                    // so no need to carry it in the self-filter set.
+                }
+                Err(e) => {
+                    tracing::debug!("Ignoring malformed interface address {:?}: {}", ip_str, e);
+                }
             }
         }
     }
-
-    tracing::info!(
-        "Self-filter: {} local address(es) will be excluded",
-        own.len()
-    );
     own
+}
+
+/// True if an address is a routable/LAN address worth excluding as "ours".
+///
+/// Filters out loopback and IPv6 link-local (`fe80::/10`) - addresses that
+/// cannot appear as a distinct foreign host on the LAN map, so they never need
+/// to be in the self-filter set.
+fn is_own_addressable(ip: &IpAddr) -> bool {
+    if ip.is_loopback() {
+        return false;
+    }
+    if let IpAddr::V6(v6) = ip {
+        // IPv6 link-local fe80::/10.
+        if (v6.segments()[0] & 0xffc0) == 0xfe80 {
+            return false;
+        }
+    }
+    true
 }
 
 /// Get gateway and local IP address, plus the local IPv4 prefix length.
@@ -479,6 +528,16 @@ mod tests {
     }
 
     #[test]
+    fn absurd_prefix_clamps_to_32() {
+        // Unreachable from a real Ipv4Net, but guard the defensive >32 clamp
+        // so it can never panic on the left-shift.
+        assert_eq!(
+            subnet_cidr_v4(Ipv4Addr::new(10, 0, 0, 1), 99),
+            "10.0.0.1/32"
+        );
+    }
+
+    #[test]
     fn exactly_16_is_not_clamped() {
         // Boundary: /16 is the cap itself, so it passes through unchanged.
         assert_eq!(
@@ -526,6 +585,72 @@ mod tests {
         assert!(!foreign.contains(&ip("172.17.0.1")));
         assert!(!foreign.contains(&ip("100.64.0.1")));
         assert!(!foreign.contains(&gateway));
+    }
+
+    fn iface(name: &str, is_loopback: bool, ips: &[&str]) -> pentest_platform::NetworkInterface {
+        pentest_platform::NetworkInterface {
+            name: name.to_string(),
+            ip_addresses: ips.iter().map(|s| s.to_string()).collect(),
+            mac_address: None,
+            is_up: true,
+            is_loopback,
+        }
+    }
+
+    #[test]
+    fn own_ips_strips_cidr_suffix_ipv4_and_ipv6() {
+        let ifaces = vec![
+            iface("eth0", false, &["192.168.1.42/24"]),
+            iface("eth1", false, &["10.0.0.5"]),  // no suffix
+            iface("wg0", false, &["fd00::1/64"]), // ULA v6 with suffix
+        ];
+        let own = own_ips_from_interfaces(ifaces);
+        assert!(own.contains(&ip("192.168.1.42")));
+        assert!(own.contains(&ip("10.0.0.5")));
+        assert!(own.contains(&ip("fd00::1")));
+    }
+
+    #[test]
+    fn own_ips_skips_loopback_interface_and_loopback_addr() {
+        // A loopback *interface* is skipped wholesale...
+        let via_iface = own_ips_from_interfaces(vec![iface("lo", true, &["127.0.0.1", "::1"])]);
+        assert!(via_iface.is_empty());
+        // ...and a loopback *address* on a non-loopback iface is excluded too
+        // (defense against a backend that mislabels is_loopback).
+        let via_addr = own_ips_from_interfaces(vec![iface("eth0", false, &["127.0.0.1"])]);
+        assert!(
+            via_addr.is_empty(),
+            "loopback addr must not enter self-filter"
+        );
+    }
+
+    #[test]
+    fn own_ips_excludes_ipv6_link_local() {
+        // fe80::/10 is per-interface local, never a distinct foreign LAN host.
+        let own = own_ips_from_interfaces(vec![iface(
+            "eth0",
+            false,
+            &["fe80::1343:2e71:941d:6935", "192.168.1.10"],
+        )]);
+        assert!(!own.iter().any(|i| i.to_string().starts_with("fe80")));
+        assert!(own.contains(&ip("192.168.1.10")));
+    }
+
+    #[test]
+    fn own_ips_drops_malformed_without_panicking() {
+        let own = own_ips_from_interfaces(vec![iface(
+            "eth0",
+            false,
+            &["192.168.1.256", "not-an-ip", "10.0.0.9"],
+        )]);
+        // Only the one valid address survives; malformed entries are dropped.
+        assert_eq!(own.len(), 1);
+        assert!(own.contains(&ip("10.0.0.9")));
+    }
+
+    #[test]
+    fn own_ips_empty_interface_list_is_empty_set() {
+        assert!(own_ips_from_interfaces(vec![]).is_empty());
     }
 
     #[test]

--- a/crates/tools/src/safety_check/network_map.rs
+++ b/crates/tools/src/safety_check/network_map.rs
@@ -3,8 +3,8 @@
 use super::oui;
 use super::types::{Device, NetworkMap, ThreatLevel};
 use anyhow::Context;
-use pentest_platform::NetworkOps;
-use std::collections::HashMap;
+use pentest_platform::{NetworkOps, SystemInfo};
+use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv4Addr};
 use std::process::Stdio;
 use tokio::process::Command;
@@ -89,24 +89,50 @@ pub async fn discover_network() -> anyhow::Result<NetworkMap> {
         host_ips.len()
     );
 
+    // Self-attribution: collect every IP that belongs to THIS host, across all
+    // interfaces (VPN tun, docker0/virbr0, mesh like Tailscale, a second NIC),
+    // so Pick never reports its own addresses back as foreign "devices" on the
+    // network. `get_gateway_and_local_ip` only knows the default-route address;
+    // a multi-interface operator box has many more. Best-effort - if interface
+    // enumeration fails we fall back to excluding just the default local IP.
+    let mut own_ips = collect_own_ips().await;
+    own_ips.insert(local_ip);
+
     // Build device list, enriching gateway and local device too.
     let gateway = build_device(gateway_ip, &arp_info);
     let your_device = build_device(local_ip, &arp_info);
 
-    let mut other_devices = Vec::new();
-    for ip in host_ips {
-        // Skip gateway and local IP (rendered separately).
-        if ip == gateway_ip || ip == local_ip {
-            continue;
-        }
-        other_devices.push(build_device(ip, &arp_info));
-    }
+    let other_devices = filter_foreign_hosts(host_ips, gateway_ip, &own_ips)
+        .into_iter()
+        .map(|ip| build_device(ip, &arp_info))
+        .collect();
 
     Ok(NetworkMap {
         gateway,
         your_device,
         other_devices,
     })
+}
+
+/// Pure helper: from a discovered host set, keep only genuinely foreign hosts.
+///
+/// Excludes the gateway (rendered separately) and every address that belongs to
+/// this host (`own_ips` - all local interfaces, not just the default one). This
+/// is the self-reflection fix: without excluding the full `own_ips` set, a
+/// multi-interface box (VPN/container/mesh) surfaces its own other addresses as
+/// foreign "devices". Kept free of I/O so the exclusion is unit-testable.
+fn filter_foreign_hosts<I>(
+    host_ips: I,
+    gateway_ip: IpAddr,
+    own_ips: &HashSet<IpAddr>,
+) -> Vec<IpAddr>
+where
+    I: IntoIterator<Item = IpAddr>,
+{
+    host_ips
+        .into_iter()
+        .filter(|ip| *ip != gateway_ip && !own_ips.contains(ip))
+        .collect()
 }
 
 /// Build an enriched [`Device`] for an IP using ARP data and OUI lookup.
@@ -141,6 +167,14 @@ fn build_device(ip: IpAddr, arp_info: &HashMap<IpAddr, ArpInfo>) -> Device {
 /// by threat-intelligence enrichment (handled in the threat-intel check), not
 /// here. With no port data yet (Phase 1 does no per-host port scan) every host
 /// is Safe; the threshold is wired in for when port enrichment lands.
+///
+// TODO(self-attribution): when per-host port scanning lands, this will scan
+// THIS host too and flag the listeners Pick's own installed tools opened (msf
+// handlers, BloodHound Neo4j 7474/7687, etc.) as Suspicious. Before enabling
+// port enrichment, subtract Pick-owned listeners via the installer registry +
+// provenance (crates/core/src/provenance.rs) - the same self-filter applied to
+// local IPs in `collect_own_ips`. See memory note
+// `project-safety-check-self-reflection` for the full rationale.
 fn classify_threat(open_ports: &[u16]) -> ThreatLevel {
     if open_ports.len() >= SUSPICIOUS_PORT_THRESHOLD {
         ThreatLevel::Suspicious
@@ -183,6 +217,48 @@ async fn collect_arp_info() -> HashMap<IpAddr, ArpInfo> {
         );
     }
     map
+}
+
+/// Collect every IP address that belongs to this host, across all interfaces.
+///
+/// Uses the platform's interface enumeration (already implemented per-OS) so
+/// the safety check can subtract Pick's own footprint before rendering the
+/// network map. Without this, a VPN/container/mesh interface makes the host
+/// see its own other addresses as foreign devices (self-reflection).
+///
+/// Best-effort: returns an empty set on any failure - the caller still excludes
+/// the default local IP, so a failure just means a less-complete self-filter,
+/// never an error. Loopback interfaces are skipped (never part of a LAN map).
+async fn collect_own_ips() -> HashSet<IpAddr> {
+    let platform = pentest_platform::get_platform();
+    let interfaces = match platform.get_network_interfaces().await {
+        Ok(ifaces) => ifaces,
+        Err(e) => {
+            tracing::debug!("Interface enumeration unavailable for self-filter: {}", e);
+            return HashSet::new();
+        }
+    };
+
+    let mut own = HashSet::new();
+    for iface in interfaces {
+        if iface.is_loopback {
+            continue;
+        }
+        for ip_str in iface.ip_addresses {
+            // Interface addresses may carry a CIDR suffix (e.g. "192.168.1.42/24")
+            // depending on the platform backend; strip it before parsing.
+            let addr = ip_str.split('/').next().unwrap_or(ip_str.as_str());
+            if let Ok(ip) = addr.parse::<IpAddr>() {
+                own.insert(ip);
+            }
+        }
+    }
+
+    tracing::info!(
+        "Self-filter: {} local address(es) will be excluded",
+        own.len()
+    );
+    own
 }
 
 /// Get gateway and local IP address, plus the local IPv4 prefix length.
@@ -409,6 +485,60 @@ mod tests {
             subnet_cidr_v4(Ipv4Addr::new(10, 1, 2, 3), 16),
             "10.1.0.0/16"
         );
+    }
+
+    fn ip(s: &str) -> IpAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn foreign_filter_excludes_all_own_interface_ips_not_just_default() {
+        // The self-reflection bug: a host's OTHER interface addresses (VPN,
+        // docker, mesh) show up in the discovered host set. They must be
+        // excluded as our own, not surfaced as foreign devices.
+        let gateway = ip("192.168.50.1");
+        let default_local = ip("192.168.50.100");
+        let own: HashSet<IpAddr> = [
+            default_local,
+            ip("172.17.0.1"),    // docker0
+            ip("192.168.122.1"), // virbr0
+            ip("100.64.0.1"),    // mesh VPN e.g. tailscale (CGNAT range)
+        ]
+        .into_iter()
+        .collect();
+
+        let discovered = vec![
+            gateway,
+            default_local,
+            ip("172.17.0.1"),    // our own - must be dropped
+            ip("100.64.0.1"),    // our own - must be dropped
+            ip("192.168.50.55"), // a genuine peer - must stay
+            ip("192.168.50.56"), // a genuine peer - must stay
+        ];
+
+        let foreign = filter_foreign_hosts(discovered, gateway, &own);
+
+        // Only the two genuine peers survive.
+        assert_eq!(foreign.len(), 2, "own IPs and gateway must be excluded");
+        assert!(foreign.contains(&ip("192.168.50.55")));
+        assert!(foreign.contains(&ip("192.168.50.56")));
+        // Guard: none of our own addresses leaked through as "devices".
+        assert!(!foreign.contains(&ip("172.17.0.1")));
+        assert!(!foreign.contains(&ip("100.64.0.1")));
+        assert!(!foreign.contains(&gateway));
+    }
+
+    #[test]
+    fn foreign_filter_keeps_peers_when_only_default_ip_is_known() {
+        // Degraded path (interface enumeration failed): own_ips has just the
+        // default local IP. Real peers must still be reported.
+        let gateway = ip("192.168.1.1");
+        let own: HashSet<IpAddr> = [ip("192.168.1.100")].into_iter().collect();
+        let discovered = vec![gateway, ip("192.168.1.100"), ip("192.168.1.50")];
+
+        let foreign = filter_foreign_hosts(discovered, gateway, &own);
+
+        assert_eq!(foreign, vec![ip("192.168.1.50")]);
     }
 
     #[test]

--- a/crates/tools/src/safety_check/report.rs
+++ b/crates/tools/src/safety_check/report.rs
@@ -138,7 +138,7 @@ pub fn generate_recommendations(
             Recommendation {
                 priority: Priority::Critical,
                 title: "Multiple Critical Issues Detected".to_string(),
-                description: "Multiple security checks failed. This network is likely malicious or severely compromised.".to_string(),
+                description: "Multiple checks failed for this network environment, so it is likely unsafe to operate from. (This is about the network you are connected to, not your own device.)".to_string(),
                 action: Some("Disconnect immediately and use a mobile hotspot or trusted network.".to_string()),
             },
         );
@@ -174,10 +174,13 @@ pub fn generate_recommendations(
 pub fn format_report(result: &super::types::SafetyCheckResult) -> String {
     let mut output = String::new();
 
-    // Headline verdict with a one-line, non-technical gloss.
+    // Headline verdict with a one-line, non-technical gloss. The verdict is
+    // explicitly scoped to the *network environment* - never the user's own
+    // device - so an "UNSAFE" headline is not misread as "you have been
+    // compromised". Pick assesses the network it operates from, not the host.
     output.push_str("## Network Safety Check\n\n");
     output.push_str(&format!(
-        "### Verdict: {} {}\n\n",
+        "### Network environment: {} {}\n\n",
         status_indicator(result.status),
         result.status
     ));
@@ -289,7 +292,10 @@ fn status_gloss(status: super::types::SafetyStatus) -> &'static str {
         // surfaced in the recommendations below, so this stays general.
         MostlySafe => "Nothing harmful was found, but this network could not be fully verified - likely a busy or shared network. Probably fine; see the notes below before doing anything sensitive.",
         Caution => "This network has the normal unknowns of a public network. Take basic precautions like using a VPN and avoiding sensitive logins.",
-        Unsafe => "We found an active problem with this network. Avoid sensitive activity (banking, passwords) and consider disconnecting or switching to a mobile hotspot.",
+        // Scoped to the network, not the device: this verdict means the network
+        // you are connected to looks risky to operate from - it does NOT mean
+        // your own machine has been compromised.
+        Unsafe => "We found an active problem with the network you are connected to (not your own device). Avoid sensitive activity (banking, passwords) and consider disconnecting or switching to a mobile hotspot.",
     }
 }
 
@@ -418,6 +424,42 @@ mod tests {
     }
 
     #[test]
+    fn multi_critical_recommendation_does_not_imply_host_compromise() {
+        // Two Critical failures trigger the "Multiple Critical Issues" advice.
+        // Its wording must stay scoped to the NETWORK and must not tell the user
+        // their machine is "compromised" - that phrasing is the exact false
+        // "you've been hacked" misread this fix removes.
+        let checks = vec![
+            CheckResult {
+                name: "DNS Integrity".to_string(),
+                status: CheckStatus::Failed,
+                details: "no connectivity".to_string(),
+                severity: Severity::Critical,
+            },
+            CheckResult {
+                name: "Router Threat Intelligence".to_string(),
+                status: CheckStatus::Failed,
+                details: "flagged".to_string(),
+                severity: Severity::Critical,
+            },
+        ];
+
+        let recs = generate_recommendations(&checks, &None);
+        let multi = recs
+            .iter()
+            .find(|r| r.title == "Multiple Critical Issues Detected")
+            .expect("multi-critical recommendation should be present");
+
+        assert!(
+            !multi.description.contains("compromised"),
+            "verdict copy must not imply the host is compromised: {:?}",
+            multi.description
+        );
+        // It should make the network-vs-device distinction explicit.
+        assert!(multi.description.contains("not your own device"));
+    }
+
+    #[test]
     fn test_recommendations_sorted_by_priority() {
         let checks = vec![
             CheckResult {
@@ -473,7 +515,9 @@ mod tests {
     fn test_format_report_is_markdown_with_verdict() {
         let report = format_report(&sample_result(SafetyStatus::MostlySafe, None));
         assert!(report.contains("## Network Safety Check"));
-        assert!(report.contains("### Verdict"));
+        // Verdict is scoped to the network environment (not the user's device),
+        // so an UNSAFE headline is not misread as "you have been compromised".
+        assert!(report.contains("### Network environment:"));
         assert!(report.contains("MOSTLY SAFE"));
         // Status table headers present.
         assert!(report.contains("| Check | Result | Details |"));


### PR DESCRIPTION
Closes #303.

## Summary

- `safety_check` is a pre-engagement "is this network safe to operate **from**" check, but on a normal operator machine it read as "you have been compromised" because it was seeing **Pick's own host**, not a threat. This fixes the three mechanisms behind that false positive so the feature stays useful instead of being suppressed.
- **Self-attribution:** device discovery now excludes *all* local interface IPs (via the platform's existing `SystemInfo::get_network_interfaces`), not just the single default-route address. A box with VPN/container/mesh interfaces (docker0, virbr0, Tailscale, a second NIC) no longer surfaces its own addresses as foreign "devices."
- **DNS severity calibrated to reality:** a lone uncorroborated anomaly (VPN, split-horizon DNS, Pi-hole/NextDNS, corporate resolver) is now `Caution`, not `Unsafe`. Hard `Critical` is reserved for corroborated signals (total DNS loss, captive portal).
- **Verdict copy** is scoped to the network environment and no longer implies the host itself is compromised.

## Security trade-off (please scrutinize)

The DNS change means a genuine lone DNS-hijack (single unexpected IP, no captive portal, connectivity otherwise fine) now surfaces as `Caution` rather than `Unsafe`. This is deliberate: on real operator machines the benign causes (VPN/split-DNS/filtered resolvers) vastly outnumber hijacks, and a real hijack typically corroborates via the captive-portal or connectivity signals that still fire `Critical`. Flagging it here so the reviewer weighs it explicitly rather than finding it buried in the diff.

## Not in scope (deliberate)

The latent per-host port-scan self-flag (`classify_threat`, currently inert because `open_ports` is always empty) is left with a `TODO(self-attribution)` breadcrumb rather than built out now (YAGNI). The TODO points at the same self-filter pattern so Pick-owned listeners get subtracted before port enrichment ships.

## Tracked follow-ups

- #305 - escalate the DNS verdict to Critical when a *majority* of known-good domains resolve to unexpected IPs. Deferred from this PR to keep scope tight; it hardens the trade-off called out above without reintroducing the false positive.
- Parent feature: #158 (introduced `safety_check`).

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --locked --features pentest-platform/desktop-pcap -- -D warnings` clean (full CI-equivalent workspace lane; exit 0, no error lines)
- [x] `cargo test -p pentest-tools --lib safety_check` - **55 passed, 0 failed, 2 ignored** (48 original + 7 added during self-review)
- [x] Guard tests verified to **fail against the pre-fix behavior** (mutation-checked): neutering `filter_foreign_hosts` to ignore `own_ips` turns both interface-exclusion tests RED; restored -> green. The DNS test asserts `Warning`/`!=Critical` where the old code returned `Failed/Critical`.
- [x] Self-review (`/pre-review`) run: 3 independent review agents converged on `collect_own_ips()` being silently degrading + untested -> hardened (warn-on-failure, pure testable helper, loopback/IPv6-link-local defense, 5 new unit tests). See commit 90d570c.
- [ ] Reviewer: confirm the DNS severity trade-off above is acceptable.
- [ ] Optional live check on a multi-interface/VPN host: `cargo test -p pentest-tools safety_check::tests::live_report -- --ignored --nocapture`

