### PR TITLE
docs(audit): correct stale quick-xml unblock condition in audit.toml

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -15,15 +15,27 @@
 [advisories]
 ignore = [
     # quick-xml <0.41.0 — memory-exhaustion / quadratic-runtime DoS in NsReader.
-    # Pulled transitively (and only in XML parse paths we do not drive with
-    # untrusted network input) via:
-    #   - screenshots 0.8.10 -> wayland-scanner/xcb/display-info (quick-xml 0.28/0.30)
-    #   - syntect 5.3.0 -> plist (quick-xml 0.38)
-    #   - winit 0.30 -> wayland-scanner 0.31 (quick-xml 0.39)
-    # All four callers pin quick-xml to caret ranges (^0.28, ^0.30, ^0.38,
-    # ^0.39) that cannot resolve to the patched >=0.41.0. Remove these once
-    # screenshots, syntect, and winit/wayland-scanner ship releases that bump
-    # quick-xml past 0.41.0.
+    # Pulled transitively, and only in XML parse paths we do not drive with
+    # untrusted network input.
+    #
+    # Only ONE path genuinely forces these ignores to stay:
+    #   - screenshots 0.8.10 -> libwayshot 0.2.0 -> wayland-client 0.30.2
+    #       -> wayland-scanner 0.30.1 -> quick-xml 0.28.2
+    #     wayland-client 0.30.2 requires wayland-scanner ^0.30, so it cannot
+    #     reach wayland-scanner 0.31.11 (which moved to quick-xml ^0.41). The
+    #     whole stack is pinned by screenshots 0.8.10.
+    #
+    # The other paths the old comment named are ALREADY reachable today — the
+    # quick-xml fix landed in the intermediate crates, not the leaf ones — and
+    # can be cleared by an ordinary lock update without waiting on anyone:
+    #   - syntect 5.3.0 -> plist -> quick-xml: plist 1.10.0 moves to
+    #     quick-xml ^0.41 and satisfies syntect's `plist ^1.3` requirement.
+    #   - wayland-scanner 0.31.11 -> quick-xml ^0.41.
+    #   - xcb 1.7.1 -> quick-xml ^0.41 (build dep).
+    #
+    # Keep both ignores until the screenshots path above is unblocked (a
+    # screenshots release on a newer libwayshot/wayland stack); one live path
+    # still resolves quick-xml <0.41 regardless of the reachable paths.
     "RUSTSEC-2026-0194", # quadratic runtime checking start tags for duplicate attrs
     "RUSTSEC-2026-0195", # unbounded namespace-declaration allocation
 ]


### PR DESCRIPTION
## Summary
- Corrects the stale/misleading comment on the `quick-xml` (RUSTSEC-2026-0194/0195) ignores in `.cargo/audit.toml`. Flagged by @cchao-devo in the #363 review.
- The old comment implied all four transitive paths wait on `screenshots`/`syntect`/`winit`+`wayland-scanner` leaf releases. In fact the `quick-xml >=0.41` fix already landed in the **intermediate** crates, so 3 of the 4 paths are semver-reachable today; only the `screenshots` path is genuinely blocked.
- **Comment-only.** Both ignore entries stay (one live path still resolves `quick-xml <0.41`); the ignore list and `cargo-audit` behavior are unchanged.

## Verified (crates.io + local `cargo tree`)
- Genuinely blocked: `screenshots 0.8.10 → libwayshot 0.2.0 → wayland-client 0.30.2 → wayland-scanner 0.30.1 → quick-xml 0.28.2` — `wayland-client 0.30.2` requires `wayland-scanner ^0.30`, so it can't reach `wayland-scanner 0.31.11`.
- Reachable today: `plist 1.10.0` → `quick-xml ^0.41.0` (and satisfies `syntect 5.3.0`'s `plist ^1.3`); `wayland-scanner 0.31.11` → `quick-xml ^0.41`; `xcb 1.7.1` → `quick-xml ^0.41` (build dep).
- `cargo audit` still parses `audit.toml` and keeps RUSTSEC-2026-0194/0195 suppressed.

Closes #364.

## Test plan
- [x] `cargo audit` parses `.cargo/audit.toml`; quick-xml advisories remain ignored (comment-only change).
- [x] Rebased onto `main` after #363 merged, so the base carries the webbrowser (RUSTSEC-2026-0257) fix — Dependency Audit is expected clean here.
- [ ] CI green.
