### PR TITLE
fix(port_scan): distinguish unreachable hosts from closed ports (#306)

### DIFF
--- a/crates/platform/src/android/network.rs
+++ b/crates/platform/src/android/network.rs
@@ -2,24 +2,13 @@
 
 use crate::traits::*;
 use pentest_core::error::Result;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 /// Perform a port scan
 pub async fn port_scan(config: ScanConfig) -> Result<ScanResult> {
-    let start = Instant::now();
     let timeout = Duration::from_millis(config.timeout_ms);
 
-    let ports = crate::common::tcp_port_scan(&config.host, &config.ports, timeout, 0).await;
-
-    let open_count = ports.iter().filter(|p| p.open).count();
-    let duration_ms = start.elapsed().as_millis() as u64;
-
-    Ok(ScanResult {
-        host: config.host,
-        ports,
-        duration_ms,
-        open_count,
-    })
+    Ok(crate::common::tcp_port_scan(&config.host, &config.ports, timeout, 0).await)
 }
 
 /// Get the ARP table with layered fallback (bd-23):

--- a/crates/platform/src/common.rs
+++ b/crates/platform/src/common.rs
@@ -3,10 +3,11 @@
 //! This module extracts duplicated port-scanning and ARP-parsing code that was
 //! previously copy-pasted across android, desktop, and iOS implementations.
 
-use crate::traits::{port_to_service, ArpEntry, ScannedPort};
+use crate::traits::{port_to_service, ArpEntry, PortState, ScanResult, ScannedPort};
+use std::io;
 use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::Semaphore;
 
 /// The command that reports whether a binary is on the host's PATH.
@@ -39,22 +40,91 @@ fn resolve_addr(addr: &str, port: u16) -> SocketAddr {
     })
 }
 
+/// Classify the outcome of a `connect_timeout` into a [`PortState`].
+///
+/// `None` means the connect succeeded (`Open`). For a failure we inspect the
+/// [`io::ErrorKind`] so a genuinely closed port, a firewalled/timed-out port,
+/// and a host we never reached stay distinct facts (#306). Collapsing them all
+/// to "closed" lets an unroutable scan read as "checked and clean".
+fn classify_connect(err: Option<io::ErrorKind>) -> PortState {
+    match err {
+        None => PortState::Open,
+        // A reachable host explicitly refused the connection: nothing listening.
+        Some(io::ErrorKind::ConnectionRefused) => PortState::Closed,
+        // We never reached the target. `PermissionDenied` covers a sandbox or a
+        // missing capability blocking the socket, which is likewise not a fact
+        // about the remote port.
+        Some(io::ErrorKind::HostUnreachable)
+        | Some(io::ErrorKind::NetworkUnreachable)
+        | Some(io::ErrorKind::PermissionDenied) => PortState::Unreachable,
+        // Timeouts and anything else are indeterminate: could be a drop-by-policy
+        // firewall or a slow host. Report as filtered, never as closed.
+        Some(_) => PortState::Filtered,
+    }
+}
+
 /// Probe a single port on the given host string (which may be `ip:port` or
 /// `hostname:port`).  DNS resolution is attempted when the address does not
 /// parse directly as a [`SocketAddr`].
 fn probe_port(host: &str, port: u16, timeout: Duration) -> ScannedPort {
     let addr_str = format!("{}:{}", host, port);
     let socket_addr = resolve_addr(&addr_str, port);
-    let open = TcpStream::connect_timeout(&socket_addr, timeout).is_ok();
+    let state = classify_connect(
+        TcpStream::connect_timeout(&socket_addr, timeout)
+            .err()
+            .map(|e| e.kind()),
+    );
+    let open = state == PortState::Open;
 
     ScannedPort {
         port,
         open,
+        state,
         service: if open {
             port_to_service(port).map(String::from)
         } else {
             None
         },
+    }
+}
+
+/// Assemble a [`ScanResult`] from probed ports, tallying open and unreachable
+/// counts and rendering reachability failures into `errors[]`.
+///
+/// Pure and deterministic so it is unit-testable without a network: given the
+/// same ports it always produces the same counts and error strings. This is
+/// where "we could not check" is made distinguishable from "we checked and
+/// found nothing" (#306).
+fn assemble_scan_result(host: String, ports: Vec<ScannedPort>, duration_ms: u64) -> ScanResult {
+    let open_count = ports.iter().filter(|p| p.open).count();
+    let unreachable_count = ports
+        .iter()
+        .filter(|p| p.state == PortState::Unreachable)
+        .count();
+
+    let errors: Vec<String> = ports
+        .iter()
+        .filter(|p| p.state == PortState::Unreachable)
+        .map(|p| {
+            // Deliberately does not assert a specific cause: Unreachable folds
+            // host/network-unreachable AND local sandbox/capability blocks
+            // (PermissionDenied), so claiming "host unreachable" would overstate
+            // what we know. The fact worth reporting is only that no probe
+            // reached the target (#306).
+            format!(
+                "{}:{} unreachable (probe never reached the target)",
+                host, p.port
+            )
+        })
+        .collect();
+
+    ScanResult {
+        host,
+        ports,
+        duration_ms,
+        open_count,
+        unreachable_count,
+        errors,
     }
 }
 
@@ -71,12 +141,19 @@ fn probe_port(host: &str, port: u16, timeout: Duration) -> ScannedPort {
 /// directly as a [`SocketAddr`], the address is resolved via [`ToSocketAddrs`].
 ///
 /// Open ports are annotated with a service name via [`port_to_service`].
+///
+/// Returns a full [`ScanResult`] with timing and open/unreachable tallies so
+/// every platform wrapper shares one assembly path (and cannot drift on how a
+/// failed probe is counted). A probe that never reached the target is recorded
+/// as [`PortState::Unreachable`] and surfaced in [`ScanResult::errors`], never
+/// silently folded into a closed port (#306).
 pub async fn tcp_port_scan(
     host: &str,
     ports: &[u16],
     timeout: Duration,
     max_concurrent: usize,
-) -> Vec<ScannedPort> {
+) -> ScanResult {
+    let start = Instant::now();
     let semaphore = if max_concurrent > 0 {
         Some(Arc::new(Semaphore::new(max_concurrent)))
     } else {
@@ -98,9 +175,13 @@ pub async fn tcp_port_scan(
 
             tokio::task::spawn_blocking(move || probe_port(&host, port, timeout))
                 .await
+                // A join failure means the probe never completed, so we cannot
+                // claim the port is closed. Record it as Unreachable, not a
+                // silent open:false (#306).
                 .unwrap_or(ScannedPort {
                     port,
                     open: false,
+                    state: PortState::Unreachable,
                     service: None,
                 })
         });
@@ -114,7 +195,9 @@ pub async fn tcp_port_scan(
             results.push(result);
         }
     }
-    results
+
+    let duration_ms = start.elapsed().as_millis() as u64;
+    assemble_scan_result(host.to_owned(), results, duration_ms)
 }
 
 /// Parse the contents of `/proc/net/arp` into a list of [`ArpEntry`] values.
@@ -207,5 +290,136 @@ mod tests {
         } else {
             assert_eq!(cmd, "which");
         }
+    }
+
+    // ── #306: reachability is distinct from closed ──────────────────────
+    //
+    // These exercise the pure classification/assembly seam without a network,
+    // so they run in the standard suite on every CI lane. The connect() path
+    // itself is I/O and platform-dependent; the fact worth guarding is that a
+    // failed probe never masquerades as a closed-and-clean port.
+
+    fn port(port: u16, state: PortState) -> ScannedPort {
+        ScannedPort {
+            port,
+            open: state == PortState::Open,
+            state,
+            service: None,
+        }
+    }
+
+    #[test]
+    fn classify_success_is_open() {
+        assert_eq!(classify_connect(None), PortState::Open);
+    }
+
+    #[test]
+    fn classify_refused_is_closed() {
+        // A reachable host that refuses the connection is a genuine closed port.
+        assert_eq!(
+            classify_connect(Some(io::ErrorKind::ConnectionRefused)),
+            PortState::Closed
+        );
+    }
+
+    #[test]
+    fn classify_unreachable_kinds_are_unreachable_not_closed() {
+        // The core of #306: host/network unreachable and sandbox-blocked
+        // (PermissionDenied) connects must NOT collapse into a closed port.
+        for kind in [
+            io::ErrorKind::HostUnreachable,
+            io::ErrorKind::NetworkUnreachable,
+            io::ErrorKind::PermissionDenied,
+        ] {
+            let state = classify_connect(Some(kind));
+            assert_eq!(
+                state,
+                PortState::Unreachable,
+                "{kind:?} must classify as Unreachable, got {state:?}"
+            );
+            assert_ne!(
+                state,
+                PortState::Closed,
+                "{kind:?} must never read as closed"
+            );
+        }
+    }
+
+    #[test]
+    fn classify_timeout_is_filtered_not_closed() {
+        // A timeout is indeterminate (firewall drop or slow host), never a
+        // proven-closed port.
+        let state = classify_connect(Some(io::ErrorKind::TimedOut));
+        assert_eq!(state, PortState::Filtered);
+        assert_ne!(state, PortState::Closed);
+    }
+
+    #[test]
+    fn unreachable_scan_is_not_reported_as_scanned_and_clean() {
+        // Regression for #306: an unroutable host yields zero open ports, but
+        // the result must record the unreachability rather than looking clean.
+        let ports = vec![
+            port(22, PortState::Unreachable),
+            port(80, PortState::Unreachable),
+            port(443, PortState::Unreachable),
+        ];
+        let result = assemble_scan_result("203.0.113.7".to_string(), ports, 5);
+
+        assert_eq!(result.open_count, 0, "no ports should read as open");
+        assert_eq!(
+            result.unreachable_count, 3,
+            "all three probes were unreachable"
+        );
+        assert_eq!(
+            result.unreachable_count,
+            result.ports.len(),
+            "fully unreachable host: no packet reached the target"
+        );
+        assert_eq!(result.errors.len(), 3, "each failure must surface an error");
+        assert!(
+            result.errors.iter().all(|e| e.contains("203.0.113.7")),
+            "errors name the host: {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn clean_scan_has_no_errors() {
+        // A reachable host with everything closed is genuinely clean: zero open,
+        // zero unreachable, empty errors — distinguishable from the case above.
+        let ports = vec![
+            port(80, PortState::Open),
+            port(22, PortState::Closed),
+            port(3306, PortState::Closed),
+        ];
+        let result = assemble_scan_result("192.0.2.10".to_string(), ports, 3);
+
+        assert_eq!(result.open_count, 1);
+        assert_eq!(result.unreachable_count, 0);
+        assert!(
+            result.errors.is_empty(),
+            "a reachable scan reports no reachability errors: {:?}",
+            result.errors
+        );
+    }
+
+    #[test]
+    fn mixed_scan_counts_only_unreachable_as_errors() {
+        // Filtered ports are indeterminate but were reached, so they are not
+        // scan failures — only Unreachable feeds unreachable_count/errors.
+        let ports = vec![
+            port(80, PortState::Open),
+            port(81, PortState::Filtered),
+            port(82, PortState::Unreachable),
+        ];
+        let result = assemble_scan_result("198.51.100.5".to_string(), ports, 7);
+
+        assert_eq!(result.open_count, 1);
+        assert_eq!(
+            result.unreachable_count, 1,
+            "only the Unreachable port counts"
+        );
+        assert_eq!(result.errors.len(), 1);
+        assert!(result.errors[0].contains(":82"), "error names the port");
     }
 }

--- a/crates/platform/src/desktop/network.rs
+++ b/crates/platform/src/desktop/network.rs
@@ -11,22 +11,12 @@ use std::time::{Duration, Instant};
 /// (via [`std::net::ToSocketAddrs`]) and semaphore-based concurrency limiting
 /// (driven by `ScanConfig::concurrency`).
 pub async fn port_scan(config: ScanConfig) -> Result<ScanResult> {
-    let start = Instant::now();
     let timeout = Duration::from_millis(config.timeout_ms);
 
-    let ports =
+    Ok(
         crate::common::tcp_port_scan(&config.host, &config.ports, timeout, config.concurrency)
-            .await;
-
-    let open_count = ports.iter().filter(|p| p.open).count();
-    let duration_ms = start.elapsed().as_millis() as u64;
-
-    Ok(ScanResult {
-        host: config.host,
-        ports,
-        duration_ms,
-        open_count,
-    })
+            .await,
+    )
 }
 
 /// Get the system ARP table

--- a/crates/platform/src/ios/mod.rs
+++ b/crates/platform/src/ios/mod.rs
@@ -23,22 +23,9 @@ impl Default for IosPlatform {
 #[async_trait]
 impl NetworkOps for IosPlatform {
     async fn port_scan(&self, config: ScanConfig) -> Result<ScanResult> {
-        use std::time::Instant;
-
-        let start = Instant::now();
         let timeout = Duration::from_millis(config.timeout_ms);
 
-        let ports = crate::common::tcp_port_scan(&config.host, &config.ports, timeout, 0).await;
-
-        let open_count = ports.iter().filter(|p| p.open).count();
-        let duration_ms = start.elapsed().as_millis() as u64;
-
-        Ok(ScanResult {
-            host: config.host,
-            ports,
-            duration_ms,
-            open_count,
-        })
+        Ok(crate::common::tcp_port_scan(&config.host, &config.ports, timeout, 0).await)
     }
 
     async fn get_arp_table(&self) -> Result<Vec<ArpEntry>> {

--- a/crates/platform/src/traits.rs
+++ b/crates/platform/src/traits.rs
@@ -188,11 +188,36 @@ pub trait WifiAttackOps: Send + Sync {
 /// Port scan configuration (re-exported from pentest-core to avoid duplication)
 pub use pentest_core::state::ScanConfig;
 
+/// Outcome of probing a single TCP port.
+///
+/// Distinguishing these matters for a pentest report: a genuinely closed port
+/// (`Closed`) and a host that was never reachable (`Unreachable`) must not read
+/// the same way. Collapsing every non-open outcome into "closed" lets an
+/// unroutable scan masquerade as "checked and clean" (#306).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PortState {
+    /// The connect succeeded — a service is listening.
+    Open,
+    /// The connect was actively refused (`ConnectionRefused`) — a reachable
+    /// host with nothing listening on this port.
+    Closed,
+    /// The connect timed out or failed indeterminately — likely firewalled or
+    /// silently dropped. Not proof of closed, not proof of unreachable.
+    Filtered,
+    /// The probe never reached the target: host/network unreachable, or blocked
+    /// by the sandbox / a missing capability. This is a scan failure, not a
+    /// finding about the port.
+    Unreachable,
+}
+
 /// Scanned port result
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScannedPort {
     pub port: u16,
+    /// Retained for backward compatibility; equivalent to `state == Open`.
     pub open: bool,
+    pub state: PortState,
     pub service: Option<String>,
 }
 
@@ -203,6 +228,14 @@ pub struct ScanResult {
     pub ports: Vec<ScannedPort>,
     pub duration_ms: u64,
     pub open_count: usize,
+    /// Number of probes that never reached the target (see [`PortState::Unreachable`]).
+    /// When this equals the number of ports scanned, the host was never
+    /// reachable and the empty open-port list must not be read as "clean".
+    pub unreachable_count: usize,
+    /// Human-readable reachability failures encountered during the scan. Empty
+    /// on a fully successful scan; populated so a caller can tell "we checked
+    /// and found nothing" apart from "we could not check".
+    pub errors: Vec<String>,
 }
 
 /// ARP table entry

--- a/crates/tools/src/port_scan.rs
+++ b/crates/tools/src/port_scan.rs
@@ -109,6 +109,12 @@ impl PentestTool for PortScanTool {
                 "host": result.host,
                 "ports": result.ports,
                 "open_count": result.open_count,
+                // Surface reachability failures so the agent can tell "we
+                // checked and found nothing open" apart from "we could not
+                // reach the target" (#306). A scan where unreachable_count
+                // equals total_scanned means no packet reached the host.
+                "unreachable_count": result.unreachable_count,
+                "errors": result.errors,
                 "total_scanned": result.ports.len(),
                 "duration_ms": result.duration_ms,
             }))


### PR DESCRIPTION
## Summary

- `probe_port` classified every `connect_timeout` failure with `is_ok()`, so a refused port, a timeout, and a host that was never reachable all collapsed into `open: false`. A scan of an unroutable subnet returned `open_count: 0` with no errors, which the agent reads as "checked and clean" when no packet ever reached the target. Fixes #306.
- Inspect `io::ErrorKind` and classify into a new `PortState` enum: `ConnectionRefused` -> `Closed`; `HostUnreachable`/`NetworkUnreachable`/`PermissionDenied` -> `Unreachable`; `TimedOut`/other -> `Filtered` (never reported as closed).
- `ScanResult` gains `unreachable_count` + `errors[]`; `ScannedPort` gains `state` (`open: bool` retained for back-compat). The tool JSON surfaces both new fields, so a scan whose failures carry an unreachable errno is distinguishable from a clean one.
- Scope note (verified empirically): a host is classified `Unreachable` only when the OS supplies the errno (`HostUnreachable`/`NetworkUnreachable`/`PermissionDenied` - e.g. IPv6 no-route, on-link ARP failure, sandbox denial). On a normally-routed network, connecting to a dead IPv4 host **times out** before the OS emits `HostUnreachable`, so it classifies as `Filtered`, not `Unreachable`. That is deliberate: an all-timeout result is genuinely ambiguous between "host down" and "host silently drops all packets" (policy firewall), and inferring "down" would false-positive on live-but-firewalled hosts. Inferring host-down from an all-timeout/zero-response scan is tracked as a follow-up in #337.
- `tcp_port_scan` now owns timing/tallies and returns `ScanResult`, collapsing the three identical per-platform wrappers (desktop/android/ios) into one assembly path so they cannot drift on how a failed probe is counted.

## Test plan

- [x] `cargo test -p pentest-platform --lib common::` - 8 new unit tests pass (classify + assemble seam, network-free)
- [x] `cargo test -p pentest-core --test tool_integration port_scan` - 4 existing integration tests pass
- [x] `cargo check --workspace --all-targets` - clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` - clean (only pre-existing `screenshots` future-incompat warning)
- [x] Mutation-verified (Lens 1): reverting `classify_connect` to collapse-all-to-closed turns the classifier tests red; zeroing the tally in `assemble_scan_result` turns the "scanned-and-clean" regression tests red
- [x] CI-scope (Lens 2): tests are unfeatured `#[cfg(test)]` in `pentest-platform` `--lib`, so they run in both the Linux (`--workspace`) and macOS (package-scoped `--lib`) required lanes

## Notes

Acceptance criteria from #306, honestly scoped: `ErrorKind` inspected and classified; refused stays closed; timeout reported separately (`Filtered`, never closed); host/network-unreachable + permission-denied surfaced into `errors[]` and `unreachable_count`; tool summary distinguishes an errno-unreachable scan from a clean one; regression test for an unroutable address. Partial: the "dead host on a normal network" case reaches the target via a timeout, so it reports as `Filtered` rather than `Unreachable` (see the scope note above) - full host-down inference from an all-timeout scan is a tracked follow-up (#337), not delivered here. `ScannedPort`/`ScanResult` are wire types (serialized outward, never deserialized), so the additive fields need no serde back-compat.