### PR TITLE
fix(deps): bump webbrowser to 1.2.4 (RUSTSEC-2026-0257)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10156,15 +10156,15 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.0"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe985f41e291eecef5e5c0770a18d28390addb03331c043964d9e916453d6f16"
+checksum = "62c35be770821a214dbc362fc26908c853e776c0004294d0b10b8a6bad582f94"
 dependencies = [
- "core-foundation 0.10.1",
  "jni 0.22.4",
  "log",
  "ndk-context",
  "objc2 0.6.4",
+ "objc2-app-kit 0.3.2",
  "objc2-foundation 0.3.2",
  "url",
  "web-sys",


### PR DESCRIPTION
## Summary
- Bumps `webbrowser` 1.2.0 -> **1.2.4** to resolve **RUSTSEC-2026-0257** ("Unix `BROWSER` handling allows browser argument injection"), fixed in >=1.2.2.
- **Pins 1.2.4 rather than the advisory floor 1.2.2.** 1.2.2 introduced a regression ([upstream #120](https://github.com/amodm/webbrowser-rs/issues/120)) that appends the URL twice when `$BROWSER` is set without a `%s` placeholder — the same Unix code path this fix hardens. 1.2.4 fixes that (plus #121 and the 1.2.3 Windows UNC path fix), and its dependency set is **identical to 1.2.2's**, so the lock change stays surgical. Its trigger (`BROWSER` without `%s`) is disjoint from the advisory's precondition (`BROWSER` with `%s`), so this is not a security regression — just avoids shipping a known UX regression on the same path we're touching.
- `webbrowser` is transitive via `dioxus-desktop 0.7.3` -> `dioxus 0.7.3`; nothing in the workspace depends on it directly.
- Minimal 3-line lockfile change: version, checksum, and webbrowser's own dependency swap (`core-foundation` -> `objc2-app-kit 0.3.2`, already present in the lock). Kept deliberately surgical: a plain `cargo update -p webbrowser` also **de-unifies** ~8 unrelated `windows-sys` entries (main's lock unifies them at 0.61.2) plus a `prost-build` `heck 0.5.0 -> 0.4.1` downgrade, but that churn is not entailed by this fix, so it is excluded.

## Why now
`cargo-audit` queries the live RustSec advisory DB, so once RUSTSEC-2026-0257 was published the **Dependency Audit** check began failing on `main` and on every open PR against an otherwise-unchanged `Cargo.lock`. This unblocks that check repo-wide (e.g. #357 hit it despite touching zero Rust/lock files).

## Test plan
- [x] `cargo metadata --locked` passes (lock is a valid fixpoint, no re-resolution needed; CI builds with `--locked`)
- [x] `cargo audit` exits 0 locally (RUSTSEC-2026-0257 cleared; only pre-existing non-failing unmaintained/unsound warnings remain)
- [x] `cargo check --workspace --locked --features pentest-platform/desktop-pcap` exits 0 (webbrowser 1.2.4 compiles; only the pre-existing `screenshots` future-incompat warning)
- [ ] CI green (Dependency Audit + Linux/macOS build lanes)
