### PR TITLE
feat(network): expose scan-free host subnets as reusable context (#345)

### DIFF
--- a/crates/platform/src/android/system.rs
+++ b/crates/platform/src/android/system.rs
@@ -202,11 +202,11 @@ pub async fn get_network_interfaces() -> Result<Vec<NetworkInterface>> {
                 let is_loopback = name == "lo";
 
                 // Try to get IP address using ip command
-                let ip_addresses = get_interface_ips(&name).await;
+                let addresses = get_interface_addrs(&name).await;
 
                 interfaces.push(NetworkInterface {
                     name,
-                    ip_addresses,
+                    addresses,
                     mac_address: None, // Would need to read from /sys/class/net/*/address
                     is_up: true,
                     is_loopback,
@@ -218,8 +218,8 @@ pub async fn get_network_interfaces() -> Result<Vec<NetworkInterface>> {
     Ok(interfaces)
 }
 
-async fn get_interface_ips(interface: &str) -> Vec<String> {
-    let mut ips = Vec::new();
+async fn get_interface_addrs(interface: &str) -> Vec<InterfaceAddr> {
+    let mut addrs = Vec::new();
 
     if let Ok(output) = tokio::process::Command::new("ip")
         .args(["addr", "show", interface])
@@ -229,17 +229,16 @@ async fn get_interface_ips(interface: &str) -> Vec<String> {
         let stdout = String::from_utf8_lossy(&output.stdout);
         for line in stdout.lines() {
             let line = line.trim();
-            if line.starts_with("inet ") {
-                if let Some(addr) = line.split_whitespace().nth(1) {
-                    // Remove CIDR notation
-                    let ip = addr.split('/').next().unwrap_or(addr);
-                    ips.push(ip.to_string());
+            if line.starts_with("inet ") || line.starts_with("inet6 ") {
+                if let Some(token) = line.split_whitespace().nth(1) {
+                    // Keep the CIDR prefix (e.g. "/22") instead of discarding it.
+                    addrs.push(interface_addr_from_token(token));
                 }
             }
         }
     }
 
-    ips
+    addrs
 }
 
 #[cfg(test)]

--- a/crates/platform/src/desktop/system.rs
+++ b/crates/platform/src/desktop/system.rs
@@ -49,15 +49,24 @@ pub async fn get_network_interfaces() -> Result<Vec<NetworkInterface>> {
         Ok(interfaces
             .into_iter()
             .map(|iface| {
-                let ip_addresses: Vec<String> = iface
+                let addresses: Vec<InterfaceAddr> = iface
                     .addr
                     .into_iter()
-                    .map(|addr| addr.ip().to_string())
+                    .map(|addr| {
+                        // netmask is per-address; convert an IPv4 mask to a CIDR
+                        // prefix. IPv6 masks (and a missing/non-contiguous v4
+                        // mask) yield None rather than a fabricated prefix.
+                        let prefix_len = match addr.netmask() {
+                            Some(std::net::IpAddr::V4(mask)) => prefix_len_from_ipv4_netmask(mask),
+                            _ => None,
+                        };
+                        InterfaceAddr::new(addr.ip().to_string(), prefix_len)
+                    })
                     .collect();
 
                 NetworkInterface {
                     name: iface.name,
-                    ip_addresses,
+                    addresses,
                     mac_address: iface.mac_addr,
                     is_up: true,        // network-interface doesn't provide this
                     is_loopback: false, // would need to check IP
@@ -104,7 +113,7 @@ async fn get_network_interfaces_fallback() -> Result<Vec<NetworkInterface>> {
 
                     current_iface = Some(NetworkInterface {
                         name,
-                        ip_addresses: Vec::new(),
+                        addresses: Vec::new(),
                         mac_address: None,
                         is_up,
                         is_loopback,
@@ -112,18 +121,13 @@ async fn get_network_interfaces_fallback() -> Result<Vec<NetworkInterface>> {
                 }
             } else if let Some(ref mut iface) = current_iface {
                 let trimmed = line.trim();
-                if trimmed.starts_with("inet ") {
+                if trimmed.starts_with("inet ") || trimmed.starts_with("inet6 ") {
                     let parts: Vec<&str> = trimmed.split_whitespace().collect();
                     if parts.len() >= 2 {
-                        // Extract IP without subnet mask
-                        let ip = parts[1].split('/').next().unwrap_or(parts[1]);
-                        iface.ip_addresses.push(ip.to_string());
-                    }
-                } else if trimmed.starts_with("inet6 ") {
-                    let parts: Vec<&str> = trimmed.split_whitespace().collect();
-                    if parts.len() >= 2 {
-                        let ip = parts[1].split('/').next().unwrap_or(parts[1]);
-                        iface.ip_addresses.push(ip.to_string());
+                        // `ip addr` prints the address with its prefix, e.g.
+                        // "inet 10.0.8.42/22" - keep the prefix instead of
+                        // discarding it (the /24 assumption this PR removes).
+                        iface.addresses.push(interface_addr_from_token(parts[1]));
                     }
                 } else if trimmed.starts_with("link/ether ") {
                     let parts: Vec<&str> = trimmed.split_whitespace().collect();
@@ -478,7 +482,7 @@ pub async fn check_wifi_connection_status(
     // Find active WiFi interfaces (up + has IP)
     let active_wifi: Vec<_> = interfaces
         .iter()
-        .filter(|i| i.is_up && !i.ip_addresses.is_empty() && is_wifi_name(&i.name))
+        .filter(|i| i.is_up && i.has_addresses() && is_wifi_name(&i.name))
         .collect();
 
     // Find all WiFi interfaces (even if down)

--- a/crates/platform/src/traits.rs
+++ b/crates/platform/src/traits.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use pentest_core::error::Result;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::net::IpAddr;
 use std::time::Duration;
 
 /// Combined platform provider trait
@@ -307,14 +308,100 @@ pub struct DeviceInfo {
     pub platform_specific: PlatformDetails,
 }
 
+/// A single address bound to a network interface, with its prefix length.
+///
+/// Modeled per-address (not per-interface) because a single interface can carry
+/// several addresses on different prefixes - a dual-stack NIC (IPv4 + IPv6) or a
+/// host with a secondary v4 on another subnet. A per-interface scalar prefix
+/// would be ambiguous for exactly the multi-homed case network discovery needs
+/// to get right, so the prefix travels with the address it describes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InterfaceAddr {
+    /// The IP address, without any CIDR suffix (e.g. "10.0.8.42").
+    pub ip: String,
+    /// CIDR prefix length for this address (e.g. `Some(22)` for a /22), or
+    /// `None` when the backend could not determine it.
+    pub prefix_len: Option<u8>,
+}
+
+impl InterfaceAddr {
+    /// Construct from an IP string and an optional prefix.
+    pub fn new(ip: impl Into<String>, prefix_len: Option<u8>) -> Self {
+        Self {
+            ip: ip.into(),
+            prefix_len,
+        }
+    }
+
+    /// Parse the address into an [`IpAddr`], dropping any accidental CIDR
+    /// suffix. Returns `None` for a malformed address.
+    pub fn parse_ip(&self) -> Option<IpAddr> {
+        let bare = self.ip.split('/').next().unwrap_or(&self.ip);
+        bare.parse().ok()
+    }
+}
+
 /// Network interface information
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NetworkInterface {
     pub name: String,
-    pub ip_addresses: Vec<String>,
+    /// Addresses bound to this interface, each carrying its own prefix length.
+    pub addresses: Vec<InterfaceAddr>,
     pub mac_address: Option<String>,
     pub is_up: bool,
     pub is_loopback: bool,
+}
+
+impl NetworkInterface {
+    /// The interface's IP addresses as bare strings (no prefix), preserving the
+    /// pre-`InterfaceAddr` ergonomics for the many call sites that only need the
+    /// address, not its prefix.
+    pub fn ip_strings(&self) -> Vec<String> {
+        self.addresses.iter().map(|a| a.ip.clone()).collect()
+    }
+
+    /// True if the interface has at least one bound address.
+    pub fn has_addresses(&self) -> bool {
+        !self.addresses.is_empty()
+    }
+}
+
+/// Parse an `ip addr`-style address token (e.g. `"10.0.8.42/22"` or a bare
+/// `"10.0.8.42"`) into an [`InterfaceAddr`].
+///
+/// The prefix is taken verbatim from the `/N` suffix when present and parseable;
+/// a missing or malformed suffix yields `prefix_len == None` rather than a
+/// guessed default. Shared by the Linux `ip addr` fallback parsers (desktop and
+/// Android) so the token handling stays consistent and unit-testable.
+pub fn interface_addr_from_token(token: &str) -> InterfaceAddr {
+    let mut parts = token.splitn(2, '/');
+    let ip = parts.next().unwrap_or(token).to_string();
+    let prefix_len = parts.next().and_then(|p| p.parse::<u8>().ok());
+    InterfaceAddr { ip, prefix_len }
+}
+
+/// Convert an IPv4 netmask (e.g. `255.255.252.0`) to a CIDR prefix length
+/// (e.g. `22`).
+///
+/// Returns `None` for a non-contiguous mask (bits not left-packed, e.g.
+/// `255.0.255.0`), which is not a valid CIDR netmask and must not be silently
+/// coerced into a plausible-looking prefix. Kept free of I/O so the conversion
+/// is unit-testable.
+pub fn prefix_len_from_ipv4_netmask(mask: std::net::Ipv4Addr) -> Option<u8> {
+    let bits = u32::from(mask);
+    let ones = bits.count_ones();
+    // A valid netmask is `ones` contiguous 1s followed by zeros. Reconstruct that
+    // canonical mask and compare; a mismatch means the mask was non-contiguous.
+    let canonical = if ones == 0 {
+        0
+    } else {
+        u32::MAX << (32 - ones)
+    };
+    if bits == canonical {
+        Some(ones as u8)
+    } else {
+        None
+    }
 }
 
 /// WiFi network information
@@ -491,4 +578,108 @@ pub struct WifiCaptureStats {
     pub ivs: u32,            // For WEP
     pub has_handshake: bool, // For WPA
     pub data_packets: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::net::Ipv4Addr;
+
+    #[test]
+    fn netmask_to_prefix_covers_common_prefixes() {
+        // The exact conversion network discovery relies on: a /22 host (the
+        // multi-homed case this work targets) must yield 22, not a guessed /24.
+        assert_eq!(
+            prefix_len_from_ipv4_netmask(Ipv4Addr::new(255, 255, 252, 0)),
+            Some(22)
+        );
+        assert_eq!(
+            prefix_len_from_ipv4_netmask(Ipv4Addr::new(255, 255, 255, 0)),
+            Some(24)
+        );
+        assert_eq!(
+            prefix_len_from_ipv4_netmask(Ipv4Addr::new(255, 255, 255, 128)),
+            Some(25)
+        );
+        assert_eq!(
+            prefix_len_from_ipv4_netmask(Ipv4Addr::new(255, 0, 0, 0)),
+            Some(8)
+        );
+    }
+
+    #[test]
+    fn netmask_to_prefix_handles_boundaries() {
+        assert_eq!(
+            prefix_len_from_ipv4_netmask(Ipv4Addr::new(0, 0, 0, 0)),
+            Some(0)
+        );
+        assert_eq!(
+            prefix_len_from_ipv4_netmask(Ipv4Addr::new(255, 255, 255, 255)),
+            Some(32)
+        );
+    }
+
+    #[test]
+    fn netmask_to_prefix_rejects_noncontiguous_mask() {
+        // A non-contiguous mask is not a valid CIDR netmask. It has the same
+        // popcount as /16 (16 one-bits), so a naive count_ones() would wrongly
+        // report /16; we must reject it as None instead of inventing a prefix.
+        assert_eq!(
+            prefix_len_from_ipv4_netmask(Ipv4Addr::new(255, 0, 255, 0)),
+            None
+        );
+    }
+
+    #[test]
+    fn interface_addr_from_token_keeps_prefix() {
+        // The /22 that the old parser discarded (forcing a /24 assumption
+        // downstream) must survive.
+        let a = interface_addr_from_token("10.0.8.42/22");
+        assert_eq!(a.ip, "10.0.8.42");
+        assert_eq!(a.prefix_len, Some(22));
+
+        // Bare address (no suffix): prefix unknown, not guessed.
+        let b = interface_addr_from_token("10.0.0.5");
+        assert_eq!(b.ip, "10.0.0.5");
+        assert_eq!(b.prefix_len, None);
+
+        // IPv6 with prefix parses the same way.
+        let c = interface_addr_from_token("fe80::1/64");
+        assert_eq!(c.ip, "fe80::1");
+        assert_eq!(c.prefix_len, Some(64));
+
+        // Malformed suffix -> None, no panic.
+        let d = interface_addr_from_token("10.0.0.5/notaprefix");
+        assert_eq!(d.ip, "10.0.0.5");
+        assert_eq!(d.prefix_len, None);
+    }
+
+    #[test]
+    fn interface_addr_parse_ip_strips_cidr_suffix() {
+        assert_eq!(
+            InterfaceAddr::new("10.0.8.42/22", Some(22)).parse_ip(),
+            Some("10.0.8.42".parse().unwrap())
+        );
+        assert_eq!(
+            InterfaceAddr::new("10.0.8.42", Some(22)).parse_ip(),
+            Some("10.0.8.42".parse().unwrap())
+        );
+        assert_eq!(InterfaceAddr::new("not-an-ip", None).parse_ip(), None);
+    }
+
+    #[test]
+    fn ip_strings_flattens_addresses() {
+        let iface = NetworkInterface {
+            name: "eth0".to_string(),
+            addresses: vec![
+                InterfaceAddr::new("10.0.8.42", Some(22)),
+                InterfaceAddr::new("fe80::1", Some(64)),
+            ],
+            mac_address: None,
+            is_up: true,
+            is_loopback: false,
+        };
+        assert_eq!(iface.ip_strings(), vec!["10.0.8.42", "fe80::1"]);
+        assert!(iface.has_addresses());
+    }
 }

--- a/crates/tools/src/autopwn/network_plan.rs
+++ b/crates/tools/src/autopwn/network_plan.rs
@@ -10,6 +10,50 @@ use pentest_platform::{get_platform, SystemInfo};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
+/// Derive the sweep CIDR and the local IPv4 to plan around, from an interface's
+/// addresses.
+///
+/// Selects the first usable IPv4 address (like `network_context`), never the
+/// first address of any family — a garbage CIDR such as `"fe80::1.0/24"` must
+/// never reach the attack plan → nmap. Resolution:
+///
+/// * IPv4 + known prefix → real netmask math (`subnet_cidr_v4`).
+/// * IPv4 + missing prefix → `warn!` (matching the module's clamp-logging
+///   observability) then a `/24` derived **via `subnet_cidr_v4`** (correct
+///   network base, not a string-sliced guess). The prefix is unknown, not the
+///   family, so a bounded /24 keeps planning moving while staying observable.
+/// * No IPv4 at all → `Error::InvalidParams`, rather than fabricating a CIDR
+///   from an IPv6/other-family string.
+fn derive_scan_cidr(
+    addresses: &[pentest_platform::InterfaceAddr],
+    iface_name: &str,
+) -> Result<(String, String)> {
+    let (v4, prefix, ip) = addresses
+        .iter()
+        .find_map(|a| match a.parse_ip() {
+            Some(std::net::IpAddr::V4(v4)) => Some((v4, a.prefix_len, a.ip.clone())),
+            _ => None,
+        })
+        .ok_or_else(|| {
+            Error::InvalidParams(format!(
+                "interface {iface_name} has no IPv4 address to plan a network scan around"
+            ))
+        })?;
+
+    let cidr = match prefix {
+        Some(p) => crate::network_context::subnet_cidr_v4(v4, p),
+        None => {
+            tracing::warn!(
+                "interface {} address {} has no known prefix; assuming /24 for the scan CIDR",
+                iface_name,
+                ip
+            );
+            crate::network_context::subnet_cidr_v4(v4, 24)
+        }
+    };
+    Ok((cidr, ip))
+}
+
 /// Network-based attack plan
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct NetworkAttackPlan {
@@ -103,25 +147,12 @@ impl PentestTool for AutoPwnNetworkPlanTool {
                 .find(|i| i.is_up && i.has_addresses())
                 .ok_or_else(|| Error::InvalidParams("No active network interface found".into()))?;
 
-            let local_addr = active_iface
-                .addresses
-                .first()
-                .ok_or_else(|| Error::InvalidParams("No IP address assigned".into()))?;
-            let local_ip = local_addr.ip.clone();
-
-            // Derive the network CIDR from the interface's real prefix (no longer
-            // assuming /24). IPv4 with a known prefix uses the shared netmask
-            // math; a missing prefix or non-IPv4 address falls back to the prior
-            // /24-of-first-three-octets behavior so planning still proceeds.
-            let network_cidr = match (local_addr.parse_ip(), local_addr.prefix_len) {
-                (Some(std::net::IpAddr::V4(v4)), Some(prefix)) => {
-                    crate::network_context::subnet_cidr_v4(v4, prefix)
-                }
-                _ => format!(
-                    "{}.0/24",
-                    &local_ip[..local_ip.rfind('.').unwrap_or(local_ip.len())]
-                ),
-            };
+            // Derive the scan CIDR + the local IPv4 to plan around. Picks the
+            // first usable IPv4 (mirroring network_context) rather than the first
+            // address of any family, so an IPv6-first interface can't produce a
+            // garbage CIDR fed into the attack plan.
+            let (network_cidr, local_ip) =
+                derive_scan_cidr(&active_iface.addresses, &active_iface.name)?;
 
             tracing::info!("  Network:    {}", network_cidr);
             tracing::info!("  Local IP:   {}", local_ip);
@@ -405,5 +436,50 @@ mod tests {
             NetworkAttackType::Reconnaissance
         ));
         assert!(plan.estimated_duration_min < 10);
+    }
+
+    use pentest_platform::InterfaceAddr;
+
+    #[test]
+    fn derive_cidr_uses_real_prefix_for_ipv4() {
+        // The core fix: a /22 host resolves to its real /22 base via netmask math.
+        let addrs = vec![InterfaceAddr::new("10.0.11.5", Some(22))];
+        let (cidr, ip) = derive_scan_cidr(&addrs, "eth0").unwrap();
+        assert_eq!(cidr, "10.0.8.0/22");
+        assert_eq!(ip, "10.0.11.5");
+    }
+
+    #[test]
+    fn derive_cidr_skips_ipv6_and_picks_ipv4() {
+        // An IPv6-first interface must NOT yield a garbage CIDR like
+        // "fe80::1.0/24"; the IPv4 address is selected instead.
+        let addrs = vec![
+            InterfaceAddr::new("fe80::1", Some(64)),
+            InterfaceAddr::new("192.168.40.130", Some(24)),
+        ];
+        let (cidr, ip) = derive_scan_cidr(&addrs, "wlan0").unwrap();
+        assert_eq!(cidr, "192.168.40.0/24");
+        assert_eq!(ip, "192.168.40.130");
+        // Never fabricates from the IPv6 string.
+        assert!(!cidr.contains("fe80"));
+    }
+
+    #[test]
+    fn derive_cidr_ipv4_missing_prefix_assumes_24_via_netmask() {
+        // Missing prefix (not family) -> bounded /24, computed by subnet_cidr_v4
+        // (real network base), never a string-sliced "10.0.11.0/24" that could
+        // mangle a non-.0 host or an IPv6 string.
+        let addrs = vec![InterfaceAddr::new("10.0.11.5", None)];
+        let (cidr, _) = derive_scan_cidr(&addrs, "eth0").unwrap();
+        assert_eq!(cidr, "10.0.11.0/24");
+    }
+
+    #[test]
+    fn derive_cidr_no_ipv4_is_an_error_not_a_garbage_cidr() {
+        // IPv6-only interface: refuse rather than fabricate a CIDR. This is the
+        // reachability half the PR widened (Android now enumerates inet6).
+        let addrs = vec![InterfaceAddr::new("2001:db8::5", Some(64))];
+        let err = derive_scan_cidr(&addrs, "tun0").unwrap_err();
+        assert!(matches!(err, Error::InvalidParams(_)));
     }
 }

--- a/crates/tools/src/autopwn/network_plan.rs
+++ b/crates/tools/src/autopwn/network_plan.rs
@@ -100,19 +100,28 @@ impl PentestTool for AutoPwnNetworkPlanTool {
             // Find active network interface
             let active_iface = interfaces
                 .iter()
-                .find(|i| i.is_up && !i.ip_addresses.is_empty())
+                .find(|i| i.is_up && i.has_addresses())
                 .ok_or_else(|| Error::InvalidParams("No active network interface found".into()))?;
 
-            let local_ip = active_iface
-                .ip_addresses
+            let local_addr = active_iface
+                .addresses
                 .first()
                 .ok_or_else(|| Error::InvalidParams("No IP address assigned".into()))?;
+            let local_ip = local_addr.ip.clone();
 
-            // Calculate network CIDR (default to /24 since netmask not available)
-            let network_cidr = format!(
-                "{}/24",
-                &local_ip[..local_ip.rfind('.').unwrap_or(local_ip.len())]
-            );
+            // Derive the network CIDR from the interface's real prefix (no longer
+            // assuming /24). IPv4 with a known prefix uses the shared netmask
+            // math; a missing prefix or non-IPv4 address falls back to the prior
+            // /24-of-first-three-octets behavior so planning still proceeds.
+            let network_cidr = match (local_addr.parse_ip(), local_addr.prefix_len) {
+                (Some(std::net::IpAddr::V4(v4)), Some(prefix)) => {
+                    crate::network_context::subnet_cidr_v4(v4, prefix)
+                }
+                _ => format!(
+                    "{}.0/24",
+                    &local_ip[..local_ip.rfind('.').unwrap_or(local_ip.len())]
+                ),
+            };
 
             tracing::info!("  Network:    {}", network_cidr);
             tracing::info!("  Local IP:   {}", local_ip);

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -17,6 +17,7 @@ pub mod inject_test_evidence; // NEW: Test tool for three-agent pipeline
 pub mod installers; // NEW: Bespoke tool installers for the tool catalog
 pub mod lateral_movement;
 pub mod list_files;
+pub mod network_context; // Scan-free host subnet enumeration (auto/current targets)
 pub mod network_discover;
 pub mod port_scan;
 pub mod provenance_support;

--- a/crates/tools/src/network_context.rs
+++ b/crates/tools/src/network_context.rs
@@ -1,0 +1,300 @@
+//! Scan-free host network context: what subnets is this host actually on?
+//!
+//! The recurring operational failure this module addresses: an agent falls back
+//! to a hallucinated range (e.g. `192.168.1.0/24`) instead of gathering network
+//! facts, then scans the wrong network. The correct subnet is derivable from the
+//! interface netmask - this module exposes that derivation as a plain, cheap
+//! accessor (no nmap sweep, no ARP), so scanners can resolve `auto`/`current`
+//! targets and the agent can be seeded with real subnets up front.
+//!
+//! Pure subnet math lives here (unit-testable, no I/O); [`network_context`] wraps
+//! it with a single interface-enumeration call.
+
+use pentest_platform::{get_platform, NetworkInterface, SystemInfo};
+use std::net::{IpAddr, Ipv4Addr};
+
+/// Narrowest (largest) prefix a derived subnet is ever widened to.
+///
+/// An interface may report a very wide prefix (e.g. /8 on some VPN/container
+/// setups). A derived sweep subnet must never silently become "scan the whole
+/// /8" (16M addresses). When the real prefix is wider than this, the subnet is
+/// clamped to `/16` (bounded, still large) and the narrowing is logged so it is
+/// observable. Mirrors the cap enforced by the safety-check discovery sweep.
+pub const MIN_SUBNET_PREFIX: u8 = 16;
+
+/// An active IPv4 subnet this host is on, plus whether it is the primary
+/// (default-route) interface's subnet.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Subnet {
+    /// Network CIDR in canonical base form, e.g. `"10.0.8.0/22"`.
+    pub cidr: String,
+    /// Interface name this subnet was derived from (e.g. `"eth0"`).
+    pub interface: String,
+    /// True if this is the default-route interface's subnet (the `current`
+    /// target); the rest are secondary segments included by `auto`/`all`.
+    pub is_primary: bool,
+}
+
+/// Compute the network-base CIDR for an IPv4 host + prefix (pure).
+///
+/// * Computes the network base via the netmask (`addr & mask`), so a /22 host
+///   `10.0.11.5` yields `10.0.8.0/22`, not `10.0.11.0/24`.
+/// * Clamps a `0` prefix and anything wider than [`MIN_SUBNET_PREFIX`] to the
+///   cap - logging the narrowing - so a wide interface prefix cannot become an
+///   implicit huge scan. A nonsensical `>32` is defensively clamped to `32`
+///   (unreachable from a real prefix, so not logged).
+///
+/// Free of any interface/I/O so the subnet math is unit-testable.
+pub fn subnet_cidr_v4(addr: Ipv4Addr, prefix_len: u8) -> String {
+    let effective = if prefix_len == 0 || prefix_len < MIN_SUBNET_PREFIX {
+        tracing::info!(
+            "Interface prefix /{} is wider than the /{} cap; clamping derived subnet \
+             to /{} to avoid an oversized scan",
+            prefix_len,
+            MIN_SUBNET_PREFIX,
+            MIN_SUBNET_PREFIX
+        );
+        MIN_SUBNET_PREFIX
+    } else {
+        prefix_len.min(32)
+    };
+
+    // `effective` is in 16..=32 here, so the shift is well-defined.
+    let mask: u32 = u32::MAX << (32 - effective as u32);
+    let network = u32::from(addr) & mask;
+    format!("{}/{}", Ipv4Addr::from(network), effective)
+}
+
+/// Derive the CIDR base for a single interface address (pure).
+///
+/// Returns `None` for a non-IPv4 address, a missing prefix (unknown netmask), or
+/// a malformed address - never a guessed default. A known prefix is required
+/// because the whole point is to stop inventing subnet sizes.
+fn subnet_for_ipv4(ip: &str, prefix_len: Option<u8>) -> Option<String> {
+    let bare = ip.split('/').next().unwrap_or(ip);
+    let prefix = prefix_len?;
+    match bare.parse::<IpAddr>() {
+        Ok(IpAddr::V4(v4)) if !v4.is_loopback() && !v4.is_link_local() => {
+            Some(subnet_cidr_v4(v4, prefix))
+        }
+        _ => None,
+    }
+}
+
+/// Reduce enumerated interfaces to a deduplicated list of active IPv4 subnets
+/// (pure).
+///
+/// * Skips loopback interfaces and down interfaces.
+/// * Marks a subnet primary when its interface name matches `primary_iface`.
+/// * Drops addresses with no known prefix (can't derive a subnet without
+///   inventing one) and non-IPv4 addresses (IPv6 subnets not yet modeled).
+/// * Deduplicates by CIDR, preferring the primary attribution if any interface
+///   claiming that CIDR is the primary.
+///
+/// Extracted from [`network_context`] so the derivation rules are unit-testable
+/// without live interface enumeration.
+pub fn subnets_from_interfaces(
+    interfaces: &[NetworkInterface],
+    primary_iface: Option<&str>,
+) -> Vec<Subnet> {
+    let mut out: Vec<Subnet> = Vec::new();
+    for iface in interfaces {
+        if iface.is_loopback || !iface.is_up {
+            continue;
+        }
+        let is_primary = primary_iface == Some(iface.name.as_str());
+        for addr in &iface.addresses {
+            let Some(cidr) = subnet_for_ipv4(&addr.ip, addr.prefix_len) else {
+                continue;
+            };
+            match out.iter_mut().find(|s| s.cidr == cidr) {
+                Some(existing) => {
+                    // A CIDR already seen: keep primary attribution if either
+                    // sighting is primary.
+                    existing.is_primary = existing.is_primary || is_primary;
+                }
+                None => out.push(Subnet {
+                    cidr,
+                    interface: iface.name.clone(),
+                    is_primary,
+                }),
+            }
+        }
+    }
+    out
+}
+
+/// Enumerate this host's active IPv4 subnets, scan-free.
+///
+/// One interface-enumeration call plus pure derivation - no nmap, no ARP. The
+/// primary (default-route) subnet is flagged via `default_net`. Best-effort on
+/// the primary detection: if the default interface can't be determined, no
+/// subnet is marked primary (callers treat `current` as "first available").
+///
+/// # Errors
+///
+/// Propagates a platform interface-enumeration failure - the caller decides
+/// whether an empty/failed context is fatal (e.g. resolving `auto` with no
+/// known subnets) or merely degraded.
+pub async fn network_context() -> pentest_core::error::Result<Vec<Subnet>> {
+    let platform = get_platform();
+    let interfaces = platform.get_network_interfaces().await?;
+    let primary = default_net::get_default_interface().ok().map(|i| i.name);
+    Ok(subnets_from_interfaces(&interfaces, primary.as_deref()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pentest_platform::InterfaceAddr;
+
+    fn iface(
+        name: &str,
+        up: bool,
+        loopback: bool,
+        addrs: &[(&str, Option<u8>)],
+    ) -> NetworkInterface {
+        NetworkInterface {
+            name: name.to_string(),
+            addresses: addrs
+                .iter()
+                .map(|(ip, p)| InterfaceAddr::new(*ip, *p))
+                .collect(),
+            mac_address: None,
+            is_up: up,
+            is_loopback: loopback,
+        }
+    }
+
+    #[test]
+    fn subnet_cidr_computes_network_base_from_prefix() {
+        // The core fix: a /22 host resolves to its real /22 base, not a /24.
+        assert_eq!(
+            subnet_cidr_v4("10.0.11.5".parse().unwrap(), 22),
+            "10.0.8.0/22"
+        );
+        assert_eq!(
+            subnet_cidr_v4("192.168.40.130".parse().unwrap(), 24),
+            "192.168.40.0/24"
+        );
+        assert_eq!(
+            subnet_cidr_v4("192.168.1.130".parse().unwrap(), 25),
+            "192.168.1.128/25"
+        );
+    }
+
+    #[test]
+    fn subnet_cidr_computes_base_via_netmask_across_prefixes() {
+        // Not "zero the last octet": /25 of .130 -> .128, /26 of .200 -> .192,
+        // /30 of .6 -> .4, /23 spanning two octets.
+        assert_eq!(
+            subnet_cidr_v4("172.16.5.9".parse().unwrap(), 23),
+            "172.16.4.0/23"
+        );
+        assert_eq!(
+            subnet_cidr_v4("10.0.0.200".parse().unwrap(), 26),
+            "10.0.0.192/26"
+        );
+        assert_eq!(
+            subnet_cidr_v4("10.0.0.6".parse().unwrap(), 30),
+            "10.0.0.4/30"
+        );
+    }
+
+    #[test]
+    fn subnet_cidr_prefix_32_is_single_address() {
+        assert_eq!(
+            subnet_cidr_v4("203.0.113.7".parse().unwrap(), 32),
+            "203.0.113.7/32"
+        );
+    }
+
+    #[test]
+    fn subnet_cidr_clamps_overly_wide_prefix() {
+        // #182 safety cap: a prefix wider than /16 must clamp to /16, never
+        // expand to a /8-scale sweep. A degenerate /0 clamps too (guards the
+        // shift). /16 itself (the cap) passes through unchanged.
+        assert_eq!(
+            subnet_cidr_v4("10.1.2.3".parse().unwrap(), 8),
+            "10.1.0.0/16"
+        );
+        assert_eq!(
+            subnet_cidr_v4("172.20.30.40".parse().unwrap(), 12),
+            "172.20.0.0/16"
+        );
+        assert_eq!(
+            subnet_cidr_v4("10.1.2.3".parse().unwrap(), 0),
+            "10.1.0.0/16"
+        );
+        assert_eq!(
+            subnet_cidr_v4("10.1.2.3".parse().unwrap(), 16),
+            "10.1.0.0/16"
+        );
+    }
+
+    #[test]
+    fn subnet_cidr_absurd_prefix_clamps_to_32() {
+        // Unreachable from a real prefix, but guard the defensive >32 clamp so
+        // the left-shift can never panic.
+        assert_eq!(
+            subnet_cidr_v4("10.0.0.1".parse().unwrap(), 99),
+            "10.0.0.1/32"
+        );
+    }
+
+    #[test]
+    fn subnet_for_ipv4_requires_known_prefix() {
+        // No prefix -> None (we refuse to invent a subnet size).
+        assert_eq!(subnet_for_ipv4("10.0.8.5", None), None);
+        // Loopback / link-local excluded.
+        assert_eq!(subnet_for_ipv4("127.0.0.1", Some(8)), None);
+        assert_eq!(subnet_for_ipv4("169.254.1.1", Some(16)), None);
+        // Valid -> derived base.
+        assert_eq!(
+            subnet_for_ipv4("10.0.11.5", Some(22)),
+            Some("10.0.8.0/22".to_string())
+        );
+    }
+
+    #[test]
+    fn multi_homed_host_yields_all_subnets_with_primary_flagged() {
+        // The motivating case: two active interfaces on different subnets.
+        let ifaces = vec![
+            iface("enx0024", true, false, &[("10.0.8.42", Some(22))]),
+            iface("wlp0s20", true, false, &[("10.0.40.5", Some(24))]),
+            iface("lo", true, true, &[("127.0.0.1", Some(8))]),
+        ];
+        let subnets = subnets_from_interfaces(&ifaces, Some("wlp0s20"));
+
+        assert_eq!(subnets.len(), 2, "loopback excluded, both LAN subnets kept");
+        let primary: Vec<_> = subnets.iter().filter(|s| s.is_primary).collect();
+        assert_eq!(primary.len(), 1);
+        assert_eq!(primary[0].cidr, "10.0.40.0/24");
+        assert!(subnets
+            .iter()
+            .any(|s| s.cidr == "10.0.8.0/22" && !s.is_primary));
+    }
+
+    #[test]
+    fn down_interface_and_unknown_prefix_are_skipped() {
+        let ifaces = vec![
+            iface("eth0", false, false, &[("10.0.8.42", Some(22))]), // down
+            iface("eth1", true, false, &[("10.0.9.5", None)]),       // no prefix
+        ];
+        assert!(subnets_from_interfaces(&ifaces, None).is_empty());
+    }
+
+    #[test]
+    fn duplicate_cidr_deduplicated_keeping_primary() {
+        // Two interfaces on the same CIDR: one primary. Result carries it once,
+        // marked primary.
+        let ifaces = vec![
+            iface("eth0", true, false, &[("10.0.8.42", Some(22))]),
+            iface("eth1", true, false, &[("10.0.8.99", Some(22))]),
+        ];
+        let subnets = subnets_from_interfaces(&ifaces, Some("eth1"));
+        assert_eq!(subnets.len(), 1);
+        assert_eq!(subnets[0].cidr, "10.0.8.0/22");
+        assert!(subnets[0].is_primary);
+    }
+}

--- a/crates/tools/src/safety_check/mod.rs
+++ b/crates/tools/src/safety_check/mod.rs
@@ -113,6 +113,32 @@ pub async fn run_safety_check() -> anyhow::Result<SafetyCheckResult> {
         }
     };
 
+    // Derive the host's active subnets scan-free (interface netmasks only, no
+    // nmap/ARP). This is the reusable "what network am I on" source of truth,
+    // independent of whether the discovery sweep above succeeded. Best-effort:
+    // an enumeration failure yields an empty list, never a failed check.
+    let active_subnets = match crate::network_context::network_context().await {
+        Ok(subnets) => {
+            tracing::info!(
+                "Active subnets (scan-free): {}",
+                if subnets.is_empty() {
+                    "none derived".to_string()
+                } else {
+                    subnets
+                        .iter()
+                        .map(|s| s.cidr.as_str())
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                }
+            );
+            subnets.into_iter().map(|s| s.cidr).collect()
+        }
+        Err(e) => {
+            tracing::warn!("Could not derive active subnets: {}", e);
+            Vec::new()
+        }
+    };
+
     // Determine overall status based on check results, then cap it for the
     // realities of a large/shared network (busy networks never read a
     // confident green "Safe").
@@ -125,6 +151,7 @@ pub async fn run_safety_check() -> anyhow::Result<SafetyCheckResult> {
         status,
         checks,
         network_map,
+        active_subnets,
         recommendations,
         timestamp,
     })

--- a/crates/tools/src/safety_check/network_map.rs
+++ b/crates/tools/src/safety_check/network_map.rs
@@ -2,10 +2,11 @@
 
 use super::oui;
 use super::types::{Device, NetworkMap, ThreatLevel};
+use crate::network_context::subnet_cidr_v4;
 use anyhow::Context;
 use pentest_platform::{NetworkOps, SystemInfo};
 use std::collections::{HashMap, HashSet};
-use std::net::{IpAddr, Ipv4Addr};
+use std::net::IpAddr;
 use std::process::Stdio;
 use tokio::process::Command;
 
@@ -16,16 +17,6 @@ use tokio::process::Command;
 /// box). Kept conservative to avoid alarming a non-technical user over a
 /// normal NAS or printer.
 const SUSPICIOUS_PORT_THRESHOLD: usize = 10;
-
-/// Narrowest (largest) prefix we will ever widen a discovery sweep to.
-///
-/// The interface may legitimately report a very wide prefix (e.g. /8 on some
-/// VPN or container setups). Sweeping a /8 is 16M addresses - a netmask fix
-/// (#182) must never silently turn into "scan the whole /8". When the real
-/// prefix is wider than this, we clamp the sweep subnet to `/16` (still large,
-/// but bounded) and log the clamp so the narrowing is observable. The full
-/// host-count bounding for sizing lives in `cap_for_network_size` (mod.rs).
-const MIN_SUBNET_PREFIX: u8 = 16;
 
 /// Enrichment data for a single host, keyed by IP, drawn from the ARP table.
 struct ArpInfo {
@@ -271,20 +262,19 @@ fn own_ips_from_interfaces(interfaces: Vec<pentest_platform::NetworkInterface>) 
         if iface.is_loopback {
             continue;
         }
-        for ip_str in iface.ip_addresses {
-            // Interface addresses may carry a CIDR suffix (e.g. "192.168.1.42/24")
-            // depending on the platform backend; strip it before parsing.
-            let addr = ip_str.split('/').next().unwrap_or(ip_str.as_str());
-            match addr.parse::<IpAddr>() {
-                Ok(ip) if is_own_addressable(&ip) => {
+        for iface_addr in iface.addresses {
+            // `InterfaceAddr::parse_ip` strips any CIDR suffix and returns the
+            // bare address, or `None` if malformed.
+            match iface_addr.parse_ip() {
+                Some(ip) if is_own_addressable(&ip) => {
                     own.insert(ip);
                 }
-                Ok(_) => {
+                Some(_) => {
                     // Loopback / link-local: real but never a foreign LAN host,
                     // so no need to carry it in the self-filter set.
                 }
-                Err(e) => {
-                    tracing::debug!("Ignoring malformed interface address {:?}: {}", ip_str, e);
+                None => {
+                    tracing::debug!("Ignoring malformed interface address {:?}", iface_addr.ip);
                 }
             }
         }
@@ -340,13 +330,10 @@ async fn get_gateway_and_local_ip() -> anyhow::Result<(IpAddr, IpAddr, Option<u8
 
 /// Determine the subnet CIDR notation from a local IP and its prefix length.
 ///
-/// Uses the interface's real prefix instead of assuming /24 (#182). The network
-/// base address is computed by applying the netmask (`addr & mask`), so a /25
-/// host `.130` yields `.128/25`, not `.0/24`. A missing prefix (e.g. a future
-/// IPv6-only path) falls back to /24 for IPv4 to preserve prior behavior.
-///
-/// Safety cap: a prefix wider than [`MIN_SUBNET_PREFIX`] is clamped up to it, so
-/// the discovery sweep is never silently widened to a /8-scale range.
+/// Delegates the netmask math to [`crate::network_context::subnet_cidr_v4`] (the
+/// single source of truth for subnet derivation, with the /16 sweep cap). A
+/// missing prefix (e.g. a future IPv6-only path) falls back to /24 for IPv4 to
+/// preserve prior behavior. IPv6 subnets are not yet modeled.
 fn determine_subnet(local_ip: &IpAddr, prefix_len: Option<u8>) -> anyhow::Result<String> {
     match local_ip {
         IpAddr::V4(ipv4) => Ok(subnet_cidr_v4(*ipv4, prefix_len.unwrap_or(24))),
@@ -354,37 +341,6 @@ fn determine_subnet(local_ip: &IpAddr, prefix_len: Option<u8>) -> anyhow::Result
             anyhow::bail!("IPv6 subnets not yet supported");
         }
     }
-}
-
-/// Pure helper: compute the sweep-subnet CIDR for an IPv4 host + prefix.
-///
-/// * Clamps a `0` prefix and anything wider than [`MIN_SUBNET_PREFIX`] to the
-///   cap - logging the narrowing - so a wide interface prefix can't become an
-///   implicit huge scan. A nonsensical `>32` is defensively clamped to `32`
-///   (unreachable from a real `Ipv4Net`, so it is not logged).
-/// * Computes the network base via the netmask, not by zeroing octets.
-///
-/// Kept free of any interface/I/O so the subnet math is unit-testable.
-fn subnet_cidr_v4(addr: Ipv4Addr, prefix_len: u8) -> String {
-    let effective = if prefix_len == 0 || prefix_len < MIN_SUBNET_PREFIX {
-        tracing::info!(
-            "Interface prefix /{} is wider than the /{} sweep cap; clamping discovery \
-             subnet to /{} to avoid an oversized scan",
-            prefix_len,
-            MIN_SUBNET_PREFIX,
-            MIN_SUBNET_PREFIX
-        );
-        MIN_SUBNET_PREFIX
-    } else {
-        prefix_len.min(32)
-    };
-
-    // Netmask for the effective prefix. `effective` is in 16..=32 here, so the
-    // shift is well-defined (a /0 would need the all-zero mask special-case,
-    // but the clamp above guarantees effective >= 16).
-    let mask: u32 = u32::MAX << (32 - effective as u32);
-    let network = u32::from(addr) & mask;
-    format!("{}/{}", Ipv4Addr::from(network), effective)
 }
 
 /// Run nmap ARP scan to discover hosts on the subnet.
@@ -472,79 +428,10 @@ mod tests {
         assert!(determine_subnet(&ip, Some(64)).is_err());
     }
 
-    #[test]
-    fn derives_subnet_from_real_prefix_not_assumed_24() {
-        // #182: the derived subnet must reflect the real prefix, not /24.
-        assert_eq!(
-            subnet_cidr_v4(Ipv4Addr::new(172, 16, 5, 9), 23),
-            "172.16.4.0/23"
-        );
-        assert_eq!(
-            subnet_cidr_v4(Ipv4Addr::new(192, 168, 1, 130), 25),
-            "192.168.1.128/25"
-        );
-    }
-
-    #[test]
-    fn computes_network_address_via_netmask_not_by_zeroing_octet() {
-        // /25 of .130 -> .128 (bit 7 of the last octet is part of the network),
-        // NOT .0 as a "zero the last octet" shortcut would give.
-        assert_eq!(
-            subnet_cidr_v4(Ipv4Addr::new(192, 168, 1, 130), 25),
-            "192.168.1.128/25"
-        );
-        // /26 of .200 -> .192.
-        assert_eq!(
-            subnet_cidr_v4(Ipv4Addr::new(10, 0, 0, 200), 26),
-            "10.0.0.192/26"
-        );
-        // /30 of .6 -> .4.
-        assert_eq!(
-            subnet_cidr_v4(Ipv4Addr::new(10, 0, 0, 6), 30),
-            "10.0.0.4/30"
-        );
-    }
-
-    #[test]
-    fn exact_host_prefix_32_is_single_address() {
-        assert_eq!(
-            subnet_cidr_v4(Ipv4Addr::new(203, 0, 113, 7), 32),
-            "203.0.113.7/32"
-        );
-    }
-
-    #[test]
-    fn very_wide_prefix_is_capped_not_silently_swept() {
-        // #182 safety cap: a prefix wider than /16 must clamp to /16, never
-        // expand the sweep to a /8-scale range. The network base is recomputed
-        // at the clamped prefix.
-        assert_eq!(subnet_cidr_v4(Ipv4Addr::new(10, 1, 2, 3), 8), "10.1.0.0/16");
-        assert_eq!(
-            subnet_cidr_v4(Ipv4Addr::new(172, 20, 30, 40), 12),
-            "172.20.0.0/16"
-        );
-        // A degenerate /0 also clamps to /16 (guards the shift, too).
-        assert_eq!(subnet_cidr_v4(Ipv4Addr::new(10, 1, 2, 3), 0), "10.1.0.0/16");
-    }
-
-    #[test]
-    fn absurd_prefix_clamps_to_32() {
-        // Unreachable from a real Ipv4Net, but guard the defensive >32 clamp
-        // so it can never panic on the left-shift.
-        assert_eq!(
-            subnet_cidr_v4(Ipv4Addr::new(10, 0, 0, 1), 99),
-            "10.0.0.1/32"
-        );
-    }
-
-    #[test]
-    fn exactly_16_is_not_clamped() {
-        // Boundary: /16 is the cap itself, so it passes through unchanged.
-        assert_eq!(
-            subnet_cidr_v4(Ipv4Addr::new(10, 1, 2, 3), 16),
-            "10.1.0.0/16"
-        );
-    }
+    // Note: the exhaustive `subnet_cidr_v4` prefix/clamp cases live with the
+    // function in `crate::network_context` (single source of truth). The tests
+    // above cover the `determine_subnet` wrapper's own behavior (v4 pass-through,
+    // /24 fallback, IPv6 rejection).
 
     fn ip(s: &str) -> IpAddr {
         s.parse().unwrap()
@@ -590,7 +477,10 @@ mod tests {
     fn iface(name: &str, is_loopback: bool, ips: &[&str]) -> pentest_platform::NetworkInterface {
         pentest_platform::NetworkInterface {
             name: name.to_string(),
-            ip_addresses: ips.iter().map(|s| s.to_string()).collect(),
+            addresses: ips
+                .iter()
+                .map(|s| pentest_platform::InterfaceAddr::new(*s, None))
+                .collect(),
             mac_address: None,
             is_up: true,
             is_loopback,

--- a/crates/tools/src/safety_check/report.rs
+++ b/crates/tools/src/safety_check/report.rs
@@ -506,6 +506,7 @@ mod tests {
                 severity: Severity::Info,
             }],
             network_map: map,
+            active_subnets: Vec::new(),
             recommendations: generate_recommendations(&[], &None),
             timestamp: chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap(),
         }

--- a/crates/tools/src/safety_check/types.rs
+++ b/crates/tools/src/safety_check/types.rs
@@ -141,6 +141,13 @@ pub struct SafetyCheckResult {
     pub checks: Vec<CheckResult>,
     /// Network topology map if available.
     pub network_map: Option<NetworkMap>,
+    /// Active IPv4 subnets this host is on, derived scan-free from interface
+    /// netmasks (e.g. `["10.0.8.0/22", "10.0.40.0/24"]`). This is the reusable
+    /// source of truth for "what network am I actually on" - it lets a scan
+    /// target resolve to `auto`/`current` and lets the agent be seeded with real
+    /// subnets instead of guessing a range. Empty if enumeration failed.
+    #[serde(default)]
+    pub active_subnets: Vec<String>,
     /// Actionable recommendations.
     pub recommendations: Vec<Recommendation>,
     /// Timestamp when check was performed.


### PR DESCRIPTION
Part of #344 (fact-first network discovery). This is **PR 1 - Foundation**: pure plumbing, no intended agent-visible behavior change. Closes #345.

## Summary

- Makes the host's active subnets a **reusable, scan-free source of truth** (`network_context()` in `crates/tools/src/network_context.rs`) so later PRs can resolve `auto`/`current` scan targets (#346) and seed the agent with real subnets (#347) instead of relying on the model to guess a range.
- Models interface addresses **per-address**: `NetworkInterface.ip_addresses: Vec<String>` becomes `addresses: Vec<InterfaceAddr { ip, prefix_len }>`. `network-interface` v2.0.5 exposes netmask per-address, and one interface can be multi-homed / dual-stack, so a per-interface prefix scalar would be lossy for exactly the case this epic targets. (Deviates from #345's original AC, which is updated with the rationale.)
- Populates the real prefix in all three enumeration paths (desktop `network-interface` primary, desktop `ip addr` fallback, Android).
- Relocates the pure `subnet_cidr_v4` netmask math into `network_context` as the single source of truth; `safety_check/network_map` now imports it (removes a duplicate).
- Removes the hardcoded `/24` in `autopwn/network_plan.rs:111` (derives from the real prefix; the fallback now also emits a valid CIDR base rather than a malformed `x.y.z/24`).
- Exposes `active_subnets` on `SafetyCheckResult`, derived scan-free and independent of whether the discovery sweep succeeds.

## Verification

- `cargo check --workspace` clean; `cargo clippy -p pentest-tools -p pentest-platform --all-targets -- -D warnings` clean; `cargo fmt --all` applied.
- `cargo test -p pentest-platform -p pentest-tools --lib` -> 58 + 343 pass, 0 fail. 15 new tests.
- **Mutation-verified** the new guards go red when the code is broken: (A) `subnet_cidr_v4` with masking removed -> 6 tests red; (B) `prefix_len_from_ipv4_netmask` trusting popcount (dropping the non-contiguous-mask rejection) -> red; (C) `interface_addr_from_token` dropping the prefix -> red.
- Blast radius: `NetworkInterface` shape change touches 4 construction + 3 read sites (all updated); verified the struct is never serialized across a wire boundary or persisted (no json/bincode/toml/cache/fixture consumers), so the field rename is safe.

## Reviewer note (CI-scope, deliberate)

A pick-reviewer pass flagged that the macOS CI lane (`ci.yml:90`, `--package pentest-platform --package pentest-core --lib`) does not run `pentest-tools`, so the new `network_context` tests do not execute on macOS. This is **intentional and low-risk**: those tests are platform-invariant pure math and **do** run in the required Linux `--workspace` lane (`ci.yml:74`); the platform-specific helper (`prefix_len_from_ipv4_netmask`) lives in `pentest-platform` and runs on both lanes. Not adding `--package pentest-tools` to macOS (would bloat the lane for zero macOS-specific coverage). If PR 2's shared resolver naturally lands in `pentest-core`, the pure math can migrate then.

## Test plan

- [x] `cargo test -p pentest-platform -p pentest-tools --lib` green
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Mutation-verified the new guards (3 mutants confirmed red)
- [ ] CI green on the required Linux lane