### PR TITLE
ci: harden gitleaks binary download (pin version + retry)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,15 +97,20 @@ jobs:
         with:
           fetch-depth: 0
       - name: Install gitleaks
-        env:
-          GH_TOKEN: ${{ github.token }}
         run: |
-          # `gh api` gives us a proper JSON parse via --jq so we don't have to
-          # regex our way through GitHub's compact JSON, which used to catch
-          # the whole `"tag_name":"v8.30.1","draft":...` blob and produce a
-          # malformed download URL.
-          GITLEAKS_VERSION=$(gh api repos/gitleaks/gitleaks/releases/latest --jq '.tag_name' | sed 's/^v//')
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar xz
+          # Pinned instead of resolved from releases/latest at run time: that
+          # extra API call was a failure point, and an unpinned tool version is
+          # non-reproducible. Bump deliberately.
+          GITLEAKS_VERSION=8.30.1
+          # --retry with backoff + --retry-all-errors survives the transient
+          # "curl: (56) Connection died" that flaked this step before. Download
+          # to a file (not | tar) so a partial transfer fails the retry rather
+          # than corrupting the extract.
+          curl --fail --show-error --location \
+            --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30 \
+            -o gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          tar -xzf gitleaks.tar.gz gitleaks
           sudo mv gitleaks /usr/local/bin/
       - run: gitleaks detect --source . --verbose
 


### PR DESCRIPTION
## Summary
Fixes the flaky **Gitleaks** check without changing the scanner or adding any secret.

The job resolved gitleaks from `releases/latest` at run time and piped `curl … | tar`, which failed intermittently on a transient network error (`curl: (56) Connection died, tried 5 times`) — blocking PRs on a step that never reached scanning.

- **Pin `GITLEAKS_VERSION=8.30.1`** — reproducible, and removes the extra `releases/latest` API call that was a second network dependency.
- **Retry-hardened `curl`** — `--retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30`, downloading to a file instead of piping to `tar`, so a partial transfer is retried rather than corrupting the extract.

## Why not the official `gitleaks-action`
The official action **requires a `GITLEAKS_LICENSE` key for organization-owned repos** (free, but must be requested at gitleaks.io and stored as a secret). We don't have one, and without it the action hard-fails before scanning — so the license-free CLI approach stays. Supersedes #368 (which switched to the action).

## Behavior preserved
- Scan rules unchanged — `.gitleaks.toml` (the test-JWT allowlist) is still auto-loaded by `gitleaks detect --source .`.
- Same full-tree/history scan on every push and PR; `fetch-depth: 0` retained.

## Optional further hardening (not in this PR)
Could add SHA-256 checksum verification of the downloaded tarball (gitleaks publishes `*_checksums.txt`) for supply-chain integrity — happy to add if wanted.

## Test plan
- [x] `python3` YAML parse — workflow valid; `gitleaks` job = `checkout@v5` → install (pinned + retry) → `gitleaks detect`.
- [ ] CI green (this PR's own Gitleaks run exercises the new install path).
