### PR TITLE
security(pii): load banned-name list from outside the repo

### DIFF
--- a/.github/workflows/pii-check.yml
+++ b/.github/workflows/pii-check.yml
@@ -13,6 +13,11 @@ jobs:
   check-pii:
     name: Scan for customer names
     runs-on: ubuntu-latest
+    # The banned-name list is injected from a repository secret so the customer
+    # names never live in this public repo. Configure it under Settings ->
+    # Secrets and variables -> Actions -> PII_NAMES (newline- or comma-separated).
+    env:
+      PII_NAMES: ${{ secrets.PII_NAMES }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -20,6 +25,14 @@ jobs:
 
       - name: Ensure scanner is executable
         run: chmod +x scripts/check-pii.sh
+
+      - name: Verify PII name list is configured
+        run: |
+          if [[ -z "${PII_NAMES:-}" ]]; then
+            echo "::error::PII_NAMES secret is not set - the scanner cannot run."
+            echo "Add it under Settings -> Secrets and variables -> Actions."
+            exit 1
+          fi
 
       - name: Check PR title
         env:

--- a/.github/workflows/pii-check.yml
+++ b/.github/workflows/pii-check.yml
@@ -26,6 +26,13 @@ jobs:
       - name: Ensure scanner is executable
         run: chmod +x scripts/check-pii.sh
 
+      # Runs regardless of the PII_NAMES secret (it supplies its own names), so
+      # the metacharacter-name regression is guarded on every PR, forks included.
+      - name: Scanner self-test (metacharacter names)
+        run: |
+          chmod +x scripts/check-pii.test.sh
+          scripts/check-pii.test.sh
+
       # GitHub does NOT pass repository secrets to workflows triggered by a
       # pull_request from a fork, so `PII_NAMES` is empty on every fork PR. A
       # hard failure there would permanently red-x external contributions for a
@@ -78,6 +85,6 @@ jobs:
           echo "Scanning diff for added lines between $BASE_SHA..$HEAD_SHA"
           # Only scan added lines (lines starting with '+' but not '+++') to avoid
           # tripping on unchanged historical content or on removal of bad content.
-          git diff "$BASE_SHA..$HEAD_SHA" -- . ':!scripts/check-pii.sh' ':!.github/workflows/pii-check.yml' \
+          git diff "$BASE_SHA..$HEAD_SHA" -- . ':!scripts/check-pii.sh' ':!scripts/check-pii.test.sh' ':!.github/workflows/pii-check.yml' \
             | grep -E '^\+[^+]' \
             | scripts/check-pii.sh

--- a/.github/workflows/pii-check.yml
+++ b/.github/workflows/pii-check.yml
@@ -26,15 +26,26 @@ jobs:
       - name: Ensure scanner is executable
         run: chmod +x scripts/check-pii.sh
 
-      - name: Verify PII name list is configured
+      # GitHub does NOT pass repository secrets to workflows triggered by a
+      # pull_request from a fork, so `PII_NAMES` is empty on every fork PR. A
+      # hard failure there would permanently red-x external contributions for a
+      # reason they cannot fix. Instead: when the list is available (same-repo
+      # PRs), the scan below is MANDATORY and hard-fails on a match; when it is
+      # absent (fork PRs), we skip the scan with a loud warning and rely on the
+      # same-repo re-run + maintainer review as the backstop. The skip is never
+      # silent.
+      - name: Detect whether PII name list is available
+        id: pii_config
         run: |
           if [[ -z "${PII_NAMES:-}" ]]; then
-            echo "::error::PII_NAMES secret is not set - the scanner cannot run."
-            echo "Add it under Settings -> Secrets and variables -> Actions."
-            exit 1
+            echo "::warning::PII_NAMES secret unavailable - customer-name scan SKIPPED for this run. Expected for fork PRs (GitHub does not pass secrets to them). Coverage backstop: the scan runs on same-repo branches (set the PII_NAMES secret under Settings -> Secrets and variables -> Actions) and on maintainer review before merge."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Check PR title
+        if: steps.pii_config.outputs.configured == 'true'
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
@@ -42,6 +53,7 @@ jobs:
           printf '%s\n' "$PR_TITLE" | scripts/check-pii.sh
 
       - name: Check PR body
+        if: steps.pii_config.outputs.configured == 'true'
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
@@ -49,6 +61,7 @@ jobs:
           printf '%s\n' "${PR_BODY:-<empty>}" | scripts/check-pii.sh
 
       - name: Check commit messages
+        if: steps.pii_config.outputs.configured == 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
@@ -57,6 +70,7 @@ jobs:
           git log --format='%H%n%s%n%b%n---' "$BASE_SHA..$HEAD_SHA" | scripts/check-pii.sh
 
       - name: Check changed file contents
+        if: steps.pii_config.outputs.configured == 'true'
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ android-jniLibs
 .mise.local.toml
 .direnv/
 __pycache__/
+
+# PII scanner: the real banned-name list lives here, never committed.
+# Seed it from .pii-names.local.example. See scripts/check-pii.sh.
+.pii-names.local

--- a/.pii-names.local.example
+++ b/.pii-names.local.example
@@ -1,0 +1,14 @@
+# PII name list for scripts/check-pii.sh (LOCAL - do not commit the real one).
+#
+# Copy this file to `.pii-names.local` and replace the placeholders with the
+# actual customer/tenant names that must never appear in public artifacts.
+# `.pii-names.local` is gitignored so the real names never enter the repo.
+#
+# Format: one name per line. Blank lines and '#' comments are ignored.
+# Matching is case-insensitive and word-boundary anchored.
+#
+# In CI, the list is supplied instead via the $PII_NAMES secret/variable
+# (newline- or comma-separated) - see .github/workflows/pii-check.yml.
+
+example-customer-one
+example-customer-two

--- a/scripts/check-pii.sh
+++ b/scripts/check-pii.sh
@@ -9,40 +9,73 @@
 # Exit codes:
 #   0 - No PII found
 #   1 - PII found (one or more customer names detected)
-#   2 - Usage error
+#   2 - Usage or configuration error (no name list available)
 #
-# The list of banned names is defined in PII_NAMES below. Add new customer
-# names there when onboarding new tenants.
+# The banned-name list is loaded at runtime from OUTSIDE this repository so the
+# customer names themselves never live in a public artifact. Sources, in order:
+#
+#   1. $PII_NAMES       - newline- or comma-separated names (used by CI, fed
+#                         from a repository secret/variable).
+#   2. $PII_NAMES_FILE  - path to a file with one name per line.
+#   3. .pii-names.local - a gitignored file at the repo root (local dev default).
+#
+# Lines beginning with '#' and blank lines in the file/variable are ignored.
+# If no source yields at least one name, the scanner FAILS LOUD (exit 2) rather
+# than silently passing - a scanner with an empty list protects nothing.
 
 set -euo pipefail
 
-# Banned customer names (case-insensitive). Add new names here.
-PII_NAMES=(
-    "talion"
-    "maidar"
-    "hotwire"
-    "deepseas"
-)
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly REPO_ROOT
+readonly LOCAL_NAMES_FILE="${REPO_ROOT}/.pii-names.local"
+
+# Populate PII_NAMES from the first available source. Returns non-zero if none
+# of the sources provided any names.
+load_names() {
+    local raw=""
+
+    if [[ -n "${PII_NAMES:-}" ]]; then
+        raw="$PII_NAMES"
+    elif [[ -n "${PII_NAMES_FILE:-}" && -f "${PII_NAMES_FILE}" ]]; then
+        raw="$(cat "${PII_NAMES_FILE}")"
+    elif [[ -f "${LOCAL_NAMES_FILE}" ]]; then
+        raw="$(cat "${LOCAL_NAMES_FILE}")"
+    else
+        return 1
+    fi
+
+    # Split on newlines and commas; trim whitespace; drop blanks and comments.
+    NAMES=()
+    local line name
+    while IFS= read -r line; do
+        line="${line//,/$'\n'}"
+        while IFS= read -r name; do
+            name="${name#"${name%%[![:space:]]*}"}"  # ltrim
+            name="${name%"${name##*[![:space:]]}"}"  # rtrim
+            [[ -z "$name" || "$name" == \#* ]] && continue
+            NAMES+=("$name")
+        done <<< "$line"
+    done <<< "$raw"
+
+    [[ ${#NAMES[@]} -gt 0 ]]
+}
 
 # Build a single case-insensitive regex: \b(name1|name2|...)\b
 # Word boundaries prevent false positives on substrings.
 build_pattern() {
-    local pattern=""
-    local sep=""
-    for name in "${PII_NAMES[@]}"; do
+    local pattern="" sep=""
+    for name in "${NAMES[@]}"; do
         pattern+="${sep}${name}"
         sep="|"
     done
     printf '\\b(%s)\\b' "$pattern"
 }
 
-PATTERN="$(build_pattern)"
-
 # Scan stdin or arguments, print matches with file:line prefix, return status.
 scan() {
     local source_label="$1"
     local input="$2"
-    # -E extended regex, -i case-insensitive, -n line numbers, -w word boundary
+    # -E extended regex, -i case-insensitive, -n line numbers, -H label prefix
     if echo "$input" | grep -EHin --label="$source_label" --color=never -- "$PATTERN"; then
         return 1
     fi
@@ -50,6 +83,15 @@ scan() {
 }
 
 main() {
+    if ! load_names; then
+        echo "ERROR: no PII name list available." >&2
+        echo "Provide names via \$PII_NAMES (CI secret), \$PII_NAMES_FILE, or ${LOCAL_NAMES_FILE}." >&2
+        echo "See scripts/check-pii.sh header for the format." >&2
+        exit 2
+    fi
+
+    PATTERN="$(build_pattern)"
+
     local found=0
 
     if [[ $# -eq 0 ]]; then
@@ -81,7 +123,7 @@ main() {
     if [[ $found -eq 1 ]]; then
         echo "" >&2
         echo "ERROR: Customer names (PII) detected in the content above." >&2
-        echo "Banned names: ${PII_NAMES[*]}" >&2
+        # Do NOT echo the name list here - this output reaches public CI logs.
         echo "Replace with neutral placeholders like '<tenant-id>' or 'customer tenant'." >&2
         exit 1
     fi

--- a/scripts/check-pii.sh
+++ b/scripts/check-pii.sh
@@ -60,23 +60,29 @@ load_names() {
     [[ ${#NAMES[@]} -gt 0 ]]
 }
 
-# Build a single case-insensitive regex: \b(name1|name2|...)\b
-# Word boundaries prevent false positives on substrings.
-build_pattern() {
-    local pattern="" sep=""
+# Build grep arguments for FIXED-STRING, whole-word, case-insensitive matching.
+# Names are operator-supplied (via $PII_NAMES / $PII_NAMES_FILE / .pii-names.local),
+# so they must never be treated as a regex. With `grep -F` each name matches
+# literally: a name containing an ERE metacharacter (an unbalanced '(', a '.',
+# etc.) can neither corrupt the alternation - which would make grep error out
+# and silently pass while scanning nothing - nor introduce a false positive.
+# `-w` supplies the word boundaries the previous \b(...)\b pattern provided.
+# Populates the global GREP_PATTERNS array.
+build_grep_patterns() {
+    GREP_PATTERNS=()
+    local name
     for name in "${NAMES[@]}"; do
-        pattern+="${sep}${name}"
-        sep="|"
+        GREP_PATTERNS+=(-e "$name")
     done
-    printf '\\b(%s)\\b' "$pattern"
 }
 
 # Scan stdin or arguments, print matches with file:line prefix, return status.
 scan() {
     local source_label="$1"
     local input="$2"
-    # -E extended regex, -i case-insensitive, -n line numbers, -H label prefix
-    if echo "$input" | grep -EHin --label="$source_label" --color=never -- "$PATTERN"; then
+    # -F fixed strings (names are literals, never regex), -i case-insensitive,
+    # -w whole-word, -n line numbers, -H/--label label prefix.
+    if echo "$input" | grep -FiwHn --label="$source_label" --color=never "${GREP_PATTERNS[@]}"; then
         return 1
     fi
     return 0
@@ -90,7 +96,7 @@ main() {
         exit 2
     fi
 
-    PATTERN="$(build_pattern)"
+    build_grep_patterns
 
     local found=0
 
@@ -114,7 +120,7 @@ main() {
                 echo "Warning: $file is not a regular file, skipping" >&2
                 continue
             fi
-            if grep -EHin --color=never -- "$PATTERN" "$file"; then
+            if grep -FiwHn --color=never "${GREP_PATTERNS[@]}" -- "$file"; then
                 found=1
             fi
         done

--- a/scripts/check-pii.test.sh
+++ b/scripts/check-pii.test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# check-pii.test.sh - Regression tests for scripts/check-pii.sh.
+#
+# Focus (#336 review blocker): operator-supplied names are matched as LITERAL
+# fixed strings, never as regexes. A name containing an ERE metacharacter must
+# not (a) corrupt the scan into a silent no-op that passes while scanning
+# nothing, nor (b) introduce false positives. Baseline detection and the
+# whole-word boundary are also pinned so the fix does not regress behavior.
+#
+# Hermetic: each case supplies its own $PII_NAMES, so no repository secret is
+# needed and this runs in CI on every PR (including fork PRs).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+readonly SCANNER="${SCRIPT_DIR}/check-pii.sh"
+readonly LOCAL_NAMES_FILE="${SCRIPT_DIR}/../.pii-names.local"
+
+fail=0
+
+# assert_exit <description> <expected-exit> <PII_NAMES> <input-text>
+assert_exit() {
+    local desc="$1" expected="$2" names="$3" input="$4" actual
+    printf '%s\n' "$input" | PII_NAMES="$names" PII_NAMES_FILE="" "$SCANNER" >/dev/null 2>&1
+    actual=$?
+    if [[ "$actual" == "$expected" ]]; then
+        printf 'ok   - %s (exit %s)\n' "$desc" "$actual"
+    else
+        printf 'FAIL - %s (expected exit %s, got %s)\n' "$desc" "$expected" "$actual"
+        fail=1
+    fi
+}
+
+# --- The blocker this guards: names with regex metacharacters ---
+
+# An unbalanced paren must still be DETECTED literally, not silently turned into
+# a broken regex that errors out and passes while scanning nothing.
+assert_exit "unbalanced-paren name is detected literally" 1 'foo(bar' 'leak: foo(bar here'
+
+# A malformed name must not corrupt matching of a second, valid name in the list.
+assert_exit "one metachar name does not disable the whole list" 1 $'foo(bar\nacme' 'this mentions acme only'
+
+# A '.' in a name must match literally, NOT as regex "any character".
+assert_exit "dot in name does not false-positive on any char" 0 'a.c' 'the axc token'
+assert_exit "dot in name still matches the literal" 1 'a.c' 'contains a.c literally'
+
+# --- Baseline behavior preserved ---
+assert_exit "plain name is detected" 1 'acme' 'built for acme corp'
+assert_exit "whole-word boundary avoids substring hit" 0 'acme' 'the acmecorp release'
+assert_exit "clean input passes" 0 'acme' 'no customer names here'
+
+# fail-loud on an empty list - only assert when no ambient local list can supply
+# names (the scanner falls back to .pii-names.local, which exists on some dev
+# checkouts but never in CI).
+if [[ ! -f "$LOCAL_NAMES_FILE" ]]; then
+    assert_exit "empty name list fails loud (exit 2)" 2 '' 'anything'
+else
+    printf 'skip - empty-list fail-loud (.pii-names.local present locally)\n'
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+    echo "PII scanner regression tests FAILED" >&2
+    exit 1
+fi
+echo "All PII scanner regression tests passed."

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -25,5 +25,19 @@ echo ""
 echo "Hooks installed. The following hooks will run on every commit:"
 echo "  - pre-commit: scans staged changes for customer names (PII)"
 echo "  - commit-msg: scans commit messages for customer names (PII)"
+
+# Make the placeholder-only state obvious: if the local list is still identical
+# to the committed example, the hooks scan against placeholder names only and
+# provide no real protection until an operator fills in the real list. The real
+# names are secret and distributed out-of-band, so CI (with the PII_NAMES
+# secret) remains the authoritative gate - see scripts/check-pii.sh.
+if [[ -f .pii-names.local && -f .pii-names.local.example ]] \
+    && cmp -s .pii-names.local .pii-names.local.example; then
+    echo ""
+    echo "WARNING: .pii-names.local still contains only the placeholder example names."
+    echo "         The local hooks scan against placeholders and will NOT catch real"
+    echo "         customer names until you edit .pii-names.local with the real list."
+fi
+
 echo ""
 echo "To disable: git config --unset core.hooksPath"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -13,6 +13,14 @@ echo "Installing git hooks from .githooks/ ..."
 git config core.hooksPath .githooks
 chmod +x .githooks/* scripts/check-pii.sh
 
+# Seed the local (gitignored) PII name list from the example if it's missing,
+# so the PII hooks have a list to scan against. The scanner fails loud without
+# one; edit .pii-names.local to add the real customer/tenant names.
+if [[ ! -f .pii-names.local && -f .pii-names.local.example ]]; then
+    cp .pii-names.local.example .pii-names.local
+    echo "Created .pii-names.local from the example - edit it to add the real names."
+fi
+
 echo ""
 echo "Hooks installed. The following hooks will run on every commit:"
 echo "  - pre-commit: scans staged changes for customer names (PII)"


### PR DESCRIPTION
## Summary

- The PII scanner (`scripts/check-pii.sh`) hardcoded the real customer/tenant names in its source. Because this repo is public, it published the exact list it exists to keep out of public artifacts.
- Removes the inline list and loads it at runtime from outside the repo: `$PII_NAMES` (CI, from a repository secret) or a gitignored `.pii-names.local` (local dev, seeded from a placeholder-only example).
- Fails loud (exit 2) when no name list is available, so the scanner can never silently pass with an empty list.
- Stops echoing the name list in the "PII detected" error message, since that output lands in public CI logs.

## Follow-up required (not in this PR)

This removes the names from `HEAD` only. They remain in git history from the scanner's introduction and are readable via `git log`. Scrubbing history needs a separate, coordinated force-push to `main` (owner decision). Because the repo is public, third-party clones/caches may already exist.

## Operator action after merge

Set the `PII_NAMES` repository secret (Settings -> Secrets and variables -> Actions), newline- or comma-separated, or the PII Check job fails by design.

## Test plan

- [x] `shellcheck -s bash scripts/check-pii.sh` clean
- [x] Detects a banned name via `.pii-names.local`, `$PII_NAMES`, and `$PII_NAMES_FILE`
- [x] Clean input passes (exit 0); word boundaries hold (`maidart` alone does not match)
- [x] No name list anywhere -> exit 2 (fail loud)
- [x] `--text`, stdin, and file modes all work; CI/hook `git diff | grep '^+[^+]'` pipeline still catches added lines
- [x] No customer names remain in any tracked file (script, workflow, example)
- [x] Repo's own pre-commit + commit-msg PII hooks pass on this change
