### PR TITLE
ci: use official gitleaks-action instead of manual binary download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,18 +96,14 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - name: Install gitleaks
+      - uses: gitleaks/gitleaks-action@v3
         env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # `gh api` gives us a proper JSON parse via --jq so we don't have to
-          # regex our way through GitHub's compact JSON, which used to catch
-          # the whole `"tag_name":"v8.30.1","draft":...` blob and produce a
-          # malformed download URL.
-          GITLEAKS_VERSION=$(gh api repos/gitleaks/gitleaks/releases/latest --jq '.tag_name' | sed 's/^v//')
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar xz
-          sudo mv gitleaks /usr/local/bin/
-      - run: gitleaks detect --source . --verbose
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Free for org-owned repos, but a key must be requested at
+          # https://gitleaks.io and stored as the GITLEAKS_LICENSE secret.
+          # Personal accounts do not need it; organizations do, or the action
+          # fails. The action auto-loads the repo's .gitleaks.toml.
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
   cargo-audit:
     name: Dependency Audit


### PR DESCRIPTION
## Summary
- Replaces the hand-rolled Gitleaks install (`gh api releases/latest` + `curl | tar` + `gitleaks detect`) with the official **`gitleaks/gitleaks-action@v3`**.
- Motivation: the manual download failed intermittently on a transient network error (`curl: (56) Connection died, tried 5 times`) and blocked PRs on a step that never reached scanning. The action handles fetching/caching and is maintained upstream.
- **Scan rules unchanged:** the action auto-loads the repo's `.gitleaks.toml` (the test-JWT allowlist) from the checked-out root, same as the old CLI invocation. `fetch-depth: 0` is retained.

## ⚠️ Required before this can pass: add a `GITLEAKS_LICENSE` secret
`gitleaks-action` is free but requires a **free** license key for **organization-owned** repos (this one). Personal accounts don't need it.

1. Request a key at **https://gitleaks.io** (form → emailed key).
2. Add it as an Actions secret named **`GITLEAKS_LICENSE`** (repo: Settings → Secrets and variables → Actions → New repository secret; or org-level so other repos inherit it).
3. Re-run the Gitleaks check on this PR.

Until the secret exists, **the Gitleaks check on this PR will fail** with a license error — that's expected, not a regression. This is the chicken-and-egg we discussed: the workflow change has to land (or at least the secret has to exist) before the check goes green.

## Behavior notes (honest deltas)
- **Scan scope:** the action scans the commits in the push/PR event; the old step ran `gitleaks detect` over full history on every run. Our triggers are `push: [main]` + `pull_request: [main]` (no schedule), so new commits are still scanned on every PR and every push to `main`. If you want periodic full-history sweeps, add a `schedule` trigger later (separate change).
- **Permissions:** left at the workflow's existing least-privilege `contents: read`. The action posts a PR comment only if it has `pull-requests: write`; without it, it still scans and fails-on-leak, just doesn't comment. Add `pull-requests: write` to this job later if you want inline PR annotations.
- Not pinned to a commit SHA — matches the repo's existing tag-pinning convention (`actions/checkout@v5`, `dtolnay/rust-toolchain@stable`). Say the word if you'd prefer SHA-pinning for the third-party action.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — workflow parses; `gitleaks` job = `checkout@v5` → `gitleaks-action@v3`.
- [ ] `GITLEAKS_LICENSE` secret added, then Gitleaks check green.
