### PR TITLE
docs: scrub operator-specific local paths and device serial

### DIFF
--- a/apps/desktop/examples/EGUI_GRAPH_POC_RESULTS.md
+++ b/apps/desktop/examples/EGUI_GRAPH_POC_RESULTS.md
@@ -78,7 +78,7 @@ petgraph = "0.8"  # Graph data structure (upgraded from 0.6)
 ## Run the POC
 
 ```bash
-cd /home/jtomek/Code/pick
+cd <repo-root>
 RUSTUP_TOOLCHAIN= cargo run --example egui_graph_poc
 ```
 

--- a/docs/ANDROID_DEPLOYMENT_TEST_RESULTS.md
+++ b/docs/ANDROID_DEPLOYMENT_TEST_RESULTS.md
@@ -16,7 +16,7 @@
 **Status**: PASSED
 
 Verified integration:
-- Symlink created: `target/dx/pentest-mobile/debug/android/app/android-lib` → `/home/jtomek/Code/pick/android-lib`
+- Symlink created: `target/dx/pentest-mobile/debug/android/app/android-lib` → `<repo>/android-lib`
 - Entry in `settings.gradle`: `include ':android-lib'`
 - Dependency in `app/build.gradle.kts`: `implementation(project(":android-lib"))`
 - Gradle build succeeded with android-lib bundled
@@ -49,7 +49,7 @@ just run-android
 ADB verification:
 ```bash
 adb devices -l
-# 56180DLCH000AV         device usb:3-1.1.1 product:blazer model:Pixel_10_Pro device:blazer
+# <device-serial>         device usb:3-1.1.1 product:blazer model:Pixel_10_Pro device:blazer
 ```
 
 Package verification:


### PR DESCRIPTION
## Summary

- Replace an operator's absolute path (`/home/jtomek/Code/pick`) and a physical Android device serial with generic placeholders in two tracked docs. Neither value is meaningful to a reader, and both violate the repo's no-local-path / no-PII documentation policy.
- `docs/ANDROID_DEPLOYMENT_TEST_RESULTS.md`: path → `<repo>`, serial → `<device-serial>`
- `apps/desktop/examples/EGUI_GRAPH_POC_RESULTS.md`: path → `<repo-root>`

## Scope

- **HEAD only.** The same strings remain in git history; a history rewrite is a separate decision and is intentionally not part of this PR.
- Other `/home/jtomek` mentions were left alone on purpose: they live in planning docs being frozen by the separate docs-archive PR (#355), and in `CLAUDE.md`'s legitimate config-inherit pointer.
- The `jt-demo-01.strike48.engineering` / `non-prod` values in `RUNNING.md` are a sanctioned test env (maintainer decision, same basis as disco-ball) and are deliberately not touched here.

## Test plan

- [x] `git grep /home/jtomek` returns nothing outside archive-bound docs and CLAUDE.md
- [x] `git grep 56180DLCH000AV` returns nothing
- [x] No functional/code files changed; docs only