### PR TITLE
feat(network): resolve auto/current/all scan targets + validate bypass tools (#346)

### DIFF
--- a/crates/tools/src/external/network/arp_scan.rs
+++ b/crates/tools/src/external/network/arp_scan.rs
@@ -34,7 +34,10 @@ impl PentestTool for ArpScanTool {
             .param(ToolParam::required(
                 "target",
                 ParamType::String,
-                "Target network (CIDR)",
+                "Target network (CIDR), or a sentinel: 'current' (this host's \
+                 primary subnet), 'auto'/'all' (every active local subnet). \
+                 Prefer a sentinel over guessing a range - it uses the host's \
+                 real interface subnets.",
             ))
             .param(ToolParam::optional(
                 "timeout",
@@ -63,7 +66,13 @@ impl PentestTool for ArpScanTool {
 
             let timeout_secs = crate::util::param_u64(&params, "timeout", 60);
 
-            let builder = CommandBuilder::new().positional(&target);
+            // Resolve auto/current/all -> real subnets, validate, and surface an
+            // out-of-subnet advisory. arp-scan accepts multiple positional
+            // targets ("arp-scan [options] [hosts...]"), so a multi-subnet
+            // resolution fans out in one invocation.
+            let prepared = crate::scan_target::prepare_scan_targets(&target).await?;
+
+            let builder = CommandBuilder::new().extend(&prepared.targets);
 
             let args = builder.build();
             let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
@@ -80,6 +89,8 @@ impl PentestTool for ArpScanTool {
 
             Ok(json!({
                 "target": target,
+                "resolved_targets": prepared.targets,
+                "out_of_subnet_warning": prepared.warning,
                 "hosts": hosts,
                 "count": hosts.len(),
             }))

--- a/crates/tools/src/external/network/masscan_fast.rs
+++ b/crates/tools/src/external/network/masscan_fast.rs
@@ -34,7 +34,10 @@ impl PentestTool for MasscanFastTool {
             .param(ToolParam::required(
                 "target",
                 ParamType::String,
-                "Target IP or CIDR range",
+                "Target IP or CIDR range, or a sentinel: 'current' (this host's \
+                 primary subnet), 'auto'/'all' (every active local subnet). \
+                 Prefer a sentinel over guessing a range - it uses the host's \
+                 real interface subnets.",
             ))
             .param(ToolParam::optional(
                 "rate",
@@ -70,8 +73,13 @@ impl PentestTool for MasscanFastTool {
             let rate = params.get("rate").and_then(|v| v.as_u64()).unwrap_or(10000);
             let timeout_secs = crate::util::param_u64(&params, "timeout", 120);
 
+            // Resolve auto/current/all -> real subnets, validate, warn if
+            // out-of-subnet. masscan accepts multiple positional targets, so a
+            // multi-subnet resolution fans out in one invocation.
+            let prepared = crate::scan_target::prepare_scan_targets(&target).await?;
+
             let builder = CommandBuilder::new()
-                .positional(&target)
+                .extend(&prepared.targets)
                 .arg("-p", "21,22,23,25,80,443,445,3306,3389,8080")
                 .arg("--rate", &rate.to_string());
 
@@ -90,6 +98,8 @@ impl PentestTool for MasscanFastTool {
 
             Ok(json!({
                 "target": target,
+                "resolved_targets": prepared.targets,
+                "out_of_subnet_warning": prepared.warning,
                 "open_ports": open_ports,
                 "count": open_ports.len(),
             }))

--- a/crates/tools/src/external/network/netdiscover.rs
+++ b/crates/tools/src/external/network/netdiscover.rs
@@ -35,7 +35,10 @@ impl PentestTool for NetdiscoverTool {
             .param(ToolParam::optional(
                 "range",
                 ParamType::String,
-                "IP range (e.g., 192.168.1.0/24)",
+                "IP range (e.g., 192.168.1.0/24), or a sentinel: 'current' (this \
+                 host's primary subnet), 'auto'/'all' (every active local subnet, \
+                 scanned one per invocation). Empty = netdiscover auto-scan. \
+                 Prefer a sentinel over guessing a range.",
                 json!(""),
             ))
             .param(ToolParam::optional(
@@ -53,7 +56,8 @@ impl PentestTool for NetdiscoverTool {
             .param(ToolParam::optional(
                 "timeout",
                 ParamType::Integer,
-                "Timeout",
+                "Total timeout in seconds, split across subnets when 'auto'/'all' \
+                 expands to several (each gets total/N, floored at 1s).",
                 json!(60),
             ))
             .platforms(vec![Platform::Desktop, Platform::Tui])
@@ -73,38 +77,90 @@ impl PentestTool for NetdiscoverTool {
             let passive = param_bool(&params, "passive", false);
             let timeout_secs = crate::util::param_u64(&params, "timeout", 60);
 
-            let mut builder = CommandBuilder::new();
+            // Resolve the range when one is given. netdiscover's `-r` takes a
+            // SINGLE range (multiple require `-l file`), so an auto/current/all
+            // sentinel that fans out to several subnets is run once per subnet
+            // and the host lists are merged. An absent/empty range preserves
+            // netdiscover's built-in auto-scan (no `-r`).
+            let (ranges, out_of_subnet_warning): (Vec<Option<String>>, Option<String>) =
+                match range.as_deref() {
+                    Some(r) if !r.is_empty() => {
+                        let prepared = crate::scan_target::prepare_scan_targets(r).await?;
+                        (
+                            prepared.targets.into_iter().map(Some).collect(),
+                            prepared.warning,
+                        )
+                    }
+                    // No range: single auto-scan invocation (range = None).
+                    _ => (vec![None], None),
+                };
 
-            if let Some(r) = range {
-                if !r.is_empty() {
-                    builder = builder.arg("-r", &r);
-                }
-            }
-
-            if let Some(i) = interface {
-                if !i.is_empty() {
-                    builder = builder.arg("-i", &i);
-                }
-            }
-
-            if passive {
-                builder = builder.flag("-p");
-            }
-
-            let args = builder.build();
-            let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
-            let result = platform
-                .execute_command("netdiscover", &args_refs, Duration::from_secs(timeout_secs))
-                .await?;
+            // Split the timeout budget across subnets so N subnets total ~=
+            // `timeout_secs`, not N x timeout_secs. Floored at 1s per subnet.
+            let per_range_timeout =
+                Duration::from_secs((timeout_secs / ranges.len().max(1) as u64).max(1));
 
             let mut hosts = Vec::new();
-            for line in result.stdout.lines() {
-                if line.contains('.') && !line.starts_with(' ') {
-                    hosts.push(line.trim().to_string());
+            let mut failed_ranges: Vec<String> = Vec::new();
+            for range_opt in &ranges {
+                let mut builder = CommandBuilder::new();
+
+                if let Some(r) = range_opt {
+                    builder = builder.arg("-r", r);
+                }
+
+                if let Some(ref i) = interface {
+                    if !i.is_empty() {
+                        builder = builder.arg("-i", i);
+                    }
+                }
+
+                if passive {
+                    builder = builder.flag("-p");
+                }
+
+                let args = builder.build();
+                let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+                // Per-subnet failure is non-fatal: one unreachable subnet must
+                // not discard the hosts already found on the others. Log and
+                // continue, recording which range failed for the result.
+                match platform
+                    .execute_command("netdiscover", &args_refs, per_range_timeout)
+                    .await
+                {
+                    Ok(result) => {
+                        for line in result.stdout.lines() {
+                            if line.contains('.') && !line.starts_with(' ') {
+                                hosts.push(line.trim().to_string());
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        let label = range_opt.as_deref().unwrap_or("(auto-scan)");
+                        tracing::warn!("netdiscover failed on range {}: {}", label, e);
+                        failed_ranges.push(label.to_string());
+                    }
                 }
             }
 
-            Ok(json!({"hosts": hosts, "count": hosts.len()}))
+            // If every range failed (and at least one was attempted), surface a
+            // hard error - a wholesale failure is not a "0 hosts" success.
+            if !failed_ranges.is_empty() && failed_ranges.len() == ranges.len() {
+                return Err(pentest_core::error::Error::Network(format!(
+                    "netdiscover failed on all {} range(s): {}",
+                    ranges.len(),
+                    failed_ranges.join(", ")
+                )));
+            }
+
+            let resolved: Vec<&str> = ranges.iter().filter_map(|r| r.as_deref()).collect();
+            Ok(json!({
+                "resolved_ranges": resolved,
+                "failed_ranges": failed_ranges,
+                "out_of_subnet_warning": out_of_subnet_warning,
+                "hosts": hosts,
+                "count": hosts.len(),
+            }))
         })
         .await
     }

--- a/crates/tools/src/external/network/netdiscover.rs
+++ b/crates/tools/src/external/network/netdiscover.rs
@@ -14,6 +14,20 @@ use crate::external::install::ensure_tool_installed;
 use crate::external::runner::{param_str_opt, CommandBuilder};
 use crate::util::param_bool;
 
+/// Minimum wall-clock a single subnet's netdiscover run is granted, regardless
+/// of how the total budget divides across subnets. Below this a per-subnet slice
+/// is too short for the ARP sweep to surface anything, so many active subnets
+/// (VPN + docker + wifi + wired) would otherwise all starve.
+const MIN_PER_RANGE_TIMEOUT_SECS: u64 = 10;
+
+/// Per-subnet timeout: split `total_secs` across `n_ranges`, but never below
+/// [`MIN_PER_RANGE_TIMEOUT_SECS`]. When the floor binds, total time exceeds the
+/// requested budget rather than running scans too short to complete. Pure so the
+/// starvation boundary is unit-testable.
+fn per_range_timeout_secs(total_secs: u64, n_ranges: usize) -> u64 {
+    (total_secs / n_ranges.max(1) as u64).max(MIN_PER_RANGE_TIMEOUT_SECS)
+}
+
 pub struct NetdiscoverTool;
 
 #[async_trait]
@@ -57,7 +71,8 @@ impl PentestTool for NetdiscoverTool {
                 "timeout",
                 ParamType::Integer,
                 "Total timeout in seconds, split across subnets when 'auto'/'all' \
-                 expands to several (each gets total/N, floored at 1s).",
+                 expands to several (each gets total/N, with a per-subnet minimum \
+                 so many subnets don't starve).",
                 json!(60),
             ))
             .platforms(vec![Platform::Desktop, Platform::Tui])
@@ -96,9 +111,14 @@ impl PentestTool for NetdiscoverTool {
                 };
 
             // Split the timeout budget across subnets so N subnets total ~=
-            // `timeout_secs`, not N x timeout_secs. Floored at 1s per subnet.
+            // `timeout_secs`, not N x timeout_secs. Floored at a per-subnet
+            // MINIMUM so a many-subnet host (VPN + docker + wifi + wired) can't
+            // starve every range: with a 60s budget and 61 subnets, integer
+            // division would give 0 -> a useless 1s each and nothing completes.
+            // Below the floor we let the total exceed `timeout_secs` (each subnet
+            // still gets a workable slice) rather than run scans that can't finish.
             let per_range_timeout =
-                Duration::from_secs((timeout_secs / ranges.len().max(1) as u64).max(1));
+                Duration::from_secs(per_range_timeout_secs(timeout_secs, ranges.len()));
 
             let mut hosts = Vec::new();
             let mut failed_ranges: Vec<String> = Vec::new();
@@ -163,5 +183,31 @@ impl PentestTool for NetdiscoverTool {
             }))
         })
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn per_range_timeout_splits_budget_when_few_subnets() {
+        // Normal case: 60s over 4 subnets -> 15s each (above the floor).
+        assert_eq!(per_range_timeout_secs(60, 4), 15);
+        // Single range (or none) gets the whole budget.
+        assert_eq!(per_range_timeout_secs(60, 1), 60);
+        assert_eq!(per_range_timeout_secs(60, 0), 60);
+    }
+
+    #[test]
+    fn per_range_timeout_floors_so_many_subnets_dont_starve() {
+        // The M2 bug: 60s / 61 subnets floors to 0 -> 1s each and nothing
+        // completes. The floor must keep each subnet workable instead.
+        assert_eq!(per_range_timeout_secs(60, 61), MIN_PER_RANGE_TIMEOUT_SECS);
+        // Right at the boundary where the split would dip below the floor.
+        assert_eq!(per_range_timeout_secs(60, 7), MIN_PER_RANGE_TIMEOUT_SECS); // 60/7=8 -> floored
+        assert_eq!(per_range_timeout_secs(60, 6), 10); // 60/6=10 == floor, exact
+                                                       // Never returns the useless sub-floor slice the bug produced.
+        assert!(per_range_timeout_secs(60, 100) >= MIN_PER_RANGE_TIMEOUT_SECS);
     }
 }

--- a/crates/tools/src/external/network/nmap_vuln.rs
+++ b/crates/tools/src/external/network/nmap_vuln.rs
@@ -34,7 +34,10 @@ impl PentestTool for NmapVulnTool {
             .param(ToolParam::required(
                 "target",
                 ParamType::String,
-                "Target IP or hostname",
+                "Target IP, CIDR, or hostname, or a sentinel: 'current' (this \
+                 host's primary subnet), 'auto'/'all' (every active local \
+                 subnet). Prefer a sentinel over guessing a range for local \
+                 scans - it uses the host's real interface subnets.",
             ))
             .param(ToolParam::optional(
                 "timeout",
@@ -63,10 +66,15 @@ impl PentestTool for NmapVulnTool {
 
             let timeout_secs = crate::util::param_u64(&params, "timeout", 600);
 
+            // Resolve auto/current/all -> real subnets, validate, warn if
+            // out-of-subnet. nmap accepts multiple positional targets, so a
+            // multi-subnet resolution fans out in one invocation.
+            let prepared = crate::scan_target::prepare_scan_targets(&target).await?;
+
             let builder = CommandBuilder::new()
                 .arg("-sV", "")
                 .arg("--script", "vuln")
-                .positional(&target);
+                .extend(&prepared.targets);
 
             let args = builder.build();
             let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
@@ -83,6 +91,8 @@ impl PentestTool for NmapVulnTool {
 
             Ok(json!({
                 "target": target,
+                "resolved_targets": prepared.targets,
+                "out_of_subnet_warning": prepared.warning,
                 "vulnerabilities": vulns,
                 "count": vulns.len(),
                 "output": result.stdout,

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -25,6 +25,7 @@ pub mod read_file;
 pub mod registry; // Quick action registry for UI
 pub mod safety_check; // NEW: Network safety validation
 pub mod safety_check_tool; // NEW: Safety check tool wrapper
+pub mod scan_target; // Resolve auto/current/all target sentinels + out-of-subnet warning
 pub mod screenshot;
 pub mod service_banner;
 pub mod session_export;

--- a/crates/tools/src/scan_target.rs
+++ b/crates/tools/src/scan_target.rs
@@ -164,7 +164,7 @@ pub fn resolve_against_subnets(
 }
 
 /// True if a raw target is one of the recognized sentinels (case-insensitive).
-pub fn is_sentinel(raw: &str) -> bool {
+pub(crate) fn is_sentinel(raw: &str) -> bool {
     matches!(
         raw.trim().to_ascii_lowercase().as_str(),
         SENTINEL_CURRENT | SENTINEL_AUTO | SENTINEL_ALL
@@ -173,16 +173,33 @@ pub fn is_sentinel(raw: &str) -> bool {
 
 /// Resolve a raw target against the host's live network context.
 ///
-/// Fetches [`network_context`] (scan-free) and delegates to
-/// [`resolve_against_subnets`]. Only performs the interface enumeration when the
-/// target is actually a sentinel *or* a concrete address worth range-checking -
-/// a hostname passes straight through without touching the network.
+/// Delegates to [`resolve_against_subnets`], but only performs the (scan-free)
+/// interface enumeration via [`network_context`] when the target actually needs
+/// it: a sentinel (`auto`/`current`/`all`) that must expand to real subnets, or
+/// a concrete IPv4 literal worth range-checking for the out-of-subnet advisory.
+/// A hostname (or any non-IPv4 literal) passes straight through without touching
+/// the network, since there is nothing to resolve or range-check against.
 pub async fn resolve_scan_target(raw: &str) -> Result<ResolvedTargets, ResolveError> {
-    let subnets: Vec<Subnet> = network_context().await.unwrap_or_else(|e| {
-        tracing::warn!("network_context unavailable while resolving target: {}", e);
+    let subnets: Vec<Subnet> = if needs_subnet_context(raw) {
+        network_context().await.unwrap_or_else(|e| {
+            tracing::warn!("network_context unavailable while resolving target: {}", e);
+            Vec::new()
+        })
+    } else {
         Vec::new()
-    });
+    };
     resolve_against_subnets(raw, &subnets)
+}
+
+/// Whether resolving `raw` needs the host's subnet context at all.
+///
+/// True only for a sentinel (must expand to real subnets) or a concrete IPv4
+/// literal (range-checked for the out-of-subnet advisory). A hostname or any
+/// non-IPv4 literal has nothing to resolve or range-check, so enumeration is
+/// skipped - keeping the "hostname passes straight through without touching the
+/// network" contract [`resolve_scan_target`] documents actually true.
+fn needs_subnet_context(raw: &str) -> bool {
+    is_sentinel(raw) || target_ipv4(raw.trim()).is_some()
 }
 
 /// Validated, ready-to-scan targets plus any advisory to surface.
@@ -357,5 +374,20 @@ mod tests {
         assert!(is_sentinel("ALL"));
         assert!(!is_sentinel("10.0.8.0/22"));
         assert!(!is_sentinel("scanme.nmap.org"));
+    }
+
+    #[test]
+    fn needs_subnet_context_only_for_sentinels_and_ipv4() {
+        // Sentinels must expand -> need enumeration.
+        assert!(needs_subnet_context("auto"));
+        assert!(needs_subnet_context("current"));
+        assert!(needs_subnet_context(" ALL "));
+        // Concrete IPv4 (host or CIDR) -> range-checked, needs enumeration.
+        assert!(needs_subnet_context("10.0.8.50"));
+        assert!(needs_subnet_context("192.168.1.0/24"));
+        // Hostname / non-IPv4 literal -> nothing to resolve; must NOT touch the
+        // network. This is the H1 contract: skip enumeration for a hostname.
+        assert!(!needs_subnet_context("scanme.nmap.org"));
+        assert!(!needs_subnet_context("example.com"));
     }
 }

--- a/crates/tools/src/scan_target.rs
+++ b/crates/tools/src/scan_target.rs
@@ -1,0 +1,361 @@
+//! Resolve scan-target sentinels (`auto`/`current`/`all`) against the host's
+//! real subnets, and flag out-of-subnet targets.
+//!
+//! The operational failure this addresses: an agent hallucinates a range
+//! (`192.168.1.0/24`) instead of scanning the network it is actually on. Making
+//! `auto`/`current` first-class targets (resolved from
+//! [`crate::network_context`]) lets the safe target be the default instead of a
+//! discipline the model must remember.
+//!
+//! Two layers: a pure core ([`resolve_against_subnets`]) that takes the subnet
+//! list as input (unit-testable, no I/O), and an async wrapper
+//! ([`resolve_scan_target`]) that fetches the live context.
+
+use crate::network_context::{network_context, Subnet};
+use pentest_core::error::Error;
+use pentest_core::validation::validate_target;
+use std::net::Ipv4Addr;
+
+/// Sentinel target values, matched case-insensitively.
+const SENTINEL_CURRENT: &str = "current";
+const SENTINEL_AUTO: &str = "auto";
+const SENTINEL_ALL: &str = "all";
+
+/// Outcome of resolving a raw target argument.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedTargets {
+    /// Concrete targets to hand to the scanner (CIDRs and/or the original
+    /// literal). Never empty on `Ok`.
+    pub targets: Vec<String>,
+    /// Non-blocking advisory: the raw target is a literal outside every known
+    /// local subnet (possible typo, or an intentional routed/pivot scan). The
+    /// scan still proceeds - this is surfaced, not enforced.
+    pub out_of_subnet_warning: Option<String>,
+}
+
+/// Error resolving a sentinel target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResolveError {
+    /// A sentinel (`auto`/`current`/`all`) was requested but no local subnet
+    /// could be derived (interface enumeration failed or found nothing usable).
+    NoSubnets(String),
+}
+
+impl std::fmt::Display for ResolveError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ResolveError::NoSubnets(s) => write!(
+                f,
+                "target '{s}' requires knowing this host's subnets, but none could be \
+                 determined (interface enumeration failed or found no usable IPv4 subnet); \
+                 specify an explicit CIDR instead"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for ResolveError {}
+
+/// True if `ip` falls inside the IPv4 `cidr` (e.g. `10.0.8.0/22`).
+///
+/// Hand-rolled v4 containment (no external CIDR crate): parse base + prefix,
+/// mask both, compare. Non-IPv4 or malformed inputs yield `false` (a v6 target
+/// is simply never "in" a v4 subnet for this advisory check).
+fn ipv4_in_cidr(ip: Ipv4Addr, cidr: &str) -> bool {
+    let Some((base, prefix)) = cidr.split_once('/') else {
+        return false;
+    };
+    let Ok(base_addr) = base.parse::<Ipv4Addr>() else {
+        return false;
+    };
+    let Ok(prefix_len) = prefix.parse::<u8>() else {
+        return false;
+    };
+    if prefix_len > 32 {
+        return false;
+    }
+    // /0 contains everything; guard the shift (<<32 is UB-adjacent).
+    let mask: u32 = if prefix_len == 0 {
+        0
+    } else {
+        u32::MAX << (32 - prefix_len as u32)
+    };
+    (u32::from(ip) & mask) == (u32::from(base_addr) & mask)
+}
+
+/// Extract the bare IPv4 address a raw target refers to, if any.
+///
+/// Handles a plain IP (`10.0.8.5`) and a CIDR (`10.0.8.0/22` -> its base). A
+/// hostname or IPv6 target yields `None` (the out-of-subnet check only applies
+/// to concrete v4 addresses).
+fn target_ipv4(raw: &str) -> Option<Ipv4Addr> {
+    let bare = raw.split('/').next().unwrap_or(raw);
+    bare.parse::<Ipv4Addr>().ok()
+}
+
+/// Resolve a raw target against a known subnet list (pure).
+///
+/// * `current` -> the primary (default-route) subnet, or the first subnet if
+///   none is flagged primary (best-effort when primary detection failed).
+/// * `auto` / `all` -> every known subnet.
+/// * anything else -> passed through unchanged, with an out-of-subnet advisory
+///   attached when it is a concrete v4 address/CIDR outside every known subnet.
+///
+/// Sentinel matching is case-insensitive. Returns [`ResolveError::NoSubnets`]
+/// only when a sentinel is requested and `subnets` is empty.
+pub fn resolve_against_subnets(
+    raw: &str,
+    subnets: &[Subnet],
+) -> Result<ResolvedTargets, ResolveError> {
+    let trimmed = raw.trim();
+    let lower = trimmed.to_ascii_lowercase();
+
+    match lower.as_str() {
+        SENTINEL_CURRENT => {
+            let chosen = subnets
+                .iter()
+                .find(|s| s.is_primary)
+                .or_else(|| subnets.first())
+                .ok_or_else(|| ResolveError::NoSubnets(trimmed.to_string()))?;
+            Ok(ResolvedTargets {
+                targets: vec![chosen.cidr.clone()],
+                out_of_subnet_warning: None,
+            })
+        }
+        SENTINEL_AUTO | SENTINEL_ALL => {
+            if subnets.is_empty() {
+                return Err(ResolveError::NoSubnets(trimmed.to_string()));
+            }
+            Ok(ResolvedTargets {
+                targets: subnets.iter().map(|s| s.cidr.clone()).collect(),
+                out_of_subnet_warning: None,
+            })
+        }
+        _ => {
+            // Literal target: pass through, but advise if it's a concrete v4
+            // address outside every known local subnet. Only warn when we
+            // actually know our subnets (empty list -> no basis to judge).
+            let warning = match target_ipv4(trimmed) {
+                Some(ip) if !subnets.is_empty() => {
+                    let inside = subnets.iter().any(|s| ipv4_in_cidr(ip, &s.cidr));
+                    if inside {
+                        None
+                    } else {
+                        let known = subnets
+                            .iter()
+                            .map(|s| s.cidr.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        Some(format!(
+                            "target {trimmed} is outside your active subnet(s) [{known}]; \
+                             scanning anyway (intentional if this is a routed/pivot target, \
+                             but check for a typo if not)"
+                        ))
+                    }
+                }
+                _ => None,
+            };
+            Ok(ResolvedTargets {
+                targets: vec![trimmed.to_string()],
+                out_of_subnet_warning: warning,
+            })
+        }
+    }
+}
+
+/// True if a raw target is one of the recognized sentinels (case-insensitive).
+pub fn is_sentinel(raw: &str) -> bool {
+    matches!(
+        raw.trim().to_ascii_lowercase().as_str(),
+        SENTINEL_CURRENT | SENTINEL_AUTO | SENTINEL_ALL
+    )
+}
+
+/// Resolve a raw target against the host's live network context.
+///
+/// Fetches [`network_context`] (scan-free) and delegates to
+/// [`resolve_against_subnets`]. Only performs the interface enumeration when the
+/// target is actually a sentinel *or* a concrete address worth range-checking -
+/// a hostname passes straight through without touching the network.
+pub async fn resolve_scan_target(raw: &str) -> Result<ResolvedTargets, ResolveError> {
+    let subnets: Vec<Subnet> = network_context().await.unwrap_or_else(|e| {
+        tracing::warn!("network_context unavailable while resolving target: {}", e);
+        Vec::new()
+    });
+    resolve_against_subnets(raw, &subnets)
+}
+
+/// Validated, ready-to-scan targets plus any advisory to surface.
+#[derive(Debug, Clone)]
+pub struct PreparedTargets {
+    /// Concrete targets, each already through `validate_target`. Never empty.
+    pub targets: Vec<String>,
+    /// Non-blocking out-of-subnet advisory, if any (for inclusion in the tool
+    /// result so the agent sees it).
+    pub warning: Option<String>,
+}
+
+/// Full target pipeline for a discovery scanner: **resolve sentinel -> validate
+/// -> warn**, in that fixed order.
+///
+/// This is the single choke point the network scanners share so the ordering
+/// (and the previously-missing validation on the bypass tools) lives in one
+/// place rather than being re-implemented per tool:
+///
+/// 1. Resolve `auto`/`current`/`all` against the host's live subnets.
+/// 2. Validate every resolved target with [`validate_target`] (format /
+///    command-injection guard) - this closes the gap where `arp_scan`,
+///    `netdiscover`, `masscan_fast`, and `nmap_vuln` shelled a raw string.
+/// 3. Log any out-of-subnet advisory and return it for the tool result. The
+///    advisory never blocks the scan (routed/pivot targets are legitimate).
+///
+/// # Errors
+///
+/// - [`Error::InvalidParams`] if a sentinel can't be resolved (no known subnets)
+///   or if any resolved/literal target fails validation.
+pub async fn prepare_scan_targets(raw: &str) -> pentest_core::error::Result<PreparedTargets> {
+    let resolved = resolve_scan_target(raw)
+        .await
+        .map_err(|e| Error::InvalidParams(e.to_string()))?;
+
+    // Validate every concrete target (closes the bypass-tool gap).
+    let mut validated = Vec::with_capacity(resolved.targets.len());
+    for t in &resolved.targets {
+        validated.push(validate_target(t)?);
+    }
+
+    if let Some(ref w) = resolved.out_of_subnet_warning {
+        tracing::warn!("{}", w);
+    }
+
+    Ok(PreparedTargets {
+        targets: validated,
+        warning: resolved.out_of_subnet_warning,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sn(cidr: &str, primary: bool) -> Subnet {
+        Subnet {
+            cidr: cidr.to_string(),
+            interface: "test".to_string(),
+            is_primary: primary,
+        }
+    }
+
+    #[test]
+    fn current_resolves_to_primary_subnet() {
+        let subnets = vec![sn("10.0.8.0/22", false), sn("10.0.40.0/24", true)];
+        let r = resolve_against_subnets("current", &subnets).unwrap();
+        assert_eq!(r.targets, vec!["10.0.40.0/24"]);
+        assert!(r.out_of_subnet_warning.is_none());
+    }
+
+    #[test]
+    fn current_falls_back_to_first_when_no_primary_flagged() {
+        let subnets = vec![sn("10.0.8.0/22", false), sn("10.0.40.0/24", false)];
+        let r = resolve_against_subnets("current", &subnets).unwrap();
+        assert_eq!(r.targets, vec!["10.0.8.0/22"]);
+    }
+
+    #[test]
+    fn auto_and_all_resolve_to_every_subnet() {
+        let subnets = vec![sn("10.0.8.0/22", true), sn("10.0.40.0/24", false)];
+        for sentinel in ["auto", "all", "AUTO", "All"] {
+            let r = resolve_against_subnets(sentinel, &subnets).unwrap();
+            assert_eq!(
+                r.targets,
+                vec!["10.0.8.0/22", "10.0.40.0/24"],
+                "sentinel {sentinel} should fan out to all subnets"
+            );
+        }
+    }
+
+    #[test]
+    fn sentinel_with_no_subnets_is_an_error() {
+        for sentinel in ["auto", "current", "all"] {
+            assert!(
+                matches!(
+                    resolve_against_subnets(sentinel, &[]),
+                    Err(ResolveError::NoSubnets(_))
+                ),
+                "sentinel {sentinel} with no subnets must error, not silently pass through"
+            );
+        }
+    }
+
+    #[test]
+    fn literal_target_passes_through_unchanged() {
+        let subnets = vec![sn("10.0.8.0/22", true)];
+        let r = resolve_against_subnets("10.0.8.50", &subnets).unwrap();
+        assert_eq!(r.targets, vec!["10.0.8.50"]);
+        assert!(
+            r.out_of_subnet_warning.is_none(),
+            "an in-subnet literal must not warn"
+        );
+    }
+
+    #[test]
+    fn in_subnet_cidr_literal_does_not_warn() {
+        let subnets = vec![sn("10.0.8.0/22", true)];
+        let r = resolve_against_subnets("10.0.9.0/24", &subnets).unwrap();
+        assert_eq!(r.targets, vec!["10.0.9.0/24"]);
+        assert!(r.out_of_subnet_warning.is_none());
+    }
+
+    #[test]
+    fn out_of_subnet_literal_warns_but_still_scans() {
+        // The motivating bug: 192.168.1.0/24 while actually on 10.0.x.
+        let subnets = vec![sn("10.0.8.0/22", true), sn("10.0.40.0/24", false)];
+        let r = resolve_against_subnets("192.168.1.0/24", &subnets).unwrap();
+        // Still scans the requested target (non-blocking).
+        assert_eq!(r.targets, vec!["192.168.1.0/24"]);
+        let warning = r.out_of_subnet_warning.expect("should warn");
+        assert!(warning.contains("192.168.1.0/24"));
+        assert!(warning.contains("10.0.8.0/22"));
+        assert!(warning.contains("10.0.40.0/24"));
+    }
+
+    #[test]
+    fn out_of_subnet_never_warns_when_subnets_unknown() {
+        // No basis to judge -> no false warning.
+        let r = resolve_against_subnets("192.168.1.5", &[]).unwrap();
+        assert_eq!(r.targets, vec!["192.168.1.5"]);
+        assert!(r.out_of_subnet_warning.is_none());
+    }
+
+    #[test]
+    fn hostname_target_passes_through_without_warning() {
+        let subnets = vec![sn("10.0.8.0/22", true)];
+        let r = resolve_against_subnets("scanme.nmap.org", &subnets).unwrap();
+        assert_eq!(r.targets, vec!["scanme.nmap.org"]);
+        assert!(r.out_of_subnet_warning.is_none());
+    }
+
+    #[test]
+    fn ipv4_in_cidr_boundaries() {
+        // /22 spans 10.0.8.0 - 10.0.11.255.
+        assert!(ipv4_in_cidr("10.0.8.0".parse().unwrap(), "10.0.8.0/22"));
+        assert!(ipv4_in_cidr("10.0.11.255".parse().unwrap(), "10.0.8.0/22"));
+        assert!(!ipv4_in_cidr("10.0.12.0".parse().unwrap(), "10.0.8.0/22"));
+        // /32 host route.
+        assert!(ipv4_in_cidr("1.2.3.4".parse().unwrap(), "1.2.3.4/32"));
+        assert!(!ipv4_in_cidr("1.2.3.5".parse().unwrap(), "1.2.3.4/32"));
+        // /0 contains everything.
+        assert!(ipv4_in_cidr("8.8.8.8".parse().unwrap(), "0.0.0.0/0"));
+        // Malformed cidr -> false, no panic.
+        assert!(!ipv4_in_cidr("10.0.8.5".parse().unwrap(), "not-a-cidr"));
+    }
+
+    #[test]
+    fn is_sentinel_matches_case_insensitively() {
+        assert!(is_sentinel("auto"));
+        assert!(is_sentinel("  Current "));
+        assert!(is_sentinel("ALL"));
+        assert!(!is_sentinel("10.0.8.0/22"));
+        assert!(!is_sentinel("scanme.nmap.org"));
+    }
+}


### PR DESCRIPTION
Part of #344 (fact-first network discovery). This is **PR 2 - Target pipeline**. Closes #346.

> **Stacked on #348** (PR 1, `feat/network-context-foundation`). Base is that branch, not `main`, because this consumes `network_context()`. **Merge #348 first**, then rebase this onto `main` (or it retargets automatically once #348 merges).

## Summary

- **`auto`/`current`/`all` become first-class scan targets.** `current` -> the host's primary (default-route) subnet; `auto`/`all` -> every active local subnet, resolved scan-free from `network_context()` (#345). This makes the safe target the default instead of relying on the model to remember to gather facts.
- **One shared `prepare_scan_targets` pipeline** enforces a fixed order: **resolve sentinel -> `validate_target` (each) -> warn**. Routing the four previously-unvalidated discovery tools through it *closes the bypass gap* where they shelled a raw target string with no format/injection check.
- **Non-blocking out-of-subnet advisory:** a literal target outside every known local subnet (the `192.168.1.0/24`-on-`10.0.x` case) is flagged in the result but still scanned - routed/pivot scans are legitimate and never blocked.
- **Wiring per CLI capability** (verified empirically): `arp_scan`, `masscan_fast`, `nmap_vuln` accept multiple positional targets -> fan out in one invocation; `netdiscover`'s `-r` takes a single range -> loops per subnet with a split timeout budget and non-fatal per-subnet failures.
- Each tool result now carries `resolved_targets`/`resolved_ranges` + `out_of_subnet_warning`. Param descriptions document the sentinels (the schema has no `enum` slot).

## Scope correction

`responder` was dropped from the bypass-tool list: it targets an **interface**, not an IP/CIDR (only `interface` + bool params), so there's nothing to resolve or range-check. #346 updated. Real scope is the 4 target-taking tools.

## Verification

- `cargo check --workspace` clean; `cargo clippy -p pentest-tools --all-targets -- -D warnings` clean; fmt applied.
- `cargo test -p pentest-tools -p pentest-platform --lib` -> 354 + 58 pass, 0 fail (11 new `scan_target` tests).
- **Mutation-verified** 3 guards go red when broken: (A) `current` -> last-instead-of-primary; (B) dropping the auto/all empty-subnet guard; (C) inverting `ipv4_in_cidr` (4 tests red).
- **Multi-target CLI verified empirically:** `nmap -sL 10.0.8.0/30 192.168.99.0/30` scans both; arp-scan usage is `[hosts...]`; netdiscover `-r` is single-range (hence the loop); masscan doc-verified (not installed locally).

## Review dispositions (pick-reviewer pass)

- **BLOCKING "validate_target rejects masscan dash-range" - RETRACTED.** Verified empirically: `validate_target("10.0.0.1-10.0.0.20")` **accepts** it (passes as a hostname-shaped string). No regression. The finding was reasoned, not run.
- **netdiscover per-subnet timeout + fail-fast (SHOULD-FIX/LOW) - FIXED.** Timeout is now split across subnets (total ~= `timeout`, floored 1s/subnet); a per-subnet failure logs and continues (recorded in `failed_ranges`); only a wholesale failure errors out.
- **macOS CI scope (SHOULD-FIX) - deliberate, as in #348.** `scan_target` is platform-invariant pure logic and runs in the required Linux `--workspace` lane; not bloating the macOS lane.
- **Empty-subnet warning suppression (LOW):** by design - with no known subnets there's no basis to judge out-of-subnet, so no false warning is emitted.

## Test plan

- [x] `cargo test -p pentest-tools -p pentest-platform --lib` green (354 + 58)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Mutation-verified resolver + containment guards (3 mutants red)
- [x] Multi-target CLI acceptance verified empirically
- [ ] CI green on the required Linux lane
- [ ] Rebased onto `main` after #348 merges