### PR TITLE
feat(#162): differential-authz identity model, store, orchestrator advertisement + specialist prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ logs/
 
 # Operator test-identities for differential-authz testing (pick#162).
 # Holds real target credentials (cookies/JWT/headers) - never commit.
+# The loader (identities_file_path) prefers a cwd `identities.json` when present,
+# so a file copied from the template next to it here is both loaded AND ignored.
 # The committed template `identities.example.json` is deliberately re-included.
 identities.json
 identities.*.json

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,13 @@ logs/
 .env.bak-*
 .env.*.bak
 
+# Operator test-identities for differential-authz testing (pick#162).
+# Holds real target credentials (cookies/JWT/headers) - never commit.
+# The committed template `identities.example.json` is deliberately re-included.
+identities.json
+identities.*.json
+!identities.example.json
+
 # AI tooling local overlays — private, operator-specific, never committed.
 # See CLAUDE.md "Local Overrides" section.
 CLAUDE.local.md

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,11 @@ logs/
 
 # Operator test-identities for differential-authz testing (pick#162).
 # Holds real target credentials (cookies/JWT/headers) - never commit.
+# ROLLOUT WARNING: injected credentials are passed to tools via argv
+# (e.g. `curl -H "Authorization: Bearer <token>"`), so they are readable from
+# `ps` / `/proc/<pid>/cmdline` by any local user for the child's lifetime. Do
+# NOT provision real credentials on a shared or multi-tenant connector host
+# until pick#335 moves the header off argv (`curl -H @file`).
 # The loader (identities_file_path) prefers a cwd `identities.json` when present,
 # so a file copied from the template next to it here is both loaded AND ignored.
 # The committed template `identities.example.json` is deliberately re-included.

--- a/crates/core/src/evidence.rs
+++ b/crates/core/src/evidence.rs
@@ -336,10 +336,21 @@ mod tests {
             ProbeCommand::from_exact("nmap -sV 192.168.1.1"),
             "Nmap scan report",
         );
-        let node = fixture().with_provenance(prov.clone());
+        let node = fixture().with_provenance(prov);
         let wire = serde_json::to_value(&node).unwrap();
         let back: EvidenceNode = serde_json::from_value(wire).unwrap();
-        assert_eq!(back.provenance, Some(prov));
+        // The wire-facing provenance fields survive the round-trip. The raw
+        // `command` is intentionally not serialized (#317 review) — it can carry
+        // an injected credential — so it comes back empty while the redacted
+        // `effective_command` is intact.
+        let back_prov = back.provenance.expect("provenance present");
+        assert_eq!(back_prov.underlying_tool, "nmap");
+        assert_eq!(back_prov.tool_version, "7.95");
+        assert_eq!(back_prov.probe_commands[0].command, "");
+        assert_eq!(
+            back_prov.probe_commands[0].effective_command,
+            "nmap -sV 192.168.1.1"
+        );
     }
 
     #[test]

--- a/crates/core/src/identity.rs
+++ b/crates/core/src/identity.rs
@@ -1,0 +1,230 @@
+//! Connector-side identity store for differential authorization testing
+//! (pick#162).
+//!
+//! The differential-authz method needs to replay the same request as several
+//! operator-provided identities (unauth / user / admin / tenant-A/B) and diff
+//! the responses. Those identities are authenticated by **secrets** - cookies,
+//! bearer tokens, or raw header bundles the operator supplies at engagement
+//! setup.
+//!
+//! # Why the secret lives here and not in [`crate::specialist_spawner::TestIdentity`]
+//!
+//! Pick runs standalone *and* through StrikeKit/Matrix. When spawned via Matrix,
+//! the specialist's [`SpecialistContext`](crate::specialist_spawner::SpecialistContext)
+//! is serialized and sent to the agent (the LLM reasons server-side; only tool
+//! *execution* returns to the connector). If the raw session material rode in
+//! that context it would transit to and rest on Matrix and sit in the LLM
+//! window - a leak surface for the *customer's* credentials.
+//!
+//! So the context carries only **references** (`TestIdentity { label, role,
+//! tenant }`), and the raw material stays connector-side in this
+//! [`IdentityStore`], keyed by `label`. The LLM references an identity by label
+//! in its tool calls; the connector resolves the label here and injects the
+//! auth locally at execution time. The secret never crosses the Matrix/LLM
+//! boundary.
+//!
+//! This handles **Type 1** credentials only: operator-*provided* identities for
+//! authorized testing. Type 2 (credentials *discovered* mid-engagement) are
+//! findings/evidence - logged and flagged, not redacted - and are out of scope
+//! here (see pick#313).
+//!
+//! Population is two-pathed: standalone (operator config/UI) ships now; the
+//! StrikeKit/Matrix provisioning path is pick#312.
+
+use std::collections::HashMap;
+
+/// Opaque session material (cookies, bearer token, or a raw header bundle) that
+/// authenticates a test identity when a specialist replays requests.
+///
+/// This is a secret. Its `Debug` and `Display` impls **redact** the value so it
+/// cannot leak into logs, `tracing` fields, or error messages - the
+/// secret-hygiene rule shared with pick#179. It is intentionally **not**
+/// `Serialize`: unlike the pattern-based [`crate::provenance::redact`] (which
+/// scrubs secrets out of tool output), this type keeps the secret off every
+/// serialized surface entirely. It is never placed in
+/// [`SpecialistContext`](crate::specialist_spawner::SpecialistContext); it lives
+/// only in the connector-side [`IdentityStore`]. Reach the raw value only via
+/// [`SessionMaterial::expose`], and only on the authentication path.
+#[derive(Clone, Default, PartialEq, Eq)]
+pub struct SessionMaterial(String);
+
+impl SessionMaterial {
+    /// Wrap operator-provided session material.
+    pub fn new(material: impl Into<String>) -> Self {
+        Self(material.into())
+    }
+
+    /// Borrow the raw material. This is the authentication path only - callers
+    /// that route the result into logs, evidence nodes, or tool output violate
+    /// the secret-hygiene contract.
+    pub fn expose(&self) -> &str {
+        &self.0
+    }
+
+    /// Whether any material was supplied. `true` for an anonymous identity.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+impl std::fmt::Debug for SessionMaterial {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SessionMaterial(<redacted {} bytes>)", self.0.len())
+    }
+}
+
+impl std::fmt::Display for SessionMaterial {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "<redacted {} bytes>", self.0.len())
+    }
+}
+
+/// Connector-local map from identity `label` to its [`SessionMaterial`].
+///
+/// Held on [`ToolContext`](crate::tools::ToolContext) so any tool can resolve a
+/// `label` referenced by the LLM to the real auth material and inject it at
+/// execution time. Never serialized; the whole point is that it does not leave
+/// the connector.
+#[derive(Clone, Default)]
+pub struct IdentityStore {
+    by_label: HashMap<String, SessionMaterial>,
+}
+
+impl IdentityStore {
+    /// An empty store (no identities provisioned).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Build a store from `(label, material)` pairs. Later entries win on a
+    /// duplicate label.
+    pub fn from_pairs<I, L>(pairs: I) -> Self
+    where
+        I: IntoIterator<Item = (L, SessionMaterial)>,
+        L: Into<String>,
+    {
+        let by_label = pairs
+            .into_iter()
+            .map(|(label, material)| (label.into(), material))
+            .collect();
+        Self { by_label }
+    }
+
+    /// Insert or replace the material for `label`.
+    pub fn insert(&mut self, label: impl Into<String>, material: SessionMaterial) {
+        self.by_label.insert(label.into(), material);
+    }
+
+    /// Resolve a label referenced by the LLM to its session material.
+    ///
+    /// Returns `None` when the label is unknown (typo, or an identity that was
+    /// never provisioned) - callers must treat a miss as "cannot authenticate
+    /// as this identity" and fail loudly rather than silently running
+    /// unauthenticated, which would misreport an authz result.
+    pub fn resolve(&self, label: &str) -> Option<&SessionMaterial> {
+        self.by_label.get(label)
+    }
+
+    /// Number of provisioned identities.
+    pub fn len(&self) -> usize {
+        self.by_label.len()
+    }
+
+    /// Whether no identities have been provisioned.
+    pub fn is_empty(&self) -> bool {
+        self.by_label.is_empty()
+    }
+}
+
+/// The store never reveals its secrets through `Debug` - it reports only the
+/// set of known labels (non-sensitive) and a count, so it is safe to include in
+/// a `#[derive(Debug)]` parent (e.g. `ToolContext`).
+impl std::fmt::Debug for IdentityStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut labels: Vec<&str> = self.by_label.keys().map(String::as_str).collect();
+        labels.sort_unstable();
+        f.debug_struct("IdentityStore")
+            .field("labels", &labels)
+            .field("count", &self.by_label.len())
+            .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn session_material_redacts_in_debug_and_display() {
+        let secret = "super-secret-session-token";
+        let session = SessionMaterial::new(secret);
+
+        let debug = format!("{session:?}");
+        let display = format!("{session}");
+        assert!(
+            !debug.contains(secret),
+            "Debug must not leak the secret: {debug}"
+        );
+        assert!(
+            !display.contains(secret),
+            "Display must not leak the secret: {display}"
+        );
+        // Only the raw exposure path yields the value.
+        assert_eq!(session.expose(), secret);
+    }
+
+    #[test]
+    fn anonymous_identity_has_empty_material() {
+        let default = SessionMaterial::default();
+        assert!(default.is_empty());
+        assert_eq!(default.expose(), "");
+    }
+
+    #[test]
+    fn store_resolves_known_label() {
+        let store = IdentityStore::from_pairs([
+            ("user_a", SessionMaterial::new("Cookie: sid=aaa")),
+            ("admin", SessionMaterial::new("Authorization: Bearer zzz")),
+        ]);
+        assert_eq!(store.len(), 2);
+        assert_eq!(
+            store.resolve("admin").map(SessionMaterial::expose),
+            Some("Authorization: Bearer zzz")
+        );
+    }
+
+    #[test]
+    fn store_miss_returns_none_not_empty() {
+        // A miss must be distinguishable from "resolved to empty" so callers can
+        // fail loudly instead of silently replaying unauthenticated.
+        let store = IdentityStore::from_pairs([("user_a", SessionMaterial::new("Cookie: sid=a"))]);
+        assert!(store.resolve("nonexistent").is_none());
+    }
+
+    #[test]
+    fn insert_replaces_existing_label() {
+        let mut store = IdentityStore::new();
+        store.insert("user_a", SessionMaterial::new("old"));
+        store.insert("user_a", SessionMaterial::new("new"));
+        assert_eq!(store.len(), 1);
+        assert_eq!(
+            store.resolve("user_a").map(SessionMaterial::expose),
+            Some("new")
+        );
+    }
+
+    #[test]
+    fn store_debug_never_leaks_material_but_shows_labels() {
+        let store = IdentityStore::from_pairs([
+            ("user_a", SessionMaterial::new("secret-aaa")),
+            ("admin", SessionMaterial::new("secret-zzz")),
+        ]);
+        let debug = format!("{store:?}");
+        assert!(
+            !debug.contains("secret-aaa") && !debug.contains("secret-zzz"),
+            "Debug must not leak material: {debug}"
+        );
+        // Labels are non-sensitive and useful for diagnostics.
+        assert!(debug.contains("user_a") && debug.contains("admin"));
+    }
+}

--- a/crates/core/src/identity.rs
+++ b/crates/core/src/identity.rs
@@ -31,7 +31,49 @@
 //! Population is two-pathed: standalone (operator config/UI) ships now; the
 //! StrikeKit/Matrix provisioning path is pick#312.
 
+use crate::error::{Error, Result};
+use serde::Deserialize;
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use crate::specialist_spawner::{IdentityRole, TestIdentity};
+
+/// Environment variable naming the identities file, overriding the default
+/// location. Lets an operator (or `run-pentest.sh`) point at an engagement-
+/// specific file without touching the config dir.
+pub const IDENTITIES_FILE_ENV: &str = "PICK_IDENTITIES_FILE";
+
+/// One entry in the operator-provided identities file.
+///
+/// This DTO is the **one** boundary where session material legitimately enters
+/// the process from a persisted source: the file is operator-owned and
+/// gitignored (see `.gitignore` `.env*` / dedicated secrets convention). The
+/// raw `session` string is read here and immediately wrapped in the
+/// non-serializable [`SessionMaterial`]; it is never re-serialized.
+#[derive(Debug, Deserialize)]
+struct IdentityFileEntry {
+    label: String,
+    role: IdentityRole,
+    #[serde(default)]
+    tenant: Option<String>,
+    /// Raw session material (cookie/JWT/header bundle). Omitted/empty for an
+    /// anonymous identity.
+    #[serde(default)]
+    session: String,
+}
+
+/// Parsed identities file: the reference set (labels/roles/tenants) plus the
+/// connector-side store of their secrets.
+///
+/// Splitting the two is deliberate: `references` is safe to hand to the
+/// specialist context, `store` stays connector-local.
+#[derive(Debug, Default)]
+pub struct LoadedIdentities {
+    /// Reference set to place in [`SpecialistContext`](crate::specialist_spawner::SpecialistContext).
+    pub references: Vec<TestIdentity>,
+    /// Connector-local secret store.
+    pub store: IdentityStore,
+}
 
 /// Opaque session material (cookies, bearer token, or a raw header bundle) that
 /// authenticates a test identity when a specialist replays requests.
@@ -136,6 +178,68 @@ impl IdentityStore {
     }
 }
 
+/// Resolve the identities-file path: the [`IDENTITIES_FILE_ENV`] override if
+/// set, otherwise `identities.json` in the connector's config dir. The path is
+/// not required to exist - a missing file simply means no identities.
+pub fn identities_file_path() -> PathBuf {
+    if let Ok(p) = std::env::var(IDENTITIES_FILE_ENV) {
+        if !p.trim().is_empty() {
+            return PathBuf::from(p);
+        }
+    }
+    crate::settings::settings_dir().join("identities.json")
+}
+
+/// Load operator-provided identities from a JSON file.
+///
+/// A **missing** file is not an error - it yields empty [`LoadedIdentities`], so
+/// standalone runs without identities behave exactly as before. A file that
+/// exists but is malformed (bad JSON, unknown role) **fails loudly** rather than
+/// silently degrading to zero identities, which would misreport authz coverage.
+///
+/// The file schema is a JSON array of objects:
+/// `[{"label":"user_a","role":"user","tenant":null,"session":"Cookie: sid=..."}]`
+/// (`role` is one of `anonymous` | `user` | `privileged`; `tenant`/`session`
+/// optional). The file is operator-owned and must be gitignored - it holds real
+/// credentials.
+pub fn load_identities_from_file(path: &Path) -> Result<LoadedIdentities> {
+    let contents = match std::fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(LoadedIdentities::default());
+        }
+        Err(e) => {
+            return Err(Error::Config(format!(
+                "failed to read identities file {}: {e}",
+                path.display()
+            )));
+        }
+    };
+
+    let entries: Vec<IdentityFileEntry> = serde_json::from_str(&contents)
+        .map_err(|e| Error::Config(format!("malformed identities file {}: {e}", path.display())))?;
+
+    let mut references = Vec::with_capacity(entries.len());
+    let mut store = IdentityStore::new();
+    for entry in entries {
+        if !entry.session.is_empty() {
+            store.insert(entry.label.clone(), SessionMaterial::new(entry.session));
+        }
+        references.push(TestIdentity {
+            label: entry.label,
+            role: entry.role,
+            tenant: entry.tenant,
+        });
+    }
+
+    Ok(LoadedIdentities { references, store })
+}
+
+/// Convenience: load from the default [`identities_file_path`].
+pub fn load_default_identities() -> Result<LoadedIdentities> {
+    load_identities_from_file(&identities_file_path())
+}
+
 /// The store never reveals its secrets through `Debug` - it reports only the
 /// set of known labels (non-sensitive) and a count, so it is safe to include in
 /// a `#[derive(Debug)]` parent (e.g. `ToolContext`).
@@ -226,5 +330,87 @@ mod tests {
         );
         // Labels are non-sensitive and useful for diagnostics.
         assert!(debug.contains("user_a") && debug.contains("admin"));
+    }
+
+    // ---- file loader ----
+
+    fn write_temp(name: &str, contents: &str) -> PathBuf {
+        // Unique-per-name temp path; tests use distinct names so no clash.
+        let path = std::env::temp_dir().join(format!("pick-identities-test-{name}.json"));
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[test]
+    fn missing_file_yields_empty_not_error() {
+        let path = std::env::temp_dir().join("pick-identities-does-not-exist-xyz.json");
+        let _ = std::fs::remove_file(&path);
+        let loaded = load_identities_from_file(&path).expect("missing file is not an error");
+        assert!(loaded.references.is_empty());
+        assert!(loaded.store.is_empty());
+    }
+
+    #[test]
+    fn valid_file_splits_references_from_secrets() {
+        let path = write_temp(
+            "valid",
+            r#"[
+                {"label":"unauth","role":"anonymous"},
+                {"label":"user_a","role":"user","tenant":"t1","session":"Cookie: sid=aaa"},
+                {"label":"admin","role":"privileged","session":"Authorization: Bearer zzz"}
+            ]"#,
+        );
+        let loaded = load_identities_from_file(&path).expect("valid file loads");
+
+        // References carry no secret and include all three identities.
+        assert_eq!(loaded.references.len(), 3);
+        let admin = loaded
+            .references
+            .iter()
+            .find(|r| r.label == "admin")
+            .unwrap();
+        assert_eq!(admin.role, IdentityRole::Privileged);
+
+        // The store holds only the two with session material.
+        assert_eq!(loaded.store.len(), 2);
+        assert_eq!(
+            loaded.store.resolve("user_a").map(SessionMaterial::expose),
+            Some("Cookie: sid=aaa")
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn anonymous_entry_has_reference_but_no_store_slot() {
+        let path = write_temp("anon", r#"[{"label":"unauth","role":"anonymous"}]"#);
+        let loaded = load_identities_from_file(&path).expect("loads");
+        assert_eq!(loaded.references.len(), 1);
+        assert!(
+            loaded.store.resolve("unauth").is_none(),
+            "anonymous identity carries no session material"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn malformed_file_fails_loudly() {
+        let path = write_temp("malformed", r#"{ not an array"#);
+        let err = load_identities_from_file(&path).expect_err("malformed file must error");
+        assert!(
+            err.to_string().contains("malformed identities file"),
+            "unexpected error: {err}"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn unknown_role_fails_loudly_not_silently_dropped() {
+        let path = write_temp(
+            "badrole",
+            r#"[{"label":"x","role":"superuser","session":"s"}]"#,
+        );
+        let err = load_identities_from_file(&path).expect_err("unknown role must error");
+        assert!(err.to_string().contains("malformed identities file"));
+        std::fs::remove_file(&path).ok();
     }
 }

--- a/crates/core/src/identity.rs
+++ b/crates/core/src/identity.rs
@@ -182,12 +182,40 @@ impl IdentityStore {
 /// set, otherwise `identities.json` in the connector's config dir. The path is
 /// not required to exist - a missing file simply means no identities.
 pub fn identities_file_path() -> PathBuf {
-    if let Ok(p) = std::env::var(IDENTITIES_FILE_ENV) {
+    let env_override = std::env::var(IDENTITIES_FILE_ENV).ok();
+    let cwd_candidate = PathBuf::from("identities.json");
+    let cwd_present = cwd_candidate.is_file();
+    resolve_identities_path(
+        env_override.as_deref(),
+        cwd_present,
+        cwd_candidate,
+        crate::settings::settings_dir().join("identities.json"),
+    )
+}
+
+/// Pure resolution logic for [`identities_file_path`], split out so the
+/// precedence rules are testable without mutating process-global cwd/env.
+///
+/// Precedence: explicit `PICK_IDENTITIES_FILE` (if non-blank) > a cwd
+/// `identities.json` that exists > the per-user settings-dir path. Preferring
+/// the cwd file when present is what makes the natural "copy the template and
+/// edit it in place" workflow load, and aligns the loaded path with the one the
+/// repo `.gitignore` protects (#317 H3).
+fn resolve_identities_path(
+    env_override: Option<&str>,
+    cwd_present: bool,
+    cwd_path: PathBuf,
+    settings_path: PathBuf,
+) -> PathBuf {
+    if let Some(p) = env_override {
         if !p.trim().is_empty() {
             return PathBuf::from(p);
         }
     }
-    crate::settings::settings_dir().join("identities.json")
+    if cwd_present {
+        return cwd_path;
+    }
+    settings_path
 }
 
 /// Load operator-provided identities from a JSON file.
@@ -222,9 +250,14 @@ pub fn load_identities_from_file(path: &Path) -> Result<LoadedIdentities> {
     let mut references = Vec::with_capacity(entries.len());
     let mut store = IdentityStore::new();
     for entry in entries {
-        if !entry.session.is_empty() {
-            store.insert(entry.label.clone(), SessionMaterial::new(entry.session));
-        }
+        // Every provisioned label gets a store slot - anonymous identities with
+        // an empty `session` get an empty [`SessionMaterial`]. This keeps a
+        // resolvable-but-empty identity distinct from an unknown label: the
+        // former injects nothing and runs (that IS the anonymous identity), the
+        // latter still misses and fails loud. Skipping empty entries here made
+        // the LLM-instructed `identity_ref: "unauth"` unreachable (it resolved
+        // to `None` and errored "not a provisioned test identity").
+        store.insert(entry.label.clone(), SessionMaterial::new(entry.session));
         references.push(TestIdentity {
             label: entry.label,
             role: entry.role,
@@ -397,25 +430,91 @@ mod tests {
             .unwrap();
         assert_eq!(admin.role, IdentityRole::Privileged);
 
-        // The store holds only the two with session material.
-        assert_eq!(loaded.store.len(), 2);
+        // Every label gets a store slot; anonymous resolves to empty material.
+        assert_eq!(loaded.store.len(), 3);
         assert_eq!(
             loaded.store.resolve("user_a").map(SessionMaterial::expose),
             Some("Cookie: sid=aaa")
+        );
+        assert_eq!(
+            loaded
+                .store
+                .resolve("unauth")
+                .map(SessionMaterial::is_empty),
+            Some(true),
+            "anonymous identity resolves to empty material, not a miss"
         );
         std::fs::remove_file(&path).ok();
     }
 
     #[test]
-    fn anonymous_entry_has_reference_but_no_store_slot() {
+    fn anonymous_entry_resolves_to_empty_material_not_a_miss() {
+        // Regression for #317 H1: the LLM emits `identity_ref: "unauth"` (both
+        // specialist prompts instruct it). A provisioned anonymous identity must
+        // resolve to Some(empty) so the injection fast-path injects nothing and
+        // runs - NOT `None`, which the tool treats as "unprovisioned" and errors.
         let path = write_temp("anon", r#"[{"label":"unauth","role":"anonymous"}]"#);
         let loaded = load_identities_from_file(&path).expect("loads");
         assert_eq!(loaded.references.len(), 1);
+        let material = loaded
+            .store
+            .resolve("unauth")
+            .expect("anonymous identity is provisioned in the store");
         assert!(
-            loaded.store.resolve("unauth").is_none(),
+            material.is_empty(),
             "anonymous identity carries no session material"
         );
+        // An unprovisioned label still misses - fail-loud path is intact.
+        assert!(loaded.store.resolve("never-provisioned").is_none());
         std::fs::remove_file(&path).ok();
+    }
+
+    // ---- path resolution (#317 H3) ----
+
+    #[test]
+    fn path_prefers_env_override_when_set() {
+        let got = resolve_identities_path(
+            Some("/explicit/override.json"),
+            true, // cwd file present - env must still win
+            PathBuf::from("identities.json"),
+            PathBuf::from("/settings/identities.json"),
+        );
+        assert_eq!(got, PathBuf::from("/explicit/override.json"));
+    }
+
+    #[test]
+    fn path_ignores_blank_env_override() {
+        let got = resolve_identities_path(
+            Some("   "),
+            false,
+            PathBuf::from("identities.json"),
+            PathBuf::from("/settings/identities.json"),
+        );
+        assert_eq!(got, PathBuf::from("/settings/identities.json"));
+    }
+
+    #[test]
+    fn path_prefers_cwd_file_over_settings_dir() {
+        // #317 H3: a cwd `identities.json` (the gitignore-protected path) must be
+        // loaded in preference to the settings-dir path when it exists.
+        let got = resolve_identities_path(
+            None,
+            true,
+            PathBuf::from("identities.json"),
+            PathBuf::from("/settings/identities.json"),
+        );
+        assert_eq!(got, PathBuf::from("identities.json"));
+    }
+
+    #[test]
+    fn path_falls_back_to_settings_dir_without_cwd_file() {
+        let got = resolve_identities_path(
+            None,
+            false,
+            PathBuf::from("identities.json"),
+            PathBuf::from("/settings/identities.json"),
+        );
+        assert_eq!(got, PathBuf::from("/settings/identities.json"));
     }
 
     #[test]

--- a/crates/core/src/identity.rs
+++ b/crates/core/src/identity.rs
@@ -121,7 +121,36 @@ impl std::fmt::Display for SessionMaterial {
     }
 }
 
-/// Connector-local map from identity `label` to its [`SessionMaterial`].
+/// A provisioned identity as held connector-side: its declared
+/// [`IdentityRole`] plus the [`SessionMaterial`] that authenticates it.
+///
+/// The role travels *with* the secret so the injection path can tell an
+/// anonymous identity (empty material *by design*) apart from a mis-provisioned
+/// privileged one (empty material *by mistake*). The latter must fail loud
+/// rather than run unauthenticated under a privileged label, which would
+/// misreport a differential-authz result (#317 review #1).
+#[derive(Clone, Debug)]
+pub struct StoredIdentity {
+    role: IdentityRole,
+    material: SessionMaterial,
+}
+
+impl StoredIdentity {
+    /// The identity's declared privilege role.
+    pub fn role(&self) -> IdentityRole {
+        self.role
+    }
+
+    /// The authenticating session material. Anonymous identities carry empty
+    /// material by design; every other role is guaranteed non-empty by the
+    /// loader and store constructors.
+    pub fn material(&self) -> &SessionMaterial {
+        &self.material
+    }
+}
+
+/// Connector-local map from identity `label` to its [`StoredIdentity`]
+/// (role + secret).
 ///
 /// Held on [`ToolContext`](crate::tools::ToolContext) so any tool can resolve a
 /// `label` referenced by the LLM to the real auth material and inject it at
@@ -129,7 +158,7 @@ impl std::fmt::Display for SessionMaterial {
 /// the connector.
 #[derive(Clone, Default)]
 pub struct IdentityStore {
-    by_label: HashMap<String, SessionMaterial>,
+    by_label: HashMap<String, StoredIdentity>,
 }
 
 impl IdentityStore {
@@ -138,32 +167,39 @@ impl IdentityStore {
         Self::default()
     }
 
-    /// Build a store from `(label, material)` pairs. Later entries win on a
-    /// duplicate label.
-    pub fn from_pairs<I, L>(pairs: I) -> Self
+    /// Build a store from `(label, role, material)` triples. Later entries win
+    /// on a duplicate label.
+    pub fn from_pairs<I, L>(entries: I) -> Self
     where
-        I: IntoIterator<Item = (L, SessionMaterial)>,
+        I: IntoIterator<Item = (L, IdentityRole, SessionMaterial)>,
         L: Into<String>,
     {
-        let by_label = pairs
+        let by_label = entries
             .into_iter()
-            .map(|(label, material)| (label.into(), material))
+            .map(|(label, role, material)| (label.into(), StoredIdentity { role, material }))
             .collect();
         Self { by_label }
     }
 
-    /// Insert or replace the material for `label`.
-    pub fn insert(&mut self, label: impl Into<String>, material: SessionMaterial) {
-        self.by_label.insert(label.into(), material);
+    /// Insert or replace the entry for `label`.
+    pub fn insert(
+        &mut self,
+        label: impl Into<String>,
+        role: IdentityRole,
+        material: SessionMaterial,
+    ) {
+        self.by_label
+            .insert(label.into(), StoredIdentity { role, material });
     }
 
-    /// Resolve a label referenced by the LLM to its session material.
+    /// Resolve a label referenced by the LLM to its stored identity (role +
+    /// material).
     ///
     /// Returns `None` when the label is unknown (typo, or an identity that was
     /// never provisioned) - callers must treat a miss as "cannot authenticate
     /// as this identity" and fail loudly rather than silently running
     /// unauthenticated, which would misreport an authz result.
-    pub fn resolve(&self, label: &str) -> Option<&SessionMaterial> {
+    pub fn resolve(&self, label: &str) -> Option<&StoredIdentity> {
         self.by_label.get(label)
     }
 
@@ -250,6 +286,23 @@ pub fn load_identities_from_file(path: &Path) -> Result<LoadedIdentities> {
     let mut references = Vec::with_capacity(entries.len());
     let mut store = IdentityStore::new();
     for entry in entries {
+        // A non-anonymous identity with no session material would run
+        // unauthenticated yet be attributed to its privileged label downstream
+        // - a false "endpoint reachable as <role>" finding, the worst
+        // differential-authz failure mode. Refuse it at the source (#317
+        // review #1): an anonymous identity carries no credential by design;
+        // any other role must supply one.
+        if entry.role != IdentityRole::Anonymous && entry.session.is_empty() {
+            return Err(Error::Config(format!(
+                "identities file {}: identity {:?} declares role {:?} but carries no \
+                 session material; a non-anonymous identity must supply a credential \
+                 (refusing to load it, which would misreport authz coverage)",
+                path.display(),
+                entry.label,
+                entry.role
+            )));
+        }
+
         // Every provisioned label gets a store slot - anonymous identities with
         // an empty `session` get an empty [`SessionMaterial`]. This keeps a
         // resolvable-but-empty identity distinct from an unknown label: the
@@ -257,7 +310,11 @@ pub fn load_identities_from_file(path: &Path) -> Result<LoadedIdentities> {
         // latter still misses and fails loud. Skipping empty entries here made
         // the LLM-instructed `identity_ref: "unauth"` unreachable (it resolved
         // to `None` and errored "not a provisioned test identity").
-        store.insert(entry.label.clone(), SessionMaterial::new(entry.session));
+        store.insert(
+            entry.label.clone(),
+            entry.role,
+            SessionMaterial::new(entry.session),
+        );
         references.push(TestIdentity {
             label: entry.label,
             role: entry.role,
@@ -346,12 +403,20 @@ mod tests {
     #[test]
     fn store_resolves_known_label() {
         let store = IdentityStore::from_pairs([
-            ("user_a", SessionMaterial::new("Cookie: sid=aaa")),
-            ("admin", SessionMaterial::new("Authorization: Bearer zzz")),
+            (
+                "user_a",
+                IdentityRole::User,
+                SessionMaterial::new("Cookie: sid=aaa"),
+            ),
+            (
+                "admin",
+                IdentityRole::Privileged,
+                SessionMaterial::new("Authorization: Bearer zzz"),
+            ),
         ]);
         assert_eq!(store.len(), 2);
         assert_eq!(
-            store.resolve("admin").map(SessionMaterial::expose),
+            store.resolve("admin").map(|s| s.material().expose()),
             Some("Authorization: Bearer zzz")
         );
     }
@@ -360,18 +425,22 @@ mod tests {
     fn store_miss_returns_none_not_empty() {
         // A miss must be distinguishable from "resolved to empty" so callers can
         // fail loudly instead of silently replaying unauthenticated.
-        let store = IdentityStore::from_pairs([("user_a", SessionMaterial::new("Cookie: sid=a"))]);
+        let store = IdentityStore::from_pairs([(
+            "user_a",
+            IdentityRole::User,
+            SessionMaterial::new("Cookie: sid=a"),
+        )]);
         assert!(store.resolve("nonexistent").is_none());
     }
 
     #[test]
     fn insert_replaces_existing_label() {
         let mut store = IdentityStore::new();
-        store.insert("user_a", SessionMaterial::new("old"));
-        store.insert("user_a", SessionMaterial::new("new"));
+        store.insert("user_a", IdentityRole::User, SessionMaterial::new("old"));
+        store.insert("user_a", IdentityRole::User, SessionMaterial::new("new"));
         assert_eq!(store.len(), 1);
         assert_eq!(
-            store.resolve("user_a").map(SessionMaterial::expose),
+            store.resolve("user_a").map(|s| s.material().expose()),
             Some("new")
         );
     }
@@ -379,8 +448,16 @@ mod tests {
     #[test]
     fn store_debug_never_leaks_material_but_shows_labels() {
         let store = IdentityStore::from_pairs([
-            ("user_a", SessionMaterial::new("secret-aaa")),
-            ("admin", SessionMaterial::new("secret-zzz")),
+            (
+                "user_a",
+                IdentityRole::User,
+                SessionMaterial::new("secret-aaa"),
+            ),
+            (
+                "admin",
+                IdentityRole::Privileged,
+                SessionMaterial::new("secret-zzz"),
+            ),
         ]);
         let debug = format!("{store:?}");
         assert!(
@@ -433,14 +510,17 @@ mod tests {
         // Every label gets a store slot; anonymous resolves to empty material.
         assert_eq!(loaded.store.len(), 3);
         assert_eq!(
-            loaded.store.resolve("user_a").map(SessionMaterial::expose),
+            loaded
+                .store
+                .resolve("user_a")
+                .map(|s| s.material().expose()),
             Some("Cookie: sid=aaa")
         );
         assert_eq!(
             loaded
                 .store
                 .resolve("unauth")
-                .map(SessionMaterial::is_empty),
+                .map(|s| s.material().is_empty()),
             Some(true),
             "anonymous identity resolves to empty material, not a miss"
         );
@@ -456,12 +536,13 @@ mod tests {
         let path = write_temp("anon", r#"[{"label":"unauth","role":"anonymous"}]"#);
         let loaded = load_identities_from_file(&path).expect("loads");
         assert_eq!(loaded.references.len(), 1);
-        let material = loaded
+        let resolved = loaded
             .store
             .resolve("unauth")
             .expect("anonymous identity is provisioned in the store");
+        assert_eq!(resolved.role(), IdentityRole::Anonymous);
         assert!(
-            material.is_empty(),
+            resolved.material().is_empty(),
             "anonymous identity carries no session material"
         );
         // An unprovisioned label still misses - fail-loud path is intact.
@@ -525,6 +606,40 @@ mod tests {
             err.to_string().contains("malformed identities file"),
             "unexpected error: {err}"
         );
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn privileged_identity_without_session_fails_loudly() {
+        // #317 review #1 (CRITICAL): a non-anonymous identity with no session
+        // material would run unauthenticated yet be reported under its
+        // privileged label - a false "reachable as admin" finding. The loader
+        // must refuse it rather than store a resolvable-but-empty privileged
+        // identity.
+        let path = write_temp(
+            "priv-no-session",
+            r#"[{"label":"admin","role":"privileged"}]"#,
+        );
+        let err = load_identities_from_file(&path)
+            .expect_err("privileged identity with no session must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("must supply a credential") && msg.contains("admin"),
+            "unexpected error: {msg}"
+        );
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn user_identity_with_empty_session_string_fails_loudly() {
+        // The empty-string form is the same defect as an omitted session.
+        let path = write_temp(
+            "user-empty-session",
+            r#"[{"label":"u","role":"user","session":""}]"#,
+        );
+        let err = load_identities_from_file(&path)
+            .expect_err("user identity with empty session must error");
+        assert!(err.to_string().contains("must supply a credential"));
         std::fs::remove_file(&path).ok();
     }
 

--- a/crates/core/src/identity.rs
+++ b/crates/core/src/identity.rs
@@ -240,6 +240,32 @@ pub fn load_default_identities() -> Result<LoadedIdentities> {
     load_identities_from_file(&identities_file_path())
 }
 
+/// SDK `InstanceMetadata` key under which the connector advertises available
+/// test-identity *references* to the Matrix Red Team orchestrator (matrix#3354).
+///
+/// Mirrors the `host_interfaces` self-exclusion metadata (matrix#2274): the
+/// connector reports a connector-side fact the orchestrator reads to shape its
+/// reasoning - here, which identities exist so it can pass them to
+/// `spawn_specialist`. Only references (label/role/tenant) travel; the session
+/// material never leaves the connector.
+pub const IDENTITIES_METADATA_KEY: &str = "authz_identities";
+
+/// Serialize identity *references* for the SDK metadata value (matrix#3354).
+///
+/// Emits a JSON array of `{label, role, tenant}` - the same non-secret shape
+/// `TestIdentity` serializes to. There is no session material here by
+/// construction: `TestIdentity` carries none (the secret lives in the
+/// [`IdentityStore`]). Returns `None` when there are no references, so the
+/// caller can skip inserting an empty key.
+pub fn references_metadata_value(references: &[TestIdentity]) -> Option<String> {
+    if references.is_empty() {
+        return None;
+    }
+    // TestIdentity serialization is infallible for these fields; fall back to
+    // skipping the key rather than failing startup on the unreachable error.
+    serde_json::to_string(references).ok()
+}
+
 /// The store never reveals its secrets through `Debug` - it reports only the
 /// set of known labels (non-sensitive) and a count, so it is safe to include in
 /// a `#[derive(Debug)]` parent (e.g. `ToolContext`).
@@ -411,6 +437,38 @@ mod tests {
         );
         let err = load_identities_from_file(&path).expect_err("unknown role must error");
         assert!(err.to_string().contains("malformed identities file"));
+        std::fs::remove_file(&path).ok();
+    }
+
+    // ---- metadata advertisement (matrix#3354) ----
+
+    #[test]
+    fn references_metadata_is_none_when_empty() {
+        assert!(references_metadata_value(&[]).is_none());
+    }
+
+    #[test]
+    fn references_metadata_carries_refs_but_no_secret() {
+        // The metadata value advertised to the orchestrator must contain the
+        // labels/roles but never any session material - the file loader put the
+        // secret in the store, not the references, and this proves it stays out
+        // of the metadata surface too.
+        let path = write_temp(
+            "meta",
+            r#"[
+                {"label":"user_a","role":"user","session":"Cookie: sid=SECRET-DO-NOT-LEAK"},
+                {"label":"admin","role":"privileged","session":"Bearer SECRET-TOKEN"}
+            ]"#,
+        );
+        let loaded = load_identities_from_file(&path).expect("loads");
+        let value = references_metadata_value(&loaded.references).expect("some");
+
+        assert!(value.contains("user_a") && value.contains("admin"));
+        assert!(value.contains("privileged"));
+        assert!(
+            !value.contains("SECRET-DO-NOT-LEAK") && !value.contains("SECRET-TOKEN"),
+            "metadata value leaked session material: {value}"
+        );
         std::fs::remove_file(&path).ok();
     }
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod error;
 pub mod evidence;
 pub mod export;
 pub mod file_browser;
+pub mod identity;
 pub mod jwt_validator;
 pub mod logging;
 pub mod matrix;
@@ -41,6 +42,7 @@ pub mod prelude {
     pub use crate::export::{
         EvidenceFile, Finding, SessionExport, SessionMetadata, Severity, ToolExecution,
     };
+    pub use crate::identity::{IdentityStore, SessionMaterial};
     pub use crate::orchestrator::{
         build_pending_evidence_manifest, build_report_agent_seed_message,
         build_validator_seed_message, gate_for_report, parse_validator_verdicts, EngagementInfo,
@@ -54,7 +56,8 @@ pub mod prelude {
     };
     pub use crate::settings::{load_settings, save_settings};
     pub use crate::specialist_spawner::{
-        AttackSurface, SpawnDecision, SpecialistContext, SpecialistSpawner, SpecialistType,
+        AttackSurface, IdentityRole, SpawnDecision, SpecialistContext, SpecialistSpawner,
+        SpecialistType, TestIdentity,
     };
     pub use crate::state::ConnectorStatus;
     pub use crate::terminal::{LogLevel, TerminalLine};

--- a/crates/core/src/orchestrator.rs
+++ b/crates/core/src/orchestrator.rs
@@ -832,7 +832,27 @@ mod tests {
         let end = msg.rfind("\n```").unwrap();
         let json = &msg[start..end];
         let back: ValidatedFindingsManifest = serde_json::from_str(json).unwrap();
-        assert_eq!(back, manifest);
+        // The raw `provenance.command` is intentionally not serialized (#317
+        // review) — it can carry an injected credential — so a full struct
+        // equality would trip on the field coming back empty. Assert the
+        // wire-facing contract the Report Agent actually relies on instead: the
+        // manifest deserializes and every finding survives with its redacted
+        // provenance intact.
+        assert_eq!(back.findings.len(), manifest.findings.len());
+        for (b, m) in back.findings.iter().zip(manifest.findings.iter()) {
+            assert_eq!(b.id, m.id);
+            assert_eq!(b.current_severity, m.current_severity);
+            assert_eq!(b.validation_status, m.validation_status);
+            assert_eq!(
+                b.provenance
+                    .as_ref()
+                    .map(|p| p.probe_commands[0].effective_command.as_str()),
+                m.provenance
+                    .as_ref()
+                    .map(|p| p.probe_commands[0].effective_command.as_str()),
+                "redacted effective_command must survive the round-trip"
+            );
+        }
     }
 
     // --- Validator seed + verdict parsing (pick#174 seams 2 & 3) ---

--- a/crates/core/src/provenance.rs
+++ b/crates/core/src/provenance.rs
@@ -18,7 +18,15 @@ const TRUNCATION_MARKER: &str = "\n…[truncated]";
 /// A single probe step with both an exact and a report-safe command form.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ProbeCommand {
-    /// Exact command as executed. May contain secrets; internal use only.
+    /// Exact command as executed. May contain secrets (e.g. an injected
+    /// `Authorization: Bearer <token>` from a differential-authz identity run,
+    /// or `curl -u user:pass`), so it is **never serialized** — `skip_serializing`
+    /// keeps it off every wire/agent/report boundary by construction, not by
+    /// best-effort scrubbing. `effective_command` is the redacted form that does
+    /// cross the boundary. `default` lets a value deserialized from the wire
+    /// (where the field is absent) round-trip to an empty string rather than
+    /// failing. See pick#162 / #317 review.
+    #[serde(skip_serializing, default)]
     pub command: String,
 
     /// Redacted form safe to publish in reports.
@@ -350,6 +358,34 @@ mod tests {
         let p = ProbeCommand::from_exact("curl -u admin:hunter2 https://x.example.com");
         assert_eq!(p.command, "curl -u admin:hunter2 https://x.example.com");
         assert!(!p.effective_command.contains("hunter2"));
+    }
+
+    #[test]
+    fn probe_command_raw_command_never_serializes() {
+        // #317 review CRITICAL: the raw `command` can carry an injected
+        // credential (e.g. `-H "Authorization: Bearer <token>"` from a
+        // differential-authz identity run). It must never cross the wire; only
+        // the redacted `effective_command` may. Guards the leak by construction
+        // — removing `#[serde(skip_serializing)]` on `command` turns this red.
+        let secret = "Bearer sk-super-secret-token-abcdef1234567890";
+        let raw = format!(r#"curl -H "Authorization: {secret}" https://target.example"#);
+        let p = ProbeCommand::from_exact(&raw);
+
+        // In memory the exact command is retained for local traceability.
+        assert!(p.command.contains(secret), "in-memory command retained");
+
+        // On the wire it must be gone: no `command` key, and the secret must not
+        // appear anywhere in the serialized form (effective_command is redacted).
+        let wire = serde_json::to_value(&p).expect("serialize");
+        assert!(
+            wire.get("command").is_none(),
+            "raw command must not serialize: {wire}"
+        );
+        let wire_str = serde_json::to_string(&p).expect("serialize");
+        assert!(
+            !wire_str.contains("sk-super-secret-token-abcdef1234567890"),
+            "secret leaked onto the wire: {wire_str}"
+        );
     }
 
     #[test]

--- a/crates/core/src/provenance.rs
+++ b/crates/core/src/provenance.rs
@@ -67,15 +67,22 @@ impl ProbeCommand {
 
         // Exact-substring scrub of the known secret first; then the regex pass
         // catches anything else (user-supplied creds in the same command line).
-        let pre_scrubbed = if secret.is_empty() {
-            command.clone()
-        } else {
-            command.replace(secret, REDACTION)
-        };
+        let effective_command = redact(&redact_known_secret(&command, secret));
+
+        // Canary: the by-value scrub silently no-ops if the secret does not
+        // appear verbatim in `command` (e.g. the caller escaped an embedded `"`
+        // while quoting the arg), leaving only the best-effort regex pass to
+        // catch it. Trip loudly in debug/test builds so a future divergence
+        // surfaces here instead of leaking to a report (#317 review, LOW).
+        debug_assert!(
+            secret.is_empty() || !effective_command.contains(secret),
+            "known-secret value scrub degraded to pattern-only: the injected \
+             secret survived verbatim into effective_command"
+        );
 
         Self {
             command,
-            effective_command: redact(&pre_scrubbed),
+            effective_command,
             description: None,
         }
     }
@@ -205,6 +212,24 @@ fn redact_regexes() -> &'static RedactRegexes {
 }
 
 const REDACTION: &str = "<REDACTED>";
+
+/// Scrub a *known* secret value from `text` by exact substring, replacing it
+/// with the same [`REDACTION`] marker [`redact`] uses. An empty `secret` is a
+/// no-op.
+///
+/// This is the by-value counterpart to [`redact`]'s pattern matching: use it
+/// wherever the exact injected credential is known — differential-authz
+/// identity runs (#317) — so an odd-shaped header value that no regex catches
+/// (`X-Api-Id: ab12cd`) is still removed before the text crosses a boundary.
+/// Unlike a command line, raw process output (`stdout`/`stderr`) is unescaped,
+/// so an exact match here is complete, not best-effort.
+pub fn redact_known_secret(text: &str, secret: &str) -> String {
+    if secret.is_empty() {
+        text.to_string()
+    } else {
+        text.replace(secret, REDACTION)
+    }
+}
 
 /// Scrub likely secrets from an exact command so it is safe to publish.
 ///
@@ -472,6 +497,26 @@ mod tests {
         // blank the whole command (empty substring replace) — it just pattern-redacts.
         let pc = ProbeCommand::from_exact_redacting_secret("curl https://x.test", "");
         assert_eq!(pc.effective_command, "curl https://x.test");
+    }
+
+    #[test]
+    fn redact_known_secret_scrubs_exact_value_and_no_ops_on_empty() {
+        // The shared by-value scrub (used for both effective_command and, at the
+        // tool layer, stdout/stderr). Removes the exact value regardless of shape;
+        // an empty secret is a no-op (never a corrupting empty-substring replace).
+        let secret = "X-Api-Id: ab12cd";
+        let scrubbed = redact_known_secret(&format!("reflected: {secret} end"), secret);
+        assert!(
+            !scrubbed.contains("ab12cd"),
+            "value not scrubbed: {scrubbed}"
+        );
+        assert!(scrubbed.contains(REDACTION));
+
+        assert_eq!(
+            redact_known_secret("nothing to hide", ""),
+            "nothing to hide",
+            "empty secret must be a no-op"
+        );
     }
 
     #[test]

--- a/crates/core/src/provenance.rs
+++ b/crates/core/src/provenance.rs
@@ -53,6 +53,33 @@ impl ProbeCommand {
         }
     }
 
+    /// Build a `ProbeCommand` when a specific secret value is *known* to be
+    /// present in the command (e.g. an injected differential-authz identity
+    /// header). The known secret is scrubbed by exact substring BEFORE the
+    /// pattern-based [`redact`] runs, so `effective_command` is safe regardless
+    /// of the secret's shape — closing the gap where a short, non-hex, oddly
+    /// named header value (`-H "X-Api-Id: ab12cd"`) would slip past every regex
+    /// and land verbatim in a customer-facing report (#317 review, Lens 10b:
+    /// security-by-construction over best-effort scrubbing). `command` (the
+    /// exact form) is retained in the struct but is never serialized.
+    pub fn from_exact_redacting_secret(command: impl Into<String>, secret: &str) -> Self {
+        let command = command.into();
+
+        // Exact-substring scrub of the known secret first; then the regex pass
+        // catches anything else (user-supplied creds in the same command line).
+        let pre_scrubbed = if secret.is_empty() {
+            command.clone()
+        } else {
+            command.replace(secret, REDACTION)
+        };
+
+        Self {
+            command,
+            effective_command: redact(&pre_scrubbed),
+            description: None,
+        }
+    }
+
     /// Attach a one-line purpose description.
     pub fn with_description(mut self, description: impl Into<String>) -> Self {
         self.description = Some(description.into());
@@ -413,6 +440,58 @@ mod tests {
         let back2: ProbeCommand = serde_json::from_str(current).expect("current wire deserializes");
         assert_eq!(back2.command, "");
         assert_eq!(back2.effective_command, "nmap -sV 10.0.0.1");
+    }
+
+    #[test]
+    fn from_exact_redacting_secret_scrubs_arbitrary_shape_by_value() {
+        // #317 review #3: a known secret is scrubbed by exact substring BEFORE
+        // pattern redaction, so it never lands in effective_command even when its
+        // shape defeats every regex (short, non-hex, non-keyword header value).
+        let secret = "X-Api-Id: ab12cd";
+        let cmd = format!(r#"curl -H "{secret}" https://x.test"#);
+
+        // Precondition: pattern redaction alone does not catch this shape.
+        assert!(redact(&cmd).contains("ab12cd"));
+
+        let pc = ProbeCommand::from_exact_redacting_secret(cmd, secret);
+        assert!(
+            !pc.effective_command.contains("ab12cd"),
+            "known secret leaked: {}",
+            pc.effective_command
+        );
+        assert!(pc.effective_command.contains(REDACTION));
+        assert!(
+            pc.command.contains("ab12cd"),
+            "exact form retained in-memory"
+        );
+    }
+
+    #[test]
+    fn from_exact_redacting_empty_secret_falls_back_to_pattern_only() {
+        // An anonymous identity injects no secret; the empty-secret path must not
+        // blank the whole command (empty substring replace) — it just pattern-redacts.
+        let pc = ProbeCommand::from_exact_redacting_secret("curl https://x.test", "");
+        assert_eq!(pc.effective_command, "curl https://x.test");
+    }
+
+    #[test]
+    fn identity_attribution_description_survives_the_wire() {
+        // #317 review #6: the identity label reaches serialized provenance via the
+        // description, so a reviewer can attribute the response to a principal even
+        // though the raw command (which carried the injected header) is not serialized.
+        let pc = ProbeCommand::from_exact_redacting_secret(
+            r#"curl -H "Cookie: sid=secret" https://x.test"#,
+            "Cookie: sid=secret",
+        )
+        .with_description("authenticated as test identity: user_a");
+        let p = Provenance::new("shell", "test", pc, "");
+
+        let wire = serde_json::to_string(&p).expect("serialize");
+        assert!(wire.contains("authenticated as test identity: user_a"));
+        assert!(
+            !wire.contains("sid=secret"),
+            "secret leaked on the wire: {wire}"
+        );
     }
 
     #[test]

--- a/crates/core/src/provenance.rs
+++ b/crates/core/src/provenance.rs
@@ -24,8 +24,11 @@ pub struct ProbeCommand {
     /// keeps it off every wire/agent/report boundary by construction, not by
     /// best-effort scrubbing. `effective_command` is the redacted form that does
     /// cross the boundary. `default` lets a value deserialized from the wire
-    /// (where the field is absent) round-trip to an empty string rather than
-    /// failing. See pick#162 / #317 review.
+    /// (where the field is now absent) round-trip to an empty string rather than
+    /// failing. Back-compat: evidence files persisted *before* this field became
+    /// `skip_serializing` still carry a `command` key and deserialize cleanly
+    /// (serde reads it, and only downstream `effective_command` is consumed), so
+    /// no schema-version bump or migration is required. See pick#162 / #317 review.
     #[serde(skip_serializing, default)]
     pub command: String,
 
@@ -386,6 +389,30 @@ mod tests {
             !wire_str.contains("sk-super-secret-token-abcdef1234567890"),
             "secret leaked onto the wire: {wire_str}"
         );
+    }
+
+    #[test]
+    fn probe_command_deserializes_legacy_wire_with_command_present() {
+        // #317 H2 back-compat: `command` gained `#[serde(skip_serializing,
+        // default)]`, so evidence files persisted BEFORE this change still carry
+        // a `command` key. They must deserialize cleanly (serde consumes the key
+        // via the field, applying `default` only when absent) — never error on a
+        // replayed old-format file. The redacted `effective_command` is what
+        // downstream reads, and it survives regardless.
+        let legacy = r#"{
+            "command": "curl -H \"Authorization: Bearer old-secret\" https://x.example",
+            "effective_command": "curl -H \"Authorization: <REDACTED>\" https://x.example"
+        }"#;
+        let back: ProbeCommand = serde_json::from_str(legacy).expect("legacy wire deserializes");
+        assert_eq!(
+            back.effective_command,
+            r#"curl -H "Authorization: <REDACTED>" https://x.example"#
+        );
+        // A new-format file (no `command` key) also deserializes, defaulting to "".
+        let current = r#"{"effective_command":"nmap -sV 10.0.0.1"}"#;
+        let back2: ProbeCommand = serde_json::from_str(current).expect("current wire deserializes");
+        assert_eq!(back2.command, "");
+        assert_eq!(back2.effective_command, "nmap -sV 10.0.0.1");
     }
 
     #[test]

--- a/crates/core/src/specialist_spawner.rs
+++ b/crates/core/src/specialist_spawner.rs
@@ -335,6 +335,57 @@ impl std::fmt::Display for SpecialistType {
     }
 }
 
+/// Privilege tier of a [`TestIdentity`] in the differential authorization matrix
+/// (pick#162).
+///
+/// Ordered least- to most-privileged so a specialist can classify which
+/// direction an authorization boundary is crossed: a `User` reaching a
+/// `Privileged`-only function is vertical escalation (BFLA); two `User`s
+/// reaching each other's objects is horizontal escalation (BOLA/IDOR).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum IdentityRole {
+    /// Unauthenticated - no credentials. Uses empty [`SessionMaterial`].
+    Anonymous,
+    /// An ordinary authenticated user.
+    User,
+    /// An administrative or otherwise elevated account.
+    Privileged,
+}
+
+/// A test identity *reference* used for differential authorization testing
+/// (pick#162).
+///
+/// This is a **reference only** - it names an identity (`label`) and describes
+/// its privilege (`role`) and tenant, but deliberately carries **no secret**.
+/// The raw session material (cookies/JWT/headers) lives connector-side in the
+/// [`crate::identity::IdentityStore`] (on `ToolContext`), keyed by `label`, and
+/// is resolved and injected locally at tool-execution time. This keeps the
+/// secret off the Matrix/LLM boundary: `SpecialistContext` (and thus the agent
+/// context sent via [`SpecialistSpawner::spawn`]) serializes only these
+/// references, never the material itself.
+///
+/// Identities are supplied by the operator at engagement setup - the specialist
+/// never creates accounts. The differential authz method replays the same
+/// request across a matrix of these identities and diffs the responses to find
+/// broken access control (horizontal BOLA/IDOR, vertical BFLA, forced
+/// browsing). The WebApp and API specialist prompts describe how the matrix is
+/// exercised; the LLM references an identity by `label` in its tool calls.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TestIdentity {
+    /// Human-readable label, e.g. `"unauth"`, `"user_a"`, `"user_b"`, `"admin"`.
+    /// This is the key the connector-side [`crate::identity::IdentityStore`]
+    /// resolves to the real session material.
+    pub label: String,
+
+    /// Privilege tier, used to classify escalation direction.
+    pub role: IdentityRole,
+
+    /// Tenant identifier for multi-tenant horizontal checks, if applicable.
+    #[serde(default)]
+    pub tenant: Option<String>,
+}
+
 /// Context passed to specialist when spawning.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SpecialistContext {
@@ -349,6 +400,26 @@ pub struct SpecialistContext {
 
     /// Attack surface summary (endpoint count, technologies detected, etc.)
     pub attack_surface: AttackSurface,
+
+    /// Operator-provided identities for differential authorization testing
+    /// (pick#162). When two or more are present, the WebApp/API specialists
+    /// replay requests across the matrix to detect broken access control
+    /// (BOLA/BFLA/forced browsing); with fewer than two, they degrade to
+    /// unauth-vs-authed checks and report reduced coverage. Defaulted so
+    /// contexts serialized before pick#162 still deserialize, and so the Red
+    /// Team agent may omit it for non-authz specialist spawns.
+    #[serde(default)]
+    pub identities: Vec<TestIdentity>,
+}
+
+impl SpecialistContext {
+    /// Whether the operator supplied enough identities (two or more) for the
+    /// differential authorization matrix. Below this threshold the authz
+    /// specialists degrade to reduced-coverage forced-browsing checks rather
+    /// than cross-identity diffing.
+    pub fn has_multi_identity(&self) -> bool {
+        self.identities.len() >= 2
+    }
 }
 
 /// Attack surface summary for target.
@@ -659,6 +730,7 @@ mod tests {
                 cloud_indicators: CloudIndicators::default(),
                 database_indicators: DatabaseIndicators::default(),
             },
+            identities: vec![],
         }
     }
 
@@ -680,6 +752,7 @@ mod tests {
                 cloud_indicators: indicators,
                 database_indicators: DatabaseIndicators::default(),
             },
+            identities: vec![],
         }
     }
 
@@ -701,6 +774,7 @@ mod tests {
                 cloud_indicators: CloudIndicators::default(),
                 database_indicators: indicators,
             },
+            identities: vec![],
         }
     }
 
@@ -1619,5 +1693,92 @@ mod tests {
         let surface: AttackSurface =
             serde_json::from_str(json).expect("legacy AttackSurface must deserialize");
         assert!(!surface.database_indicators.has_any());
+    }
+
+    // ---- pick#162: differential-authz identity model ----
+
+    #[test]
+    fn context_deserializes_without_identities_field() {
+        // Backward compatibility: contexts serialized before pick#162 have no
+        // `identities` field and must still deserialize (serde default), with an
+        // empty matrix that reports single-identity coverage.
+        let json = r#"{
+            "targets": ["https://example.com"],
+            "initial_findings": [],
+            "concerns": [],
+            "attack_surface": {
+                "endpoint_count": 5,
+                "technologies": [],
+                "auth_mechanisms": [],
+                "entry_points": []
+            }
+        }"#;
+        let ctx: SpecialistContext =
+            serde_json::from_str(json).expect("legacy SpecialistContext must deserialize");
+        assert!(ctx.identities.is_empty());
+        assert!(!ctx.has_multi_identity());
+    }
+
+    #[test]
+    fn has_multi_identity_needs_two_or_more() {
+        let identity = |label: &str, role| TestIdentity {
+            label: label.to_string(),
+            role,
+            tenant: None,
+        };
+
+        let mut ctx = make_context(10, vec![]);
+        assert!(
+            !ctx.has_multi_identity(),
+            "zero identities is single-coverage"
+        );
+
+        ctx.identities = vec![identity("unauth", IdentityRole::Anonymous)];
+        assert!(!ctx.has_multi_identity(), "one identity is single-coverage");
+
+        ctx.identities
+            .push(identity("admin", IdentityRole::Privileged));
+        assert!(ctx.has_multi_identity(), "two identities enable the matrix");
+    }
+
+    #[test]
+    fn test_identity_reference_roundtrips_through_serde() {
+        let identity = TestIdentity {
+            label: "user_a".to_string(),
+            role: IdentityRole::User,
+            tenant: Some("tenant_2".to_string()),
+        };
+        let json = serde_json::to_string(&identity).unwrap();
+        let back: TestIdentity = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, identity);
+    }
+
+    #[test]
+    fn test_identity_carries_no_secret_when_serialized() {
+        // The reference must never carry session material - that lives
+        // connector-side in the IdentityStore. Guard against a future field
+        // re-introducing a secret onto the Matrix/LLM boundary.
+        let identity = TestIdentity {
+            label: "admin".to_string(),
+            role: IdentityRole::Privileged,
+            tenant: None,
+        };
+        let json = serde_json::to_string(&identity).unwrap();
+        assert_eq!(
+            json,
+            r#"{"label":"admin","role":"privileged","tenant":null}"#
+        );
+    }
+
+    #[test]
+    fn identity_role_serializes_kebab_case() {
+        assert_eq!(
+            serde_json::to_string(&IdentityRole::Anonymous).unwrap(),
+            "\"anonymous\""
+        );
+        assert_eq!(
+            serde_json::to_string(&IdentityRole::Privileged).unwrap(),
+            "\"privileged\""
+        );
     }
 }

--- a/crates/core/src/specialist_spawner.rs
+++ b/crates/core/src/specialist_spawner.rs
@@ -982,6 +982,32 @@ mod tests {
         }
     }
 
+    #[test]
+    fn authz_specialist_prompts_wire_the_identity_matrix() {
+        // pick#162 Hop C: the WebApp and API specialist prompts must consume the
+        // injected `identities` matrix and honor reduced-coverage degradation.
+        // Guard against a future edit silently reverting the wiring (which would
+        // leave prompt text with nothing behind it).
+        let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .parent()
+            .and_then(|p| p.parent())
+            .expect("crates/core/.. should resolve to repo root")
+            .to_path_buf();
+
+        for specialist in [SpecialistType::WEB_APP, SpecialistType::API] {
+            let path = repo_root.join(specialist.prompt_file());
+            let body = std::fs::read_to_string(&path)
+                .unwrap_or_else(|e| panic!("specialist prompt unreadable at {path:?}: {e}"));
+            for needle in ["`identities`", "identity_ref", "reduced"] {
+                assert!(
+                    body.contains(needle),
+                    "specialist prompt for {specialist:?} no longer wires the identity \
+                     matrix (missing {needle:?}) - pick#162 Hop C regressed"
+                );
+            }
+        }
+    }
+
     // --- Cloud specialist (pick#151) ---------------------------------------
 
     #[test]

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -788,7 +788,7 @@ impl ToolContext {
     /// Returns `None` when the label is unknown - the caller must fail loudly
     /// rather than silently replay unauthenticated, which would misreport an
     /// authorization result.
-    pub fn resolve_identity(&self, label: &str) -> Option<&crate::identity::SessionMaterial> {
+    pub fn resolve_identity(&self, label: &str) -> Option<&crate::identity::StoredIdentity> {
         self.identities.resolve(label)
     }
 

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -697,6 +697,14 @@ pub struct ToolContext {
     /// Name of the parent agent executing tools (e.g., "pentest-connector-red-team").
     /// Used by spawn_specialist to name spawned agents.
     agent_name: String,
+
+    /// Operator-provided test identities for differential authorization testing
+    /// (pick#162). Keyed by the `label` the LLM references in tool calls; a tool
+    /// resolves the label to session material and injects auth locally at
+    /// execution time. Connector-local and never serialized - the secret does
+    /// not cross the Matrix/LLM boundary. Empty unless identities were
+    /// provisioned for the engagement.
+    identities: crate::identity::IdentityStore,
 }
 
 impl std::fmt::Debug for ToolContext {
@@ -708,6 +716,7 @@ impl std::fmt::Debug for ToolContext {
             .field("has_matrix_client", &self.matrix_client.is_some())
             .field("aggression_level", &self.aggression_level)
             .field("agent_name", &self.agent_name)
+            .field("identities", &self.identities)
             .finish()
     }
 }
@@ -721,6 +730,7 @@ impl Default for ToolContext {
             matrix_client: None,
             aggression_level: crate::aggression::AggressionLevel::default(),
             agent_name: "pentest-connector".to_string(),
+            identities: crate::identity::IdentityStore::new(),
         }
     }
 }
@@ -750,6 +760,13 @@ impl ToolContext {
         self
     }
 
+    /// Set the operator-provided identity store for differential authorization
+    /// testing (pick#162).
+    pub fn with_identities(mut self, identities: crate::identity::IdentityStore) -> Self {
+        self.identities = identities;
+        self
+    }
+
     /// Get the Matrix client if available
     pub fn matrix_client(&self) -> Option<&Arc<crate::matrix::MatrixChatClient>> {
         self.matrix_client.as_ref()
@@ -763,6 +780,22 @@ impl ToolContext {
     /// Get the agent name
     pub fn agent_name(&self) -> &str {
         &self.agent_name
+    }
+
+    /// Resolve an identity `label` (as referenced by the LLM in a tool call) to
+    /// its session material for local auth injection (pick#162).
+    ///
+    /// Returns `None` when the label is unknown - the caller must fail loudly
+    /// rather than silently replay unauthenticated, which would misreport an
+    /// authorization result.
+    pub fn resolve_identity(&self, label: &str) -> Option<&crate::identity::SessionMaterial> {
+        self.identities.resolve(label)
+    }
+
+    /// Borrow the full identity store (e.g. to check how many identities were
+    /// provisioned before deciding differential-authz coverage).
+    pub fn identities(&self) -> &crate::identity::IdentityStore {
+        &self.identities
     }
 }
 

--- a/crates/core/src/tools.rs
+++ b/crates/core/src/tools.rs
@@ -1309,9 +1309,12 @@ mod transport_tests {
 
     #[test]
     fn tool_result_with_provenance_round_trips_through_json() {
-        // Contract: once a tool attaches provenance, every field must
-        // survive a JSON round-trip intact — this is exactly what the
-        // SDK does at connector.rs:237 before sending over the wire.
+        // Contract: once a tool attaches provenance, the wire-facing fields must
+        // survive a JSON round-trip — this is what the SDK does at
+        // connector.rs:237 before sending over the wire. The raw `command` is
+        // deliberately NOT on the wire (`#[serde(skip_serializing)]`, #317
+        // review): it can carry an injected credential, so only the redacted
+        // `effective_command` crosses the boundary.
         let prov = Provenance::new(
             "nmap",
             "7.95",
@@ -1321,7 +1324,7 @@ mod transport_tests {
         let original = ToolResult::success(serde_json::json!({
             "hosts": [{"ip": "192.168.1.1"}]
         }))
-        .with_provenance(prov.clone());
+        .with_provenance(prov);
 
         let wire = serde_json::to_value(&original).expect("serialize");
 
@@ -1332,14 +1335,27 @@ mod transport_tests {
         assert_eq!(prov_json["underlying_tool"], "nmap");
         assert_eq!(prov_json["tool_version"], "7.95");
         assert_eq!(prov_json["probe_commands"].as_array().unwrap().len(), 1);
+        // The raw command must be absent from the wire; the redacted form present.
+        assert!(
+            prov_json["probe_commands"][0].get("command").is_none(),
+            "raw `command` must not be serialized: {prov_json}"
+        );
         assert_eq!(
-            prov_json["probe_commands"][0]["command"],
+            prov_json["probe_commands"][0]["effective_command"],
             "nmap -sV 192.168.1.1"
         );
 
-        // Round-trip: Report Agent parses this back into a typed Provenance.
+        // Round-trip: Report Agent parses this back into a typed Provenance. The
+        // raw `command` comes back empty (skip_serializing + default) while every
+        // wire-facing field is intact.
         let back: ToolResult = serde_json::from_value(wire).expect("deserialize");
-        assert_eq!(back.provenance, Some(prov));
+        let back_prov = back.provenance.expect("provenance present");
+        assert_eq!(back_prov.underlying_tool, "nmap");
+        assert_eq!(back_prov.probe_commands[0].command, "");
+        assert_eq!(
+            back_prov.probe_commands[0].effective_command,
+            "nmap -sV 192.168.1.1"
+        );
     }
 
     #[test]

--- a/crates/core/tests/aggression_integration_test.rs
+++ b/crates/core/tests/aggression_integration_test.rs
@@ -23,6 +23,7 @@ fn create_context(endpoint_count: usize) -> SpecialistContext {
             cloud_indicators: Default::default(),
             database_indicators: Default::default(),
         },
+        identities: vec![],
     }
 }
 
@@ -40,6 +41,7 @@ fn create_context_with_hints(endpoint_count: usize) -> SpecialistContext {
             cloud_indicators: Default::default(),
             database_indicators: Default::default(),
         },
+        identities: vec![],
     }
 }
 

--- a/crates/platform/src/desktop/command.rs
+++ b/crates/platform/src/desktop/command.rs
@@ -68,7 +68,14 @@ pub async fn execute_command_in_dir(
 ) -> Result<CommandResult> {
     // If sandbox is disabled, execute directly
     if !is_sandbox_enabled() {
-        tracing::debug!("Sandbox disabled, executing directly: {} {:?}", cmd, args);
+        // Redact args: a differential-authz identity run splices a credential
+        // (`-H "Authorization: Bearer <token>"`, `-u user:pass`) into argv, so the
+        // raw args can carry a secret. Log the redacted form (#317 review HIGH).
+        tracing::debug!(
+            "Sandbox disabled, executing directly: {} {}",
+            cmd,
+            pentest_core::provenance::redact(&format!("{args:?}"))
+        );
         return execute_command_direct(cmd, args, timeout_duration, working_dir).await;
     }
 
@@ -81,11 +88,18 @@ pub async fn execute_command_in_dir(
         format!("{} {}", cmd, escaped_args.join(" "))
     };
 
+    // Redact args/full_cmd before logging: on a differential-authz identity run
+    // these carry the injected credential, and any log sink (journald/Quickwit)
+    // would otherwise capture it in plaintext (#317 review HIGH). `cmd` is just
+    // the binary name. NOTE: passing a secret as an argv element also exposes it
+    // in the process table (`ps` / `/proc/<pid>/cmdline`) for the lifetime of the
+    // child — inherent to header-via-argv; `curl -H @file` avoids it. Tracked for
+    // the differential-authz feature rollout (gated on matrix#3354).
     tracing::info!(
-        "[execute_command] cmd={:?} args={:?} full_cmd={:?}",
+        "[execute_command] cmd={:?} args={} full_cmd={}",
         cmd,
-        args,
-        full_cmd
+        pentest_core::provenance::redact(&format!("{args:?}")),
+        pentest_core::provenance::redact(&full_cmd)
     );
 
     // Try sandboxed execution. The sandbox is enabled, so the operator expects
@@ -329,5 +343,42 @@ mod tests {
         let result = resolve_enabled_attempt("sleep", SandboxAttempt::Executed(timed_out));
         let out = result.expect("a sandbox timeout is still a successful sandbox run");
         assert!(out.timed_out);
+    }
+
+    // ── Log redaction for differential-authz identity runs (#317 review HIGH) ──
+    //
+    // execute_command / execute_command_in_dir log `args` and `full_cmd` at
+    // info/debug. On an identity run those carry an injected credential, so both
+    // sites now redact via `pentest_core::provenance::redact` before logging.
+    // This test guards that `redact` actually strips a credential from the exact
+    // string shapes the log statements build (`format!("{args:?}")` and the
+    // shell-escaped `full_cmd`) — i.e. the redactor is effective on this input,
+    // not that the call sites invoke it (that wiring is verified by reading the
+    // two `tracing!` calls above; asserting on emitted log lines would need a
+    // tracing-capture harness this crate doesn't set up).
+    #[test]
+    fn injected_credential_is_redacted_before_logging() {
+        let secret = "sk-super-secret-token-abcdef1234567890";
+        let args = vec![
+            "-H",
+            "Authorization: Bearer sk-super-secret-token-abcdef1234567890",
+            "https://target.example",
+        ];
+
+        // The `args={:?}` form the log line builds.
+        let logged_args = pentest_core::provenance::redact(&format!("{args:?}"));
+        assert!(
+            !logged_args.contains(secret),
+            "credential must be redacted from logged args: {logged_args}"
+        );
+
+        // The `full_cmd` form (shell-escaped join, as built above).
+        let escaped: Vec<String> = args.iter().map(|a| shell_escape(a)).collect();
+        let full_cmd = format!("curl {}", escaped.join(" "));
+        let logged_full = pentest_core::provenance::redact(&full_cmd);
+        assert!(
+            !logged_full.contains(secret),
+            "credential must be redacted from logged full_cmd: {logged_full}"
+        );
     }
 }

--- a/crates/tools/src/execute_command.rs
+++ b/crates/tools/src/execute_command.rs
@@ -2,12 +2,12 @@
 
 use async_trait::async_trait;
 use pentest_core::error::Result;
-use pentest_core::provenance::{truncate_excerpt, ProbeCommand, Provenance};
+use pentest_core::provenance::{redact_known_secret, truncate_excerpt, ProbeCommand, Provenance};
 use pentest_core::tools::{
     execute_timed_with_provenance, ParamType, PentestTool, Platform, ToolContext, ToolOutcome,
     ToolParam, ToolResult, ToolSchema,
 };
-use pentest_platform::{get_platform, CommandExec};
+use pentest_platform::{get_platform, CommandExec, CommandResult};
 use serde_json::{json, Value};
 use std::sync::OnceLock;
 use std::time::Duration;
@@ -155,46 +155,86 @@ impl PentestTool for ExecuteCommandTool {
             };
 
             let full_command = format_full_command(command, &args);
-            let excerpt_source = if result.stdout.is_empty() {
-                result.stderr.as_str()
-            } else {
-                result.stdout.as_str()
-            };
-
-            // When an identity was injected, scrub its exact secret from the
-            // effective (published) command by value and attribute the probe to
-            // the identity label so a reviewer can tell which principal produced
-            // the response (#317 review #3/#6). A non-empty secret is the auth
-            // header; an anonymous identity injects nothing but still attributes.
-            let probe_command = match &applied_identity {
-                Some(AppliedIdentity { label, secret }) => {
-                    ProbeCommand::from_exact_redacting_secret(full_command, secret)
-                        .with_description(format!("authenticated as test identity: {label}"))
-                }
-                None => ProbeCommand::from_exact(full_command),
-            };
-
-            let provenance = Provenance::new(
-                "shell",
-                shell_version(),
-                probe_command,
-                truncate_excerpt(excerpt_source),
-            );
-
-            let data = json!({
-                "stdout": result.stdout,
-                "stderr": result.stderr,
-                "exit_code": result.exit_code,
-                "timed_out": result.timed_out,
-                "duration_ms": result.duration_ms,
-            });
-
-            Ok((data, provenance))
+            Ok(build_run_output(full_command, result, &applied_identity))
         })
         .await?;
 
         Ok(classify_command_outcome(run))
     }
+}
+
+/// Build the `(data, provenance)` pair for a completed `execute_command` run.
+///
+/// Extracted from the run closure so the identity-secret scrub is testable
+/// without a live subprocess. When an identity was injected (`applied` is
+/// `Some` with a non-empty secret), the exact credential is scrubbed BY VALUE
+/// from every agent-facing surface before it crosses the boundary:
+/// * the published command (`effective_command`), and
+/// * the captured output (`stdout`/`stderr`), which feeds both `data` and the
+///   provenance excerpt — a target that reflects the injected header (verbose
+///   echo, error page, `curl -v` on stderr) would otherwise put the raw
+///   credential straight in front of the agent.
+///
+/// This closes the gap that the read-side sanitizer (`sanitize_agent_result`)
+/// and `redact` cannot: they are regex-only and miss odd header shapes
+/// (`X-Api-Id: ab12cd`). Because the injected secret is *known* here, scrubbing
+/// by value removes it regardless of shape — security-by-construction over a
+/// best-effort scrubber (#317 review, agent-output boundary). Anonymous
+/// identities (empty secret) and non-identity runs pass output through
+/// unchanged. The residual log/process-table surface is tracked in pick#335.
+fn build_run_output(
+    full_command: String,
+    result: CommandResult,
+    applied: &Option<AppliedIdentity>,
+) -> (Value, Provenance) {
+    let injected_secret = applied
+        .as_ref()
+        .map(|a| a.secret.as_str())
+        .filter(|s| !s.is_empty());
+
+    // Value-scrub the known secret out of the captured output. `redact_known_secret`
+    // is a no-op when there is no secret, so non-identity runs are untouched.
+    let (stdout, stderr) = match injected_secret {
+        Some(secret) => (
+            redact_known_secret(&result.stdout, secret),
+            redact_known_secret(&result.stderr, secret),
+        ),
+        None => (result.stdout, result.stderr),
+    };
+
+    let excerpt_source = if stdout.is_empty() {
+        stderr.as_str()
+    } else {
+        stdout.as_str()
+    };
+
+    // Scrub the injected secret from the published command by value and
+    // attribute the probe to the identity label so a reviewer can tell which
+    // principal produced the response (#317 review #3/#6).
+    let probe_command = match applied {
+        Some(AppliedIdentity { label, secret }) => {
+            ProbeCommand::from_exact_redacting_secret(full_command, secret)
+                .with_description(format!("authenticated as test identity: {label}"))
+        }
+        None => ProbeCommand::from_exact(full_command),
+    };
+
+    let provenance = Provenance::new(
+        "shell",
+        shell_version(),
+        probe_command,
+        truncate_excerpt(excerpt_source),
+    );
+
+    let data = json!({
+        "stdout": stdout,
+        "stderr": stderr,
+        "exit_code": result.exit_code,
+        "timed_out": result.timed_out,
+        "duration_ms": result.duration_ms,
+    });
+
+    (data, provenance)
 }
 
 /// Reclassify a completed `execute_command` run's outcome from its process
@@ -769,6 +809,109 @@ mod tests {
         assert!(pc.effective_command.contains("<REDACTED>"));
         // Exact form retained (but never serialized).
         assert!(pc.command.contains("ab12cd"));
+    }
+
+    #[test]
+    fn run_output_scrubs_reflected_identity_secret_from_output() {
+        // #317 agent-output boundary (ngdevo 2026-08-14 MEDIUM): a target that
+        // reflects the injected auth header — verbose echo, error page, `curl -v`
+        // on stderr — lands the raw credential in stdout/stderr → `data` → the
+        // agent. The read-side sanitizer is regex-only, so an exotic shape slips
+        // through. Because the injected secret is KNOWN, the tool scrubs it by
+        // value before building `data`. Use `X-Api-Id: ab12cd` — a shape no
+        // redact() regex catches — so a green result proves the value-scrub, not
+        // an incidental pattern hit, is doing the work.
+        let secret = "X-Api-Id: ab12cd";
+        let applied = Some(AppliedIdentity {
+            label: "user_a".to_string(),
+            secret: secret.to_string(),
+        });
+        let result = CommandResult {
+            stdout: format!("target reflected header: {secret}\n"),
+            stderr: format!("verbose: > {secret}\n"),
+            exit_code: 0,
+            timed_out: false,
+            duration_ms: 1,
+        };
+        let full = format_full_command(
+            "curl",
+            &[
+                "-H".to_string(),
+                secret.to_string(),
+                "https://x.test".to_string(),
+            ],
+        );
+
+        // Precondition (Lens 1): pattern redaction alone misses this shape, so
+        // without the value-scrub the secret WOULD reach the agent.
+        assert!(
+            pentest_core::provenance::redact(&result.stdout).contains("ab12cd"),
+            "precondition: this shape is not caught by pattern redaction"
+        );
+
+        let (data, prov) = build_run_output(full, result, &applied);
+
+        let stdout = data.get("stdout").and_then(Value::as_str).unwrap();
+        let stderr = data.get("stderr").and_then(Value::as_str).unwrap();
+        assert!(
+            !stdout.contains("ab12cd"),
+            "reflected secret leaked into data.stdout: {stdout}"
+        );
+        assert!(
+            !stderr.contains("ab12cd"),
+            "reflected secret leaked into data.stderr: {stderr}"
+        );
+        assert!(
+            !prov.raw_response_excerpt.contains("ab12cd"),
+            "reflected secret leaked into provenance excerpt: {}",
+            prov.raw_response_excerpt
+        );
+        // The label still rides on the wire so the principal is attributable.
+        assert!(prov.probe_commands[0]
+            .description
+            .as_deref()
+            .is_some_and(|d| d.contains("user_a")));
+    }
+
+    #[test]
+    fn run_output_leaves_non_identity_output_untouched() {
+        // No identity applied → output passes through verbatim. Guards against
+        // the scrub over-reaching on ordinary runs (it must not blank output).
+        let result = CommandResult {
+            stdout: "clean tool output\n".to_string(),
+            stderr: String::new(),
+            exit_code: 0,
+            timed_out: false,
+            duration_ms: 1,
+        };
+        let (data, _) = build_run_output("echo hi".to_string(), result, &None);
+        assert_eq!(
+            data.get("stdout").and_then(Value::as_str),
+            Some("clean tool output\n")
+        );
+    }
+
+    #[test]
+    fn run_output_anonymous_identity_does_not_scrub_output() {
+        // An anonymous identity carries an empty secret: nothing to scrub, and a
+        // naive `replace("", …)` would corrupt every character boundary. Output
+        // must pass through unchanged.
+        let applied = Some(AppliedIdentity {
+            label: "unauth".to_string(),
+            secret: String::new(),
+        });
+        let result = CommandResult {
+            stdout: "unauthenticated response body\n".to_string(),
+            stderr: String::new(),
+            exit_code: 0,
+            timed_out: false,
+            duration_ms: 1,
+        };
+        let (data, _) = build_run_output("curl https://x.test".to_string(), result, &applied);
+        assert_eq!(
+            data.get("stdout").and_then(Value::as_str),
+            Some("unauthenticated response body\n")
+        );
     }
 
     #[tokio::test]

--- a/crates/tools/src/execute_command.rs
+++ b/crates/tools/src/execute_command.rs
@@ -628,6 +628,23 @@ mod tests {
     }
 
     #[test]
+    fn build_injection_anonymous_from_real_loader_injects_nothing() {
+        // Regression for #317 H1: end-to-end through the PRODUCTION loader, not
+        // a hand-built store. Earlier this passed only because `ctx_with` seeded
+        // a placeholder the loader never created; the loader skipped empty-
+        // session entries, so `identity_ref: "unauth"` (what both specialist
+        // prompts tell the LLM to emit) resolved to None and hard-errored.
+        let path = std::env::temp_dir().join("pick-exec-anon-e2e.json");
+        std::fs::write(&path, r#"[{"label":"unauth","role":"anonymous"}]"#).unwrap();
+        let loaded = pentest_core::identity::load_identities_from_file(&path).expect("loader ok");
+        let ctx = ToolContext::default().with_identities(loaded.store);
+        let args = build_identity_injection("curl", "unauth", &ctx)
+            .expect("anonymous from real loader injects nothing, does not error");
+        assert!(args.is_empty());
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
     fn injected_auth_header_redacts_in_effective_command() {
         // The injected secret must be scrubbed from effective_command (which
         // reaches evidence/report) but retained in the exact command.

--- a/crates/tools/src/execute_command.rs
+++ b/crates/tools/src/execute_command.rs
@@ -46,6 +46,17 @@ impl PentestTool for ExecuteCommandTool {
                 "Command timeout in seconds",
                 json!(120),
             ))
+            .param(ToolParam::optional(
+                "identity_ref",
+                ParamType::String,
+                "Label of an operator-provisioned test identity to run this \
+                 command as (differential-authz testing). The connector injects \
+                 the identity's auth header for the target binary locally - you \
+                 never see or write the credential. Only these binaries support \
+                 injection: curl, ffuf, wget, sqlmap. Fails if the label is \
+                 unknown or the binary has no supported header flag.",
+                json!(null),
+            ))
     }
 
     fn supported_platforms(&self) -> Vec<Platform> {
@@ -70,6 +81,43 @@ impl PentestTool for ExecuteCommandTool {
             ));
         }
 
+        // Parse command/args up front (not inside the timed closure) so that
+        // identity injection can fail-closed BEFORE any subprocess spawns — an
+        // unknown identity_ref or an unmappable binary must never run
+        // unauthenticated and report success (pick#314 / #162 ethos).
+        let command = match params.get("command").and_then(|v| v.as_str()) {
+            Some(c) => c.to_string(),
+            None => return Ok(ToolResult::error("Command is required")),
+        };
+
+        let mut args: Vec<String> = params
+            .get("args")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        // Identity injection (pick#314): if the caller referenced a test
+        // identity, resolve it to its auth header and splice the correct
+        // per-binary flag ahead of the user args. resolve_identity never
+        // reveals the secret to the LLM; the connector injects it locally here.
+        if let Some(label) = params.get("identity_ref").and_then(|v| v.as_str()) {
+            match build_identity_injection(&command, label, ctx) {
+                // Prepend so tool-specific positional args (e.g. a target URL)
+                // stay last, matching how these binaries expect flags.
+                Ok(mut injected) => {
+                    injected.extend(std::mem::take(&mut args));
+                    args = injected;
+                }
+                Err(e) => return Ok(ToolResult::error(e.to_string())),
+            }
+        }
+
+        let timeout_seconds = param_u64(&params, "timeout_seconds", 120);
+
         // Build the run future via the provenance-timed helper so timing and
         // the error→Failed mapping stay consistent with every other tool. On
         // success we then reclassify the outcome from the process exit status
@@ -78,26 +126,9 @@ impl PentestTool for ExecuteCommandTool {
         let run = execute_timed_with_provenance(|| async move {
             let platform = get_platform();
 
-            let command = params
-                .get("command")
-                .and_then(|v| v.as_str())
-                .ok_or_else(|| {
-                    pentest_core::error::Error::InvalidParams("Command is required".into())
-                })?;
-
-            let args: Vec<String> = params
-                .get("args")
-                .and_then(|v| v.as_array())
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_str().map(String::from))
-                        .collect()
-                })
-                .unwrap_or_default();
+            let command = command.as_str();
 
             let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-
-            let timeout_seconds = param_u64(&params, "timeout_seconds", 120);
 
             let timeout = Duration::from_secs(timeout_seconds);
 
@@ -205,6 +236,75 @@ fn format_full_command(command: &str, args: &[String]) -> String {
         }
     }
     out
+}
+
+/// Reduce a `command` string to the bare executable name: strip any directory
+/// path (`/usr/bin/curl` -> `curl`, `./sqlmap` -> `sqlmap`). The identity flag
+/// map is keyed by executable name, not the invocation path.
+fn binary_basename(command: &str) -> &str {
+    std::path::Path::new(command)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(command)
+}
+
+/// Map a target binary to the argv fragment that passes a full HTTP header
+/// line as a custom request header, for the given `header` value.
+///
+/// Session material (pick#162) is stored as a complete header line
+/// (`"Authorization: Bearer ..."` or `"Cookie: sid=..."`), so a single
+/// custom-header flag per binary handles both the auth and cookie cases - no
+/// need to parse the material apart. Returns:
+/// * `Some(vec![..])` - the argv fragment to splice in for a supported binary.
+/// * `None` - the binary has no generic custom-header flag we trust. The caller
+///   MUST fail loud rather than run without the identity: a curl-shaped `-H`
+///   guessed onto a sibling tool is the exact silently-wrong bug pick#314
+///   exists to avoid (PR-review Lens 7).
+///
+/// Binaries differ in flag *shape*, which is why this is a per-binary map and
+/// not one splice rule:
+/// * `curl` / `ffuf` take a separate `-H <value>` arg pair.
+/// * `wget` / `sqlmap` take a single joined `--header=<value>` arg.
+fn header_flags_for(binary: &str, header: &str) -> Option<Vec<String>> {
+    match binary {
+        "curl" | "ffuf" => Some(vec!["-H".to_string(), header.to_string()]),
+        "wget" | "sqlmap" => Some(vec![format!("--header={header}")]),
+        _ => None,
+    }
+}
+
+/// Resolve an `identity_ref` label to the argv fragment that authenticates the
+/// target `command` as that identity (pick#314).
+///
+/// Fails loud (returns `Err(message)`) - never silently runs unauthenticated,
+/// which would misreport a differential-authz result (the pick#162 ethos) -
+/// when:
+/// * the label is unknown (not provisioned / typo), or
+/// * the identity carries material but the binary has no supported header flag.
+///
+/// Returns `Ok(vec![])` (inject nothing) when the identity is anonymous (empty
+/// material): running with no auth *is* that identity, so it is not a failure.
+fn build_identity_injection(command: &str, label: &str, ctx: &ToolContext) -> Result<Vec<String>> {
+    let material = ctx.resolve_identity(label).ok_or_else(|| {
+        pentest_core::error::Error::InvalidParams(format!(
+            "identity_ref '{label}' is not a provisioned test identity; \
+             cannot authenticate as it (refusing to run unauthenticated)"
+        ))
+    })?;
+
+    // Anonymous identity: no material to inject. Running as-is IS this identity.
+    if material.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let binary = binary_basename(command);
+    header_flags_for(binary, material.expose()).ok_or_else(|| {
+        pentest_core::error::Error::InvalidParams(format!(
+            "identity_ref '{label}' cannot be injected into '{binary}': no \
+             supported custom-header flag for this binary (supported: curl, \
+             ffuf, wget, sqlmap). Refusing to run with the identity dropped."
+        ))
+    })
 }
 
 /// Detect the login shell version once per process. Falls back to
@@ -413,5 +513,174 @@ mod tests {
         // execute(); if one reaches the classifier it must survive.
         let r = classify_command_outcome(ToolResult::skipped("unsupported platform"));
         assert_eq!(r.outcome, ToolOutcome::Skipped);
+    }
+
+    // --- identity injection (pick#314) -------------------------------------
+    //
+    // A specialist ACTS as a differential-authz identity by referencing it by
+    // `label` (never the secret, which the LLM never sees - pick#162). The
+    // connector resolves the label to session material and splices the correct
+    // "custom header" flag for the target binary. Session material is a full
+    // HTTP header line (`"Authorization: Bearer ..."` / `"Cookie: sid=..."`),
+    // so one flag handles both auth and cookie forms per binary.
+
+    use pentest_core::identity::{IdentityStore, SessionMaterial};
+
+    #[test]
+    fn header_flags_curl_uses_separate_dash_h() {
+        // curl takes the header as a separate `-H <value>` arg pair.
+        assert_eq!(
+            header_flags_for("curl", "Authorization: Bearer tok"),
+            Some(vec![
+                "-H".to_string(),
+                "Authorization: Bearer tok".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn header_flags_ffuf_uses_separate_dash_h() {
+        assert_eq!(
+            header_flags_for("ffuf", "Cookie: sid=abc"),
+            Some(vec!["-H".to_string(), "Cookie: sid=abc".to_string()])
+        );
+    }
+
+    #[test]
+    fn header_flags_wget_uses_joined_long_flag() {
+        // wget takes `--header=<value>` as one joined arg.
+        assert_eq!(
+            header_flags_for("wget", "Authorization: Bearer tok"),
+            Some(vec!["--header=Authorization: Bearer tok".to_string()])
+        );
+    }
+
+    #[test]
+    fn header_flags_sqlmap_uses_joined_long_flag() {
+        assert_eq!(
+            header_flags_for("sqlmap", "Cookie: sid=abc"),
+            Some(vec!["--header=Cookie: sid=abc".to_string()])
+        );
+    }
+
+    #[test]
+    fn header_flags_unknown_binary_is_none() {
+        // nmap/nikto/etc. have no generic custom-HTTP-header flag; return None
+        // so the caller fails loud rather than guessing a curl-shaped `-H`.
+        assert_eq!(header_flags_for("nmap", "Cookie: sid=abc"), None);
+        assert_eq!(header_flags_for("echo", "Cookie: sid=abc"), None);
+    }
+
+    #[test]
+    fn binary_basename_strips_path_and_args() {
+        assert_eq!(binary_basename("/usr/bin/curl"), "curl");
+        assert_eq!(binary_basename("curl"), "curl");
+        assert_eq!(binary_basename("./sqlmap"), "sqlmap");
+    }
+
+    fn ctx_with(label: &str, material: &str) -> ToolContext {
+        ToolContext::default().with_identities(IdentityStore::from_pairs([(
+            label,
+            SessionMaterial::new(material),
+        )]))
+    }
+
+    #[test]
+    fn build_injection_unknown_label_fails_loud() {
+        // A label the connector never provisioned must NOT silently run
+        // unauthenticated - that would misreport the authz result (#162 ethos).
+        let ctx = ToolContext::default();
+        let err = build_identity_injection("curl", "ghost", &ctx)
+            .expect_err("unknown label must fail loud")
+            .to_string();
+        assert!(err.contains("ghost"), "message names the label: {err}");
+    }
+
+    #[test]
+    fn build_injection_known_label_curl_injects_material() {
+        let ctx = ctx_with("user_a", "Cookie: sid=secret-abc");
+        let args = build_identity_injection("curl", "user_a", &ctx).expect("known label injects");
+        assert_eq!(
+            args,
+            vec!["-H".to_string(), "Cookie: sid=secret-abc".to_string()]
+        );
+    }
+
+    #[test]
+    fn build_injection_unmapped_binary_fails_loud() {
+        // Known identity, but the binary has no header flag: fail loud rather
+        // than run the scan without the requested identity applied.
+        let ctx = ctx_with("user_a", "Cookie: sid=abc");
+        let err = build_identity_injection("nmap", "user_a", &ctx)
+            .expect_err("unmapped binary must fail loud")
+            .to_string();
+        assert!(err.contains("nmap"), "message names the binary: {err}");
+    }
+
+    #[test]
+    fn build_injection_empty_material_injects_nothing() {
+        // An anonymous identity carries no material: inject nothing and succeed
+        // (running with no auth IS that identity), never fail.
+        let ctx = ctx_with("anon", "");
+        let args =
+            build_identity_injection("curl", "anon", &ctx).expect("anonymous injects nothing");
+        assert!(args.is_empty());
+    }
+
+    #[test]
+    fn injected_auth_header_redacts_in_effective_command() {
+        // The injected secret must be scrubbed from effective_command (which
+        // reaches evidence/report) but retained in the exact command.
+        let full = format_full_command(
+            "curl",
+            &[
+                "-H".to_string(),
+                "Authorization: Bearer secrettoken123".to_string(),
+                "https://x.test".to_string(),
+            ],
+        );
+        let prov = Provenance::new("shell", "test", ProbeCommand::from_exact(full), "");
+        let eff = &prov.probe_commands[0].effective_command;
+        assert!(!eff.contains("secrettoken123"), "secret leaked: {eff}");
+        assert!(eff.contains("<REDACTED>"));
+        assert!(prov.probe_commands[0].command.contains("secrettoken123"));
+    }
+
+    #[tokio::test]
+    async fn execute_unknown_identity_ref_fails_without_running() {
+        // identity_ref pointing at no known identity fails closed BEFORE any
+        // subprocess spawns - so no deterministic dependency on curl/etc.
+        pentest_platform::set_use_sandbox(false);
+        let tool = ExecuteCommandTool;
+        let ctx = ToolContext::default();
+        let params = json!({
+            "command": "curl",
+            "args": ["https://x.test"],
+            "identity_ref": "ghost",
+        });
+        let result = tool.execute(params, &ctx).await.expect("execute ok");
+        assert_eq!(result.outcome, ToolOutcome::Failed);
+        assert!(!result.success);
+        assert!(result.error.unwrap_or_default().contains("ghost"));
+    }
+
+    #[tokio::test]
+    async fn execute_identity_ref_unmapped_binary_fails() {
+        // Known identity, but nmap has no header flag: fail loud, do not run
+        // the scan with the identity silently dropped.
+        pentest_platform::set_use_sandbox(false);
+        let tool = ExecuteCommandTool;
+        let ctx = ToolContext::default().with_identities(IdentityStore::from_pairs([(
+            "user_a",
+            SessionMaterial::new("Cookie: sid=abc"),
+        )]));
+        let params = json!({
+            "command": "nmap",
+            "args": ["-sV", "10.0.0.1"],
+            "identity_ref": "user_a",
+        });
+        let result = tool.execute(params, &ctx).await.expect("execute ok");
+        assert_eq!(result.outcome, ToolOutcome::Failed);
+        assert!(result.error.unwrap_or_default().contains("nmap"));
     }
 }

--- a/crates/tools/src/execute_command.rs
+++ b/crates/tools/src/execute_command.rs
@@ -3,6 +3,7 @@
 use async_trait::async_trait;
 use pentest_core::error::Result;
 use pentest_core::provenance::{redact_known_secret, truncate_excerpt, ProbeCommand, Provenance};
+use pentest_core::specialist_spawner::IdentityRole;
 use pentest_core::tools::{
     execute_timed_with_provenance, ParamType, PentestTool, Platform, ToolContext, ToolOutcome,
     ToolParam, ToolResult, ToolSchema,
@@ -110,21 +111,37 @@ impl PentestTool for ExecuteCommandTool {
         // attribute the response to the identity — a differential-authz finding
         // is only meaningful with the principal attached (#317 review #3/#6).
         let mut applied_identity: Option<AppliedIdentity> = None;
-        if let Some(label) = params.get("identity_ref").and_then(|v| v.as_str()) {
-            match build_identity_injection(&command, label, ctx) {
-                // Prepend so tool-specific positional args (e.g. a target URL)
-                // stay last, matching how these binaries expect flags.
-                Ok(injection) => {
-                    applied_identity = Some(AppliedIdentity {
-                        label: label.to_string(),
-                        secret: injection.injected_secret,
-                    });
+        // Distinguish "no identity requested" (absent / null - run as-is) from a
+        // string label (resolve + inject) from any other JSON shape. An LLM
+        // tool-call can violate the schema; a non-string identity_ref must fail
+        // loud rather than be silently dropped and run unauthenticated while the
+        // outcome is still attributed as a differential-authz probe (#317
+        // review #2).
+        match params.get("identity_ref") {
+            None | Some(Value::Null) => {}
+            Some(Value::String(label)) => {
+                match build_identity_injection(&command, label, ctx) {
+                    // Prepend so tool-specific positional args (e.g. a target
+                    // URL) stay last, matching how these binaries expect flags.
+                    Ok(injection) => {
+                        applied_identity = Some(AppliedIdentity {
+                            label: label.clone(),
+                            secret: injection.injected_secret,
+                        });
 
-                    let mut injected = injection.args;
-                    injected.extend(std::mem::take(&mut args));
-                    args = injected;
+                        let mut injected = injection.args;
+                        injected.extend(std::mem::take(&mut args));
+                        args = injected;
+                    }
+                    Err(e) => return Ok(ToolResult::error(e.to_string())),
                 }
-                Err(e) => return Ok(ToolResult::error(e.to_string())),
+            }
+            Some(other) => {
+                return Ok(ToolResult::error(format!(
+                    "identity_ref must be a string label or omitted; got {} - \
+                     refusing to run with the identity silently dropped",
+                    json_type_name(other)
+                )));
             }
         }
 
@@ -383,19 +400,33 @@ fn build_identity_injection(
     label: &str,
     ctx: &ToolContext,
 ) -> Result<IdentityInjection> {
-    let material = ctx.resolve_identity(label).ok_or_else(|| {
+    let identity = ctx.resolve_identity(label).ok_or_else(|| {
         pentest_core::error::Error::InvalidParams(format!(
             "identity_ref '{label}' is not a provisioned test identity; \
              cannot authenticate as it (refusing to run unauthenticated)"
         ))
     })?;
+    let material = identity.material();
 
-    // Anonymous identity: no material to inject. Running as-is IS this identity.
+    // Empty material is only legitimate for an anonymous identity - running
+    // with no auth *is* that identity, so inject nothing. For any other role,
+    // empty material means the identity was mis-provisioned; running it would
+    // report an unauthenticated request under a privileged label (a false
+    // authz finding), so fail loud. This is defense-in-depth behind the loader
+    // guard (`load_identities_from_file`), covering direct store population
+    // paths that bypass the file loader (#317 review #1).
     if material.is_empty() {
-        return Ok(IdentityInjection {
-            args: Vec::new(),
-            injected_secret: String::new(),
-        });
+        if identity.role() == IdentityRole::Anonymous {
+            return Ok(IdentityInjection {
+                args: Vec::new(),
+                injected_secret: String::new(),
+            });
+        }
+        return Err(pentest_core::error::Error::InvalidParams(format!(
+            "identity_ref '{label}' (role {:?}) carries no session material; \
+             refusing to run it unauthenticated under a non-anonymous label",
+            identity.role()
+        )));
     }
 
     let binary = binary_basename(command);
@@ -414,6 +445,19 @@ fn build_identity_injection(
         // the published command by value rather than hoping a regex matches.
         injected_secret: header.to_string(),
     })
+}
+
+/// Human-readable JSON type name for a rejected `identity_ref` shape, so the
+/// fail-loud message tells the caller *what* it sent (#317 review #2).
+fn json_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
 }
 
 /// Detect the login shell version once per process. Falls back to
@@ -634,6 +678,7 @@ mod tests {
     // so one flag handles both auth and cookie forms per binary.
 
     use pentest_core::identity::{IdentityStore, SessionMaterial};
+    use pentest_core::specialist_spawner::IdentityRole;
 
     #[test]
     fn header_flags_curl_uses_separate_dash_h() {
@@ -688,8 +733,13 @@ mod tests {
     }
 
     fn ctx_with(label: &str, material: &str) -> ToolContext {
+        ctx_with_role(label, IdentityRole::User, material)
+    }
+
+    fn ctx_with_role(label: &str, role: IdentityRole, material: &str) -> ToolContext {
         ToolContext::default().with_identities(IdentityStore::from_pairs([(
             label,
+            role,
             SessionMaterial::new(material),
         )]))
     }
@@ -731,13 +781,29 @@ mod tests {
 
     #[test]
     fn build_injection_empty_material_injects_nothing() {
-        // An anonymous identity carries no material: inject nothing and succeed
+        // An ANONYMOUS identity carries no material: inject nothing and succeed
         // (running with no auth IS that identity), never fail.
-        let ctx = ctx_with("anon", "");
+        let ctx = ctx_with_role("anon", IdentityRole::Anonymous, "");
         let injection =
             build_identity_injection("curl", "anon", &ctx).expect("anonymous injects nothing");
         assert!(injection.args.is_empty());
         assert!(injection.injected_secret.is_empty());
+    }
+
+    #[test]
+    fn build_injection_nonanon_empty_material_fails_loud() {
+        // #317 review #1 defense-in-depth: a non-anonymous identity that reached
+        // the store with empty material (e.g. a direct-population path that
+        // bypasses the file loader guard) must FAIL, not silently inject nothing
+        // and run unauthenticated under a privileged label.
+        let ctx = ctx_with_role("admin", IdentityRole::Privileged, "");
+        let err = build_identity_injection("curl", "admin", &ctx)
+            .expect_err("privileged identity with empty material must fail loud")
+            .to_string();
+        assert!(
+            err.contains("admin") && err.contains("no session material"),
+            "message must name the label and the cause: {err}"
+        );
     }
 
     #[test]
@@ -933,6 +999,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn execute_non_string_identity_ref_fails_without_running() {
+        // #317 review #2: a non-string identity_ref (the LLM can violate the
+        // schema) must fail loud, NOT be silently dropped via `.as_str() ->
+        // None` and then run unauthenticated while still reported as a probe.
+        pentest_platform::set_use_sandbox(false);
+        let tool = ExecuteCommandTool;
+        let ctx = ctx_with("user_a", "Cookie: sid=abc");
+        let params = json!({
+            "command": "curl",
+            "args": ["https://x.test"],
+            "identity_ref": 123,
+        });
+        let result = tool.execute(params, &ctx).await.expect("execute ok");
+        assert_eq!(result.outcome, ToolOutcome::Failed);
+        assert!(!result.success);
+        let err = result.error.unwrap_or_default();
+        assert!(
+            err.contains("identity_ref must be a string") && err.contains("number"),
+            "message must reject the shape and name it: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_null_identity_ref_runs_as_is() {
+        // An explicit JSON null means "no identity" - same as omitted. It must
+        // NOT be treated as a malformed ref (that would block legitimate
+        // no-identity runs).
+        pentest_platform::set_use_sandbox(false);
+        let tool = ExecuteCommandTool;
+        let ctx = ToolContext::default();
+        let params = json!({
+            "command": "curl",
+            "args": ["--max-time", "1", "http://127.0.0.1:1/x"],
+            "identity_ref": Value::Null,
+        });
+        // Runs (and fails on connection), but is NOT rejected as a malformed
+        // identity_ref - the error, if any, is not the schema-rejection message.
+        let result = tool.execute(params, &ctx).await.expect("execute ok");
+        assert!(
+            !result
+                .error
+                .unwrap_or_default()
+                .contains("identity_ref must be a string"),
+            "null identity_ref must be treated as no-identity, not malformed"
+        );
+    }
+
+    #[tokio::test]
     async fn execute_with_identity_attributes_provenance_and_scrubs_secret() {
         // #317 review #6 (attribution) + #3 (value-scrub), end-to-end through
         // execute/1. curl against an unroutable host still RUNS (produces
@@ -943,6 +1057,7 @@ mod tests {
         let tool = ExecuteCommandTool;
         let ctx = ToolContext::default().with_identities(IdentityStore::from_pairs([(
             "user_a",
+            IdentityRole::User,
             SessionMaterial::new("X-Api-Id: ab12cd"),
         )]));
         let params = json!({
@@ -976,6 +1091,7 @@ mod tests {
         let tool = ExecuteCommandTool;
         let ctx = ToolContext::default().with_identities(IdentityStore::from_pairs([(
             "user_a",
+            IdentityRole::User,
             SessionMaterial::new("Cookie: sid=abc"),
         )]));
         let params = json!({

--- a/crates/tools/src/execute_command.rs
+++ b/crates/tools/src/execute_command.rs
@@ -104,11 +104,23 @@ impl PentestTool for ExecuteCommandTool {
         // identity, resolve it to its auth header and splice the correct
         // per-binary flag ahead of the user args. resolve_identity never
         // reveals the secret to the LLM; the connector injects it locally here.
+        //
+        // `applied_identity` records what was injected so provenance can (a)
+        // scrub the exact secret from `effective_command` by value, and (b)
+        // attribute the response to the identity — a differential-authz finding
+        // is only meaningful with the principal attached (#317 review #3/#6).
+        let mut applied_identity: Option<AppliedIdentity> = None;
         if let Some(label) = params.get("identity_ref").and_then(|v| v.as_str()) {
             match build_identity_injection(&command, label, ctx) {
                 // Prepend so tool-specific positional args (e.g. a target URL)
                 // stay last, matching how these binaries expect flags.
-                Ok(mut injected) => {
+                Ok(injection) => {
+                    applied_identity = Some(AppliedIdentity {
+                        label: label.to_string(),
+                        secret: injection.injected_secret,
+                    });
+
+                    let mut injected = injection.args;
                     injected.extend(std::mem::take(&mut args));
                     args = injected;
                 }
@@ -148,10 +160,24 @@ impl PentestTool for ExecuteCommandTool {
             } else {
                 result.stdout.as_str()
             };
+
+            // When an identity was injected, scrub its exact secret from the
+            // effective (published) command by value and attribute the probe to
+            // the identity label so a reviewer can tell which principal produced
+            // the response (#317 review #3/#6). A non-empty secret is the auth
+            // header; an anonymous identity injects nothing but still attributes.
+            let probe_command = match &applied_identity {
+                Some(AppliedIdentity { label, secret }) => {
+                    ProbeCommand::from_exact_redacting_secret(full_command, secret)
+                        .with_description(format!("authenticated as test identity: {label}"))
+                }
+                None => ProbeCommand::from_exact(full_command),
+            };
+
             let provenance = Provenance::new(
                 "shell",
                 shell_version(),
-                ProbeCommand::from_exact(full_command),
+                probe_command,
                 truncate_excerpt(excerpt_source),
             );
 
@@ -220,6 +246,34 @@ fn classify_command_outcome(result: ToolResult) -> ToolResult {
     }
 }
 
+/// What `build_identity_injection` produced: the argv fragment to splice in,
+/// plus the exact secret value it injected (empty for an anonymous identity) so
+/// the caller can scrub it from published provenance by value (#317 review #3).
+struct IdentityInjection {
+    args: Vec<String>,
+    injected_secret: String,
+}
+
+// Manual Debug: never print `injected_secret` (it is the raw auth header). The
+// whole point of this type is to keep that value out of every sink; a derived
+// Debug would defeat it in logs and test panic output.
+impl std::fmt::Debug for IdentityInjection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("IdentityInjection")
+            .field("args_len", &self.args.len())
+            .field("has_secret", &!self.injected_secret.is_empty())
+            .finish()
+    }
+}
+
+/// A test identity that was actually applied to this command, captured for
+/// provenance: `label` attributes the response to a principal (#317 review #6),
+/// `secret` is the exact injected value scrubbed from `effective_command` (#3).
+struct AppliedIdentity {
+    label: String,
+    secret: String,
+}
+
 /// Join `command` and its `args` into a single shell-like string suitable
 /// for `ProbeCommand.command`. Arguments containing whitespace are quoted.
 fn format_full_command(command: &str, args: &[String]) -> String {
@@ -284,7 +338,11 @@ fn header_flags_for(binary: &str, header: &str) -> Option<Vec<String>> {
 ///
 /// Returns `Ok(vec![])` (inject nothing) when the identity is anonymous (empty
 /// material): running with no auth *is* that identity, so it is not a failure.
-fn build_identity_injection(command: &str, label: &str, ctx: &ToolContext) -> Result<Vec<String>> {
+fn build_identity_injection(
+    command: &str,
+    label: &str,
+    ctx: &ToolContext,
+) -> Result<IdentityInjection> {
     let material = ctx.resolve_identity(label).ok_or_else(|| {
         pentest_core::error::Error::InvalidParams(format!(
             "identity_ref '{label}' is not a provisioned test identity; \
@@ -294,16 +352,27 @@ fn build_identity_injection(command: &str, label: &str, ctx: &ToolContext) -> Re
 
     // Anonymous identity: no material to inject. Running as-is IS this identity.
     if material.is_empty() {
-        return Ok(Vec::new());
+        return Ok(IdentityInjection {
+            args: Vec::new(),
+            injected_secret: String::new(),
+        });
     }
 
     let binary = binary_basename(command);
-    header_flags_for(binary, material.expose()).ok_or_else(|| {
+    let header = material.expose();
+    let args = header_flags_for(binary, header).ok_or_else(|| {
         pentest_core::error::Error::InvalidParams(format!(
             "identity_ref '{label}' cannot be injected into '{binary}': no \
              supported custom-header flag for this binary (supported: curl, \
              ffuf, wget, sqlmap). Refusing to run with the identity dropped."
         ))
+    })?;
+
+    Ok(IdentityInjection {
+        args,
+        // The exact injected header value, kept so provenance can scrub it from
+        // the published command by value rather than hoping a regex matches.
+        injected_secret: header.to_string(),
     })
 }
 
@@ -599,11 +668,14 @@ mod tests {
     #[test]
     fn build_injection_known_label_curl_injects_material() {
         let ctx = ctx_with("user_a", "Cookie: sid=secret-abc");
-        let args = build_identity_injection("curl", "user_a", &ctx).expect("known label injects");
+        let injection =
+            build_identity_injection("curl", "user_a", &ctx).expect("known label injects");
         assert_eq!(
-            args,
+            injection.args,
             vec!["-H".to_string(), "Cookie: sid=secret-abc".to_string()]
         );
+        // The exact injected secret is captured so provenance can scrub it by value.
+        assert_eq!(injection.injected_secret, "Cookie: sid=secret-abc");
     }
 
     #[test]
@@ -622,9 +694,10 @@ mod tests {
         // An anonymous identity carries no material: inject nothing and succeed
         // (running with no auth IS that identity), never fail.
         let ctx = ctx_with("anon", "");
-        let args =
+        let injection =
             build_identity_injection("curl", "anon", &ctx).expect("anonymous injects nothing");
-        assert!(args.is_empty());
+        assert!(injection.args.is_empty());
+        assert!(injection.injected_secret.is_empty());
     }
 
     #[test]
@@ -638,9 +711,9 @@ mod tests {
         std::fs::write(&path, r#"[{"label":"unauth","role":"anonymous"}]"#).unwrap();
         let loaded = pentest_core::identity::load_identities_from_file(&path).expect("loader ok");
         let ctx = ToolContext::default().with_identities(loaded.store);
-        let args = build_identity_injection("curl", "unauth", &ctx)
+        let injection = build_identity_injection("curl", "unauth", &ctx)
             .expect("anonymous from real loader injects nothing, does not error");
-        assert!(args.is_empty());
+        assert!(injection.args.is_empty());
         std::fs::remove_file(&path).ok();
     }
 
@@ -663,6 +736,41 @@ mod tests {
         assert!(prov.probe_commands[0].command.contains("secrettoken123"));
     }
 
+    #[test]
+    fn exotic_shape_identity_header_is_scrubbed_by_value_not_pattern() {
+        // #317 review #3: a short, non-hex, oddly-named header value slips past
+        // every redact() regex (no `authorization:`/`cookie:`/keyword, < 32 hex,
+        // < 40 base64). Because the injected secret is KNOWN, from_exact_redacting_secret
+        // scrubs it by exact substring, so it never reaches effective_command
+        // (which is published to reports) regardless of shape.
+        let secret = "X-Api-Id: ab12cd";
+        let full = format_full_command(
+            "curl",
+            &[
+                "-H".to_string(),
+                secret.to_string(),
+                "https://x.test".to_string(),
+            ],
+        );
+
+        // Baseline: pattern redaction alone does NOT catch this shape.
+        assert!(
+            pentest_core::provenance::redact(&full).contains("ab12cd"),
+            "precondition: this shape is not caught by pattern redaction"
+        );
+
+        // Fix: value-scrub removes it from the published form.
+        let pc = ProbeCommand::from_exact_redacting_secret(full, secret);
+        assert!(
+            !pc.effective_command.contains("ab12cd"),
+            "exotic-shape secret leaked into effective_command: {}",
+            pc.effective_command
+        );
+        assert!(pc.effective_command.contains("<REDACTED>"));
+        // Exact form retained (but never serialized).
+        assert!(pc.command.contains("ab12cd"));
+    }
+
     #[tokio::test]
     async fn execute_unknown_identity_ref_fails_without_running() {
         // identity_ref pointing at no known identity fails closed BEFORE any
@@ -679,6 +787,42 @@ mod tests {
         assert_eq!(result.outcome, ToolOutcome::Failed);
         assert!(!result.success);
         assert!(result.error.unwrap_or_default().contains("ghost"));
+    }
+
+    #[tokio::test]
+    async fn execute_with_identity_attributes_provenance_and_scrubs_secret() {
+        // #317 review #6 (attribution) + #3 (value-scrub), end-to-end through
+        // execute/1. curl against an unroutable host still RUNS (produces
+        // provenance) but makes no real network call, so this is deterministic.
+        // Guards the WIRING: the identity label must reach provenance.description
+        // and the injected secret must never appear in effective_command.
+        pentest_platform::set_use_sandbox(false);
+        let tool = ExecuteCommandTool;
+        let ctx = ToolContext::default().with_identities(IdentityStore::from_pairs([(
+            "user_a",
+            SessionMaterial::new("X-Api-Id: ab12cd"),
+        )]));
+        let params = json!({
+            "command": "curl",
+            "args": ["--max-time", "1", "http://127.0.0.1:1/x"],
+            "identity_ref": "user_a",
+        });
+
+        let result = tool.execute(params, &ctx).await.expect("execute ok");
+        let prov = result.provenance.expect("command run produces provenance");
+        let pc = &prov.probe_commands[0];
+
+        // Attribution reached provenance (survives the wire; command does not).
+        assert_eq!(
+            pc.description.as_deref(),
+            Some("authenticated as test identity: user_a")
+        );
+        // The exotic-shape secret is scrubbed from the published form by value.
+        assert!(
+            !pc.effective_command.contains("ab12cd"),
+            "identity secret leaked into effective_command: {}",
+            pc.effective_command
+        );
     }
 
     #[tokio::test]

--- a/crates/tools/src/spawn_specialist.rs
+++ b/crates/tools/src/spawn_specialist.rs
@@ -10,7 +10,7 @@ use pentest_core::error::{Error, Result};
 use pentest_core::matrix::MatrixChatClient;
 use pentest_core::specialist_spawner::{
     AttackSurface, CloudIndicators, DatabaseIndicators, SpawnDecision, SpecialistContext,
-    SpecialistSpawner, SpecialistType,
+    SpecialistSpawner, SpecialistType, TestIdentity,
 };
 use pentest_core::tools::{execute_timed, PentestTool, Platform, ToolContext, ToolResult};
 use serde::{Deserialize, Serialize};
@@ -57,6 +57,14 @@ pub struct SpawnSpecialistInput {
     /// Red Team agent can omit it for non-database specialist spawns.
     #[serde(default)]
     pub database_indicators: DatabaseIndicators,
+
+    /// Operator-provided identities for differential authorization testing
+    /// (pick#162). Supply two or more (e.g. unauth + user + admin, or
+    /// tenant-A + tenant-B) so the WebApp/API specialist can replay requests
+    /// across the matrix and detect broken access control. Defaulted so the
+    /// Red Team agent can omit it for non-authz specialist spawns.
+    #[serde(default)]
+    pub identities: Vec<TestIdentity>,
 
     /// Justification for spawning (required when overriding policy).
     #[serde(default)]
@@ -186,6 +194,7 @@ async fn spawn_specialist_impl(
             cloud_indicators: input.cloud_indicators,
             database_indicators: input.database_indicators,
         },
+        identities: input.identities,
     };
 
     // Evaluate spawn policy
@@ -314,6 +323,7 @@ mod tests {
             entry_points: vec![],
             cloud_indicators: Default::default(),
             database_indicators: Default::default(),
+            identities: vec![],
             justification: None,
         }
     }

--- a/crates/ui/src/components/chat_panel/constants.rs
+++ b/crates/ui/src/components/chat_panel/constants.rs
@@ -691,7 +691,7 @@ The orchestrator hands you a JSON manifest shaped like this:
         "underlying_tool": "...",
         "tool_version": "...",
         "probe_commands": [
-          { "command": "...", "effective_command": "...", "description": "..." }
+          { "effective_command": "...", "description": "..." }
         ],
         "raw_response_excerpt": "..."
       },
@@ -707,7 +707,7 @@ Every entry in `findings` is publishable — the Validator has already confirmed
 ## Hard Rules
 
 1. **Only report what is in the manifest.** Do not invent findings, CVEs, or attack paths. If the manifest is empty, say so plainly.
-2. **Never rewrite provenance.** Render `effective_command` from each finding's `probe_commands[].command`field verbatim — this is the redacted, reviewer-reproducible form. Do not paraphrase it.
+2. **Never rewrite provenance.** Render `effective_command` from each finding's `probe_commands[].effective_command` field verbatim — this is the redacted, reviewer-reproducible form. Do not paraphrase it.
 3. **Severity = `current_severity`**, which is the Validator's final call. If `severity_history` shows a revision (`set_by: validator` and severity differs from the first entry), note it in the finding: "Severity revised from X to Y — reason: ...".
 4. **Cite `set_by: validator` rationale verbatim** when a revision occurred — this is the audit trail a reviewer will look for.
 5. **No scanner tool calls.** You do not have scanners. If you catch yourself planning to scan, stop: the pipeline is already done.
@@ -864,7 +864,7 @@ The orchestrator hands you a `pending_evidence_manifest`:
         "underlying_tool": "...",
         "tool_version": "...",
         "probe_commands": [
-          { "command": "...", "effective_command": "...", "description": "..." }
+          { "effective_command": "...", "description": "..." }
         ],
         "raw_response_excerpt": "..."
       },

--- a/crates/ui/src/liveview_connector/mod.rs
+++ b/crates/ui/src/liveview_connector/mod.rs
@@ -736,22 +736,37 @@ impl LiveViewConnector {
         // (pick#162) once at startup. A missing file yields an empty store; a
         // malformed file is logged and treated as empty rather than blocking
         // connector startup (the operator can fix the file and reconnect).
-        let loaded_identities = match pentest_core::identity::load_default_identities() {
-            Ok(loaded) => {
-                if !loaded.store.is_empty() {
-                    tracing::info!(
-                        "Loaded {} operator identit{} for differential-authz testing",
-                        loaded.store.len(),
-                        if loaded.store.len() == 1 { "y" } else { "ies" }
-                    );
+        //
+        // Resolve the path explicitly (rather than via `load_default_identities`)
+        // so the chosen file is logged at startup. The precedence is
+        // env `PICK_IDENTITIES_FILE` > a cwd `identities.json` > the settings
+        // dir; preferring cwd is a launch-from-unexpected-directory foot-gun, so
+        // making the resolved path auditable is deliberate (#317 finding #8).
+        let identities_path = pentest_core::identity::identities_file_path();
+        tracing::info!(
+            "Resolved test-identities file path: {}",
+            identities_path.display()
+        );
+        let loaded_identities =
+            match pentest_core::identity::load_identities_from_file(&identities_path) {
+                Ok(loaded) => {
+                    if !loaded.store.is_empty() {
+                        tracing::info!(
+                            "Loaded {} operator identit{} for differential-authz testing",
+                            loaded.store.len(),
+                            if loaded.store.len() == 1 { "y" } else { "ies" }
+                        );
+                    }
+                    loaded
                 }
-                loaded
-            }
-            Err(e) => {
-                tracing::warn!("Ignoring identities file: {e}");
-                pentest_core::identity::LoadedIdentities::default()
-            }
-        };
+                Err(e) => {
+                    tracing::warn!(
+                        "Ignoring identities file {}: {e}",
+                        identities_path.display()
+                    );
+                    pentest_core::identity::LoadedIdentities::default()
+                }
+            };
 
         // Advertise the identity *references* (label/role/tenant only, no
         // secrets) to the Red Team orchestrator via InstanceMetadata, the same

--- a/crates/ui/src/liveview_connector/mod.rs
+++ b/crates/ui/src/liveview_connector/mod.rs
@@ -732,6 +732,27 @@ impl LiveViewConnector {
                 .and_then(|h| h.ipc_addr().cloned()),
         ));
 
+        // Load operator-provided test identities for differential-authz tools
+        // (pick#162) once at startup. A missing file yields an empty store; a
+        // malformed file is logged and treated as empty rather than blocking
+        // connector startup (the operator can fix the file and reconnect).
+        let identities = match pentest_core::identity::load_default_identities() {
+            Ok(loaded) => {
+                if !loaded.store.is_empty() {
+                    tracing::info!(
+                        "Loaded {} operator identit{} for differential-authz testing",
+                        loaded.store.len(),
+                        if loaded.store.len() == 1 { "y" } else { "ies" }
+                    );
+                }
+                loaded.store
+            }
+            Err(e) => {
+                tracing::warn!("Ignoring identities file: {e}");
+                pentest_core::identity::IdentityStore::new()
+            }
+        };
+
         // Build the PickConnector that implements BaseConnector
         let pick_connector = Arc::new(pick_connector::PickConnector {
             tools: self.tools.clone(),
@@ -748,6 +769,7 @@ impl LiveViewConnector {
             // the health handler. Starts None → /health reports "starting" until set.
             runner: self.runner.clone(),
             matrix_api_url: self.derive_matrix_api_url(),
+            identities: Arc::new(identities),
         });
 
         // Create the ConnectorRunner — it manages connection lifecycle, auth,

--- a/crates/ui/src/liveview_connector/mod.rs
+++ b/crates/ui/src/liveview_connector/mod.rs
@@ -760,11 +760,19 @@ impl LiveViewConnector {
                     loaded
                 }
                 Err(e) => {
-                    tracing::warn!(
-                        "Ignoring identities file {}: {e}",
+                    // A malformed identities file (bad JSON, unknown role, or a
+                    // non-anonymous identity with no credential) must NOT degrade
+                    // to zero identities: specialists would still run the
+                    // differential-authz prompts and report "no broken access
+                    // control" when nothing was actually tested. Refuse to start
+                    // (#317 review #3). A *missing* file is not an error -
+                    // `load_identities_from_file` returns empty for NotFound - so
+                    // only genuine corruption reaches this arm.
+                    return Err(format!(
+                        "refusing to start: identities file {} is unreadable or malformed: {e}. \
+                         Fix or remove it (a missing file is fine and means no test identities).",
                         identities_path.display()
-                    );
-                    pentest_core::identity::LoadedIdentities::default()
+                    ));
                 }
             };
 

--- a/crates/ui/src/liveview_connector/mod.rs
+++ b/crates/ui/src/liveview_connector/mod.rs
@@ -736,7 +736,7 @@ impl LiveViewConnector {
         // (pick#162) once at startup. A missing file yields an empty store; a
         // malformed file is logged and treated as empty rather than blocking
         // connector startup (the operator can fix the file and reconnect).
-        let identities = match pentest_core::identity::load_default_identities() {
+        let loaded_identities = match pentest_core::identity::load_default_identities() {
             Ok(loaded) => {
                 if !loaded.store.is_empty() {
                     tracing::info!(
@@ -745,13 +745,29 @@ impl LiveViewConnector {
                         if loaded.store.len() == 1 { "y" } else { "ies" }
                     );
                 }
-                loaded.store
+                loaded
             }
             Err(e) => {
                 tracing::warn!("Ignoring identities file: {e}");
-                pentest_core::identity::IdentityStore::new()
+                pentest_core::identity::LoadedIdentities::default()
             }
         };
+
+        // Advertise the identity *references* (label/role/tenant only, no
+        // secrets) to the Red Team orchestrator via InstanceMetadata, the same
+        // mechanism as `host_interfaces` above (matrix#2274). The orchestrator
+        // reads this to pass identities to spawn_specialist (matrix#3354). The
+        // session material stays connector-side in the store below.
+        if let Some(value) =
+            pentest_core::identity::references_metadata_value(&loaded_identities.references)
+        {
+            sdk_config.metadata.insert(
+                pentest_core::identity::IDENTITIES_METADATA_KEY.to_string(),
+                value,
+            );
+        }
+
+        let identities = loaded_identities.store;
 
         // Build the PickConnector that implements BaseConnector
         let pick_connector = Arc::new(pick_connector::PickConnector {

--- a/crates/ui/src/liveview_connector/pick_connector.rs
+++ b/crates/ui/src/liveview_connector/pick_connector.rs
@@ -52,6 +52,10 @@ pub(crate) struct PickConnector {
     pub runner: Arc<RwLock<Option<Arc<strike48_connector::ConnectorRunner>>>>,
     /// Matrix API URL derived from config for tool context
     pub matrix_api_url: String,
+    /// Operator-provided test identities (pick#162), loaded once from the
+    /// gitignored identities file at construction and cloned into each tool
+    /// context. Empty when no identities file is present.
+    pub identities: Arc<pentest_core::identity::IdentityStore>,
 }
 
 impl PickConnector {
@@ -290,6 +294,10 @@ impl BaseConnector for PickConnector {
                 // Set aggression level and agent name
                 ctx = ctx.with_aggression_level(*self.aggression_level.read().await);
                 ctx = ctx.with_agent_name(self.connector_name.clone());
+
+                // Provide operator identities for differential-authz tools
+                // (pick#162). Loaded once at construction; cloned per call.
+                ctx = ctx.with_identities((*self.identities).clone());
 
                 // Create Matrix client if API URL is available
                 let api_url = self.derive_matrix_api_url();
@@ -636,6 +644,7 @@ mod tests {
             ipc_addr: Arc::new(RwLock::new(None)),
             runner: Arc::new(RwLock::new(None)),
             matrix_api_url: String::new(),
+            identities: Arc::new(pentest_core::identity::IdentityStore::new()),
         }
     }
 

--- a/crates/ui/src/liveview_connector/pick_connector.rs
+++ b/crates/ui/src/liveview_connector/pick_connector.rs
@@ -749,6 +749,58 @@ mod tests {
         );
     }
 
+    /// Production-path regression guard for the #317 review HIGH-2 (reflected
+    /// credential): on a differential-authz identity run the connector splices
+    /// the operator's secret (`Authorization: Bearer <token>`) into argv, so a
+    /// target that reflects the request header (verbose/echo/error page, `curl
+    /// -v` on stderr) lands that secret in `data.stdout`/`stderr`. That field is
+    /// returned to the agent by `execute_with_context`, which would carry the
+    /// customer credential across the exact Matrix/LLM boundary the
+    /// differential-authz feature exists to protect.
+    ///
+    /// This is the read-side counterpart to the emit-side custody
+    /// (`SessionMaterial` non-Serialize; `ProbeCommand.command` skip-serialize):
+    /// the #320/#331 `sanitize_agent_result` choke point on the production
+    /// connector recursively scrubs secret shapes out of `data` before the result
+    /// reaches the agent. We simulate the reflection deterministically by echoing
+    /// a credential-shaped line (no network / no target dependency); the secret
+    /// must not survive to the agent-facing stdout. Reverting the
+    /// `sanitize_agent_result` call in `execute_with_context` turns this red.
+    #[tokio::test]
+    async fn execute_with_context_scrubs_reflected_credential_from_stdout() {
+        // Direct host execution — the sandbox rootfs isn't present on CI.
+        pentest_platform::set_use_sandbox(false);
+
+        let connector = test_connector();
+        let secret = "sk-super-secret-token-abcdef1234567890";
+        // Stand in for a target reflecting the injected auth header back in its
+        // response body — the exact shape `redact` targets.
+        let reflected = format!("Authorization: Bearer {secret}");
+        let request = json!({
+            "tool": "execute_command",
+            "parameters": { "command": "echo", "args": [reflected] }
+        });
+        let ctx: HashMap<String, String> = HashMap::new();
+
+        let result = connector
+            .execute_with_context(request, None, &ctx)
+            .await
+            .expect("execute_with_context failed");
+
+        let stdout = result["data"]["stdout"].as_str().unwrap_or("");
+        assert!(
+            !stdout.contains(secret),
+            "production path must scrub a reflected credential from stdout; got: {stdout:?}"
+        );
+        // The whole serialized result must be secret-free, not just stdout —
+        // guards against the credential surviving in any sibling field.
+        let whole = result.to_string();
+        assert!(
+            !whole.contains(secret),
+            "reflected credential leaked somewhere in the agent-facing result: {whole}"
+        );
+    }
+
     /// Benign tool output must pass through the production path byte-for-byte —
     /// no `_sanitization` marker, real evidence unmangled.
     #[tokio::test]

--- a/identities.example.json
+++ b/identities.example.json
@@ -1,0 +1,23 @@
+[
+  {
+    "label": "unauth",
+    "role": "anonymous"
+  },
+  {
+    "label": "user_a",
+    "role": "user",
+    "tenant": "tenant-1",
+    "session": "Cookie: session=REPLACE_WITH_REAL_SESSION_COOKIE"
+  },
+  {
+    "label": "user_b",
+    "role": "user",
+    "tenant": "tenant-2",
+    "session": "Cookie: session=REPLACE_WITH_REAL_SESSION_COOKIE"
+  },
+  {
+    "label": "admin",
+    "role": "privileged",
+    "session": "Authorization: Bearer REPLACE_WITH_REAL_ADMIN_TOKEN"
+  }
+]

--- a/skills/claude-red/specialists/api-specialist.md
+++ b/skills/claude-red/specialists/api-specialist.md
@@ -128,27 +128,43 @@ Reference: OWASP API Security Top 10 (2023), specifically API2 and API8.
 Object-level and function-level authorization are the two highest-yield API
 bug classes per OWASP API Security Top 10.
 
+**The identity matrix.** The `identities` field of your context lists the
+operator-provided test identities — each a `label` (e.g. `unauth`, `user_a`,
+`user_b`, `admin`), a `role` (`anonymous` / `user` / `privileged`), and an
+optional `tenant`. You do **not** hold their credentials; the connector does.
+Reference an identity by `label` in your tool calls (`identity_ref: "user_b"`)
+and the connector injects its session locally. Never invent identities or
+credentials outside the matrix. The replays below use these labels rather than
+abstract "user A/B".
+
 - **BOLA (Broken Object Level Authorization, API1:2023).** For every endpoint
   that operates on a resource by ID (`GET /api/orders/12345`,
-  `DELETE /api/users/777`), test cross-tenant access:
-  - Authenticate as user A, capture the request.
-  - Replay as user B with no other change. Does B retrieve A's data?
+  `DELETE /api/users/777`), test cross-identity/cross-tenant access:
+  - As `user_a`, capture a request for an object `user_a` owns (baseline).
+  - Replay it as `user_b` with no other change — does `user_b` retrieve
+    `user_a`'s data? Swap tenant-scoped IDs across `tenant` values too.
   - Test sequential IDs (1, 2, 3) and UUIDs separately. UUIDs are not
     automatically safe — they only delay enumeration.
   - Test indirect references: filename, slug, account number, email.
 - **BFLA (Broken Function Level Authorization, API5:2023).** For every
   privileged endpoint (`POST /api/admin/users`, `DELETE /api/...`):
-  - Authenticate as a low-privilege user. Replay the request. Does it
-    succeed?
+  - Replay the request as a non-privileged identity (`user_a`, or `unauth`).
+    Does it succeed? A `401`/`403` confirms the control works — not a finding.
   - Try changing the HTTP method on existing routes — `GET /api/orders/123`
     works, does `DELETE /api/orders/123` quietly succeed?
-  - Try the admin path with the user token. Frameworks often gate by URL
-    pattern; if the gate is misconfigured, you escalate.
+  - Try the admin path with a non-privileged identity. Frameworks often gate by
+    URL pattern; if the gate is misconfigured, you escalate.
 - **Mass assignment (API6:2023).** Send extra fields the documentation does
   not list. Common bypasses: `role`, `is_admin`, `account_id`, `verified`,
   `email_verified`, `tier`, `discount_pct`. PATCH and PUT endpoints are
   worse than POST because they often accept partial updates that bypass
   validation logic.
+
+**Reduced-coverage degradation.** BOLA/BFLA differential testing needs at least
+two identities. If `identities` has fewer than two, you cannot diff across the
+matrix: fall back to unauth-vs-authed checks on privileged endpoints and state
+explicitly in your findings that authorization coverage was reduced for lack of
+a multi-identity matrix — do not silently skip Phase 3.
 
 For every authorization finding, capture both directions: the request that
 should have failed, and proof it succeeded. The Validator wants the diff.

--- a/skills/claude-red/specialists/web-app-specialist.md
+++ b/skills/claude-red/specialists/web-app-specialist.md
@@ -110,12 +110,52 @@ Test the perimeter that gates everything else.
 Authorization is the highest-yield area in modern web pentests. Every endpoint
 that returns or modifies data is a candidate for IDOR.
 
-- Capture the request set as user A.
-- Replay each request as user B (same role, different identity) — does data leak?
-- Replay each request as user C (lower role) — does privilege escalation work?
-- Replay each request unauthenticated — does the endpoint require auth at all?
-- Test forced browsing to admin paths. Frameworks often gate routes by URL
-  pattern; if the gate is missing, you walk in.
+**The identity matrix.** The `identities` field of your context lists the
+operator-provided test identities, each with a `label` (e.g. `unauth`,
+`user_a`, `user_b`, `admin`), a `role` (`anonymous` / `user` / `privileged`),
+and an optional `tenant`. You do **not** hold their credentials — the connector
+does. To act as an identity, reference it by `label` in your tool calls
+(`identity_ref: "admin"`); the connector injects that identity's session
+locally. Never invent identities or credentials that are not in the matrix.
+
+Differential method — for each endpoint that returns or modifies data:
+
+- Establish the privileged baseline: request it as the highest-privilege
+  identity that legitimately has access and record the successful response.
+- Replay the same request as each **lower-privilege** identity (and as
+  `unauth`). If a weaker identity receives substantively the same successful
+  content instead of a `401`/`403`, that is broken access control:
+  - lower `role` reaching privileged content/functions → **vertical**
+    escalation (BFLA analogue).
+  - same `role`, different identity/tenant reaching another's object →
+    **horizontal** escalation (BOLA/IDOR).
+- **Object-reference swap for BOLA:** as `user_a`, take an object identifier
+  `user_a` legitimately owns, then request it as `user_b` (and vice-versa), and
+  swap tenant-scoped identifiers across `tenant` values. Getting the other
+  owner's object back is a confirmed BOLA finding — stop at first proof per
+  endpoint (see aggression limits).
+- A properly-denied replay (`401`/`403`) **confirms the control works** — do not
+  report it. Only a weaker identity that is *not* denied is a finding; this
+  differential baseline is what keeps false positives off legitimately public
+  endpoints.
+
+**Co-hosted internal paths (same host, different paths).** A common topology
+serves a public app and a privileged/internal surface from the same host on
+different paths. Discover those internal paths and test them against the matrix:
+- Content-discover privileged prefixes on the shared host (`/admin`,
+  `/internal`, `/api/internal`, `/actuator`, `/debug`, role-segmented prefixes)
+  — integrate with existing recon, do not reinvent a brute-forcer.
+- Harvest routes from client-side JS route tables / SPA route maps — the
+  internal routes a public user "should not see" are frequently shipped in JS.
+- For each discovered internal path, run the differential replay above:
+  forced-browse it as `unauth` and as each non-privileged identity.
+
+**Reduced-coverage degradation.** The differential method needs at least two
+identities. If `identities` has fewer than two, you cannot diff across the
+matrix: fall back to unauth-vs-authed forced-browsing checks on discovered
+paths, and state explicitly in your findings that authorization coverage was
+reduced for lack of a multi-identity matrix (do not silently skip Phase 3).
+
 - See OWASP WSTG section 4.5 (Authorization) and OWASP API Security Top 10
   API1:2023 (BOLA) — the API risk applies to web apps too.
 


### PR DESCRIPTION
## Summary

Delivers the Pick-side reference flow for differential authorization testing (BOLA/BFLA/forced-browsing) behind pick#162 and the pick#164 customer-attack-surface epic. Operator-provided test identities now load into a connector-side store, are advertised (references only) to the Red Team orchestrator, and are consumed by the WebApp/API specialist prompts - all while keeping the customer's credentials off the Matrix/LLM boundary.

## Re-scope note (please read before reviewing)

The issue proposed a Rust differential-authz *engine* (`crates/core/src/specialist/authz/*.rs`). Pick's specialists are **prompt-driven markdown skills**, not Rust attack logic - so this PR delivers the pieces that were actually missing (identity intake, connector-side secret custody, orchestrator advertisement, prompt wiring) and keeps execution in the LLM + existing tools. Full rationale on pick#162. This is deliberately **not** the literal module layout from the issue.

## What's in this PR (3 commits)

1. **Identity model + connector-side store** - `TestIdentity { label, role, tenant }` reference on `SpecialistContext` (serde-defaulted); new `identity.rs` with `SessionMaterial` (secret; non-`Serialize`; redacts in Debug/Display) + `IdentityStore` on `ToolContext` (resolve by label; Debug shows labels, never material).
2. **Standalone file population** - loads a gitignored `identities.json` at startup (missing = no-op; malformed/unknown-role = loud error); kept out of `settings.json` by design; `identities.example.json` documents the schema.
3. **Orchestrator advertisement (Hop A) + prompt wiring (Hop C)** - connector advertises identity *references* via `InstanceMetadata` (mirrors `host_interfaces`; consumed by matrix#3354); WebApp/API prompts consume the `identities` matrix via `identity_ref`, run the differential replay + BOLA object/tenant swap + co-hosted `/admin` discovery, treat 401/403 as a working control, and report reduced coverage below two identities.

## Security design

- `SessionMaterial` is non-serializable and never written to `settings.json` (plaintext) - credentials rest only in the operator-owned, gitignored `identities.json`.
- Guard tests: `TestIdentity` never serializes a secret; the advertised metadata value carries labels/roles but no session material; redaction holds under nested Debug.
- Type 1 (operator-provided) only; Type 2 (discovered) is a separate policy (pick#313).

## Cross-repo dependency

- **matrix#3354** - the Red Team orchestrator must read the advertised references and forward them to `spawn_specialist`. This is the keystone that activates the feature end-to-end; the metadata contract is spelled out there.

## Deferred (tracked)

pick#312 (StrikeKit provisioning) - pick#314 (execute_command injection) - pick#315 (webwright injection) - pick#316 (Settings UI) - pick#313 (Type 2 flagging)

## Test plan

- [x] `cargo check --workspace --locked --features pentest-platform/desktop-pcap`
- [x] `cargo clippy --workspace --locked --features pentest-platform/desktop-pcap -- -D warnings`
- [x] `cargo test --workspace ...` - all suites pass (see caveat below)
- [x] identity unit tests: redaction (incl. nested Debug), store resolve/miss, file loader (missing/valid/malformed/unknown-role), metadata refs-carry-no-secret
- [x] serde back-compat: context without `identities` deserializes
- [x] prompt-wiring guard: WebApp/API prompts reference the identity matrix (`identities`/`identity_ref`/reduced-coverage)
- [x] gitignore: `identities.json` ignored, `identities.example.json` trackable

### Caveat (Lens 4 - pre-existing, not introduced)

The full `--workspace` run intermittently hit a **pre-existing flaky SIGABRT** ("stack smashing detected") in the pcap-backed `tool_integration::port_scan_requires_host_flat` under heavy parallel load. It passes **30/30 in isolation**; this branch touches no pcap/port_scan/platform code. Tracked as pick#318.