### PR TITLE
fix(port_scan): infer host-level reachability from an all-timeout scan (#337)

### DIFF
--- a/crates/platform/src/common.rs
+++ b/crates/platform/src/common.rs
@@ -3,7 +3,9 @@
 //! This module extracts duplicated port-scanning and ARP-parsing code that was
 //! previously copy-pasted across android, desktop, and iOS implementations.
 
-use crate::traits::{port_to_service, ArpEntry, PortState, ScanResult, ScannedPort};
+use crate::traits::{
+    port_to_service, ArpEntry, HostReachability, PortState, ScanResult, ScannedPort,
+};
 use std::io;
 use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
 use std::sync::Arc;
@@ -102,6 +104,8 @@ fn assemble_scan_result(host: String, ports: Vec<ScannedPort>, duration_ms: u64)
         .filter(|p| p.state == PortState::Unreachable)
         .count();
 
+    let reachability = infer_reachability(&ports);
+
     let errors: Vec<String> = ports
         .iter()
         .filter(|p| p.state == PortState::Unreachable)
@@ -125,6 +129,40 @@ fn assemble_scan_result(host: String, ports: Vec<ScannedPort>, duration_ms: u64)
         open_count,
         unreachable_count,
         errors,
+        reachability,
+    }
+}
+
+/// Infer host-level reachability from a single-host scan's port states (#337).
+///
+/// The honest three-way split:
+/// * any `Open` or `Closed` -> [`HostReachability::Reachable`]: the host
+///   answered at least once (a refusal is still an answer), so it is up.
+/// * ports scanned, none reachable-responding, and **every** probe was
+///   `Unreachable` -> [`HostReachability::Unreachable`]: an errno said no packet
+///   reached the target (the #306/#333 case).
+/// * ports scanned, no response of any kind, at least one `Filtered` (timeout)
+///   and no proof of reach -> [`HostReachability::NoResponse`]: down OR silently
+///   firewalled. Deliberately not called "down" (#337 false-positive guard).
+///
+/// An empty port list is [`HostReachability::Reachable`] (nothing was probed, so
+/// there is no basis to claim a reachability problem).
+fn infer_reachability(ports: &[ScannedPort]) -> HostReachability {
+    // A response of any kind (listening OR actively refused) proves the host is up.
+    let got_response = ports
+        .iter()
+        .any(|p| matches!(p.state, PortState::Open | PortState::Closed));
+    if got_response || ports.is_empty() {
+        return HostReachability::Reachable;
+    }
+
+    // No response. If every probe carried an errno-unreachable, the host was
+    // never reached; otherwise (at least one bare timeout) it is the ambiguous
+    // down-or-firewalled case.
+    if ports.iter().all(|p| p.state == PortState::Unreachable) {
+        HostReachability::Unreachable
+    } else {
+        HostReachability::NoResponse
     }
 }
 
@@ -421,5 +459,82 @@ mod tests {
         );
         assert_eq!(result.errors.len(), 1);
         assert!(result.errors[0].contains(":82"), "error names the port");
+    }
+
+    // ---- #337: host-level reachability inference -------------------------
+
+    #[test]
+    fn all_timeout_scan_is_no_response_not_down_or_unreachable() {
+        // The #337 case: a dead-or-firewalled host on a routed network — every
+        // port times out (Filtered), no errno. Must be NoResponse: distinct from
+        // a reachable scan, but NOT asserted as "down" or errno-"unreachable".
+        let ports = vec![
+            port(22, PortState::Filtered),
+            port(80, PortState::Filtered),
+            port(443, PortState::Filtered),
+        ];
+        let result = assemble_scan_result("203.0.113.9".to_string(), ports, 6000);
+
+        assert_eq!(result.reachability, HostReachability::NoResponse);
+        assert_ne!(
+            result.reachability,
+            HostReachability::Unreachable,
+            "a bare timeout is not an errno-unreachable"
+        );
+        assert_eq!(result.open_count, 0);
+        assert_eq!(result.unreachable_count, 0, "timeouts are not unreachable");
+    }
+
+    #[test]
+    fn refused_port_makes_host_reachable_even_with_zero_open() {
+        // A single ConnectionRefused is a response: the host is up, just closed.
+        // Must NOT read as NoResponse.
+        let ports = vec![port(22, PortState::Closed), port(80, PortState::Filtered)];
+        let result = assemble_scan_result("192.0.2.20".to_string(), ports, 2000);
+
+        assert_eq!(result.reachability, HostReachability::Reachable);
+        assert_eq!(
+            result.open_count, 0,
+            "reachable does not require an open port"
+        );
+    }
+
+    #[test]
+    fn open_port_makes_host_reachable() {
+        let ports = vec![port(80, PortState::Open), port(22, PortState::Filtered)];
+        let result = assemble_scan_result("192.0.2.21".to_string(), ports, 100);
+        assert_eq!(result.reachability, HostReachability::Reachable);
+    }
+
+    #[test]
+    fn all_errno_unreachable_scan_is_unreachable_not_no_response() {
+        // Every probe carried an errno-unreachable (#306/#333). This stays
+        // Unreachable — distinct from the all-timeout NoResponse case.
+        let ports = vec![
+            port(22, PortState::Unreachable),
+            port(80, PortState::Unreachable),
+        ];
+        let result = assemble_scan_result("203.0.113.7".to_string(), ports, 5);
+        assert_eq!(result.reachability, HostReachability::Unreachable);
+    }
+
+    #[test]
+    fn mixed_timeout_and_unreachable_with_no_response_is_no_response() {
+        // No response of any kind, but not *every* probe was errno-unreachable
+        // (one bare timeout). We can't claim "no packet reached the target", so
+        // the honest verdict is the ambiguous NoResponse, not Unreachable.
+        let ports = vec![
+            port(22, PortState::Unreachable),
+            port(80, PortState::Filtered),
+        ];
+        let result = assemble_scan_result("203.0.113.8".to_string(), ports, 4000);
+        assert_eq!(result.reachability, HostReachability::NoResponse);
+    }
+
+    #[test]
+    fn empty_port_list_is_reachable_no_basis_to_flag() {
+        // Nothing probed -> no basis to assert a reachability problem.
+        let result = assemble_scan_result("192.0.2.30".to_string(), vec![], 0);
+        assert_eq!(result.reachability, HostReachability::Reachable);
     }
 }

--- a/crates/platform/src/traits.rs
+++ b/crates/platform/src/traits.rs
@@ -212,6 +212,40 @@ pub enum PortState {
     Unreachable,
 }
 
+/// Host-level reachability inferred from a single-host scan's port tally (#337).
+///
+/// Distinct from per-port [`PortState`]: it answers "did the host respond at
+/// all?", which per-port states can't express on their own. The critical
+/// honesty constraint (#337): an all-timeout scan must **not** assert the host
+/// is *down* — a live host behind a default-drop firewall produces the identical
+/// zero-response signature. [`NoResponse`](Self::NoResponse) is that honest
+/// middle state; the operator/agent must not read it as a proven-dead host.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HostReachability {
+    /// At least one probe got a definitive answer from the host (an `Open` or an
+    /// actively-`Closed`/refused port). The host is up and reachable.
+    Reachable,
+    /// Every probe failed with an errno-supplied unreachable (host/network
+    /// unreachable, or sandbox/capability block) — no packet reached the target.
+    /// A scan failure, not a fact about the host (#306).
+    Unreachable,
+    /// At least one port was scanned, nothing was `Unreachable`, and **zero**
+    /// probes got a response — every port timed out (`Filtered`). The host is
+    /// either down or silently dropping all packets; this state deliberately
+    /// does not choose between them (#337). Never present it as "host down".
+    NoResponse,
+}
+
+impl HostReachability {
+    /// Default for an older/persisted [`ScanResult`] that predates this field.
+    /// `Reachable` is the neutral choice — it makes no unreachable/no-response
+    /// claim about legacy data we can't re-derive.
+    fn default_for_deser() -> Self {
+        Self::Reachable
+    }
+}
+
 /// Scanned port result
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScannedPort {
@@ -237,6 +271,13 @@ pub struct ScanResult {
     /// on a fully successful scan; populated so a caller can tell "we checked
     /// and found nothing" apart from "we could not check".
     pub errors: Vec<String>,
+    /// Host-level reachability inferred from the port tally (#337). Lets an
+    /// all-timeout scan of a dead-or-firewalled host ([`HostReachability::NoResponse`])
+    /// be told apart from a reachable host with everything closed
+    /// ([`HostReachability::Reachable`]) — without falsely asserting "down".
+    /// `#[serde(default)]` so a persisted/older result deserializes.
+    #[serde(default = "HostReachability::default_for_deser")]
+    pub reachability: HostReachability,
 }
 
 /// ARP table entry

--- a/crates/tools/src/port_scan.rs
+++ b/crates/tools/src/port_scan.rs
@@ -6,10 +6,33 @@ use pentest_core::tools::{
     execute_timed, ParamType, PentestTool, Platform, ToolContext, ToolParam, ToolResult, ToolSchema,
 };
 use pentest_core::validation::{validate_port_spec, validate_target};
-use pentest_platform::{get_platform, NetworkOps, ScanConfig};
+use pentest_platform::{get_platform, HostReachability, NetworkOps, ScanConfig};
 use serde_json::{json, Value};
 
 use crate::util::{param_str, param_u64};
+
+/// Operator/agent-facing gloss for a host-level reachability verdict (#337).
+///
+/// The `no_response` note is deliberately non-committal: an all-timeout scan
+/// cannot distinguish a down host from a live one behind a default-drop
+/// firewall, so it must not read as "host is down".
+fn host_state_note(reachability: HostReachability) -> &'static str {
+    match reachability {
+        HostReachability::Reachable => {
+            "Host responded to at least one probe (open or refused), so it is up."
+        }
+        HostReachability::Unreachable => {
+            "No probe reached the host (network/host unreachable, or blocked by the \
+             sandbox/capabilities). This is a scan failure, not a finding about the host."
+        }
+        HostReachability::NoResponse => {
+            "Every probe timed out with no response. Two causes are indistinguishable \
+             from a TCP-connect scan: an offline host, or a live host silently dropping \
+             all packets (default-drop firewall). Do NOT record this host as offline on \
+             this evidence alone; if liveness matters, confirm with a separate probe."
+        }
+    }
+}
 
 /// Port scanning tool
 pub struct PortScanTool;
@@ -117,8 +140,43 @@ impl PentestTool for PortScanTool {
                 "errors": result.errors,
                 "total_scanned": result.ports.len(),
                 "duration_ms": result.duration_ms,
+                // Host-level reachability (#337): "reachable" (got a response),
+                // "unreachable" (errno no-route), or "no_response" (every probe
+                // timed out -> down OR silently firewalled). See host_state_note.
+                "reachability": result.reachability,
+                "host_state_note": host_state_note(result.reachability),
             }))
         })
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_response_note_never_asserts_host_is_down() {
+        // #337 honesty guard: the all-timeout verdict must NOT tell the operator
+        // the host is down (a live firewalled host is indistinguishable). It must
+        // name both possibilities and point at a separate liveness check.
+        let note = host_state_note(HostReachability::NoResponse);
+        // Must not hand the caller a ready-made "host is down"/"offline" verdict.
+        assert!(!note.to_lowercase().contains("host is down"));
+        assert!(!note.to_lowercase().contains("host is offline"));
+        // Must name the firewall alternative and flag the ambiguity + a caveat.
+        assert!(note.contains("firewall"));
+        assert!(note.contains("indistinguishable"));
+        assert!(note.contains("Do NOT record"));
+    }
+
+    #[test]
+    fn reachable_and_unreachable_notes_are_distinct_and_correct() {
+        let reachable = host_state_note(HostReachability::Reachable);
+        let unreachable = host_state_note(HostReachability::Unreachable);
+        assert!(reachable.contains("up"));
+        assert!(unreachable.contains("scan failure"));
+        assert_ne!(reachable, unreachable);
+        assert_ne!(reachable, host_state_note(HostReachability::NoResponse));
     }
 }


### PR DESCRIPTION
Closes #337. Follow-up to #306/#333.

## Summary

- #306/#333 made an **errno-supplied** unreachable (`HostUnreachable`/`NetworkUnreachable`/`PermissionDenied`) distinct from a closed port, but explicitly scoped out the most common real case: a **dead IPv4 host on a routed network**, where `connect_timeout` times out before the OS emits an errno — so every port classifies `Filtered` and an all-timeout scan of a down host is indistinguishable from a scan of a live-but-silently-firewalled host.
- Adds a host-level `HostReachability { Reachable, Unreachable, NoResponse }`, computed in `assemble_scan_result` and surfaced in the `port_scan` tool JSON as `reachability` + a plain-language `host_state_note`:
  - **Reachable** — ≥1 `Open` or `Closed` (a refusal is still a response → host is up).
  - **Unreachable** — every probe was errno-`Unreachable` (the #306/#333 case).
  - **NoResponse** — ports scanned, zero responses, ≥1 bare timeout.
- **Honesty constraint (the crux of #337):** `NoResponse` is deliberately **not** "host down". A live host behind a default-drop firewall produces the identical zero-response signature, so both the enum docs and `host_state_note` name both possibilities and steer to a separate liveness probe rather than asserting the host is offline.

## Blast radius

`ScanResult` gains one field, constructed in exactly one place (`assemble_scan_result`); its only consumer is the `port_scan` tool JSON. `#[serde(default)]` keeps older/persisted results deserializable.

## Test plan

- [x] `cargo fmt --all --check` clean
- [x] `cargo clippy --workspace --features pentest-platform/desktop-pcap -- -D warnings` clean
- [x] `cargo test --workspace --features pentest-platform/desktop-pcap` — platform 64/0, tools 349/0
- [x] Regression test for the all-timeout-on-routed-network case (`all_timeout_scan_is_no_response_not_down_or_unreachable`)
- [x] Adversarial port-state mixes covered: all-Filtered, Filtered+Unreachable, single Filtered, empty, Open+Unreachable, Closed-only
- [x] Guard-checked by mutation: neutering `infer_reachability` reddens the reachability tests; injecting an "offline" verdict into `host_state_note` reddens the honesty test
- [ ] Live headless run confirming the JSON `reachability`/`host_state_note` on a real down host (not run — needs a live target)

## Notes for reviewers

- CI scope: `common.rs` reachability tests run on both the Linux (`--workspace`) and macOS (package-scoped `pentest-platform`) lanes; the `port_scan.rs` `host_state_note` tests run on the Linux lane (tools crate not in the macOS lane) — standard for this repo.
- This closes the bug *class* the follow-up targeted; no sibling scan path has the same all-timeout blindness.