### PR TITLE
fix(ui): refresh sidebar chat history when conversations change

### DIFF
--- a/crates/ui/src/components/app_layout.rs
+++ b/crates/ui/src/components/app_layout.rs
@@ -8,6 +8,19 @@ use super::pane_boundary::PaneBoundary;
 use super::sidebar::{NavPage, Sidebar};
 use super::status_bar::StatusBar;
 
+/// Shared "conversations changed" trigger, distributed via Dioxus context.
+///
+/// The chat panel bumps this whenever it creates a conversation or an agent
+/// reply lands (which moves a conversation's `updated_at`). The sidebar's
+/// recent-conversations effect subscribes to it so the list re-fetches instead
+/// of staying frozen at its initial post-connect load. The wrapped value is an
+/// opaque monotonically-increasing counter — only its *change* matters.
+///
+/// `Signal` is `Copy`, so this newtype is `Copy` too and can be moved into the
+/// spawned tasks that perform the bump.
+#[derive(Clone, Copy)]
+pub struct ConversationRefresh(pub Signal<u64>);
+
 /// Shared layout wrapper used by all three apps.
 ///
 /// The desktop-header serves as the universal page header on both desktop and
@@ -36,6 +49,11 @@ pub fn AppLayout(
     // header actions. ChatPanel writes Some(ChatHeaderCtx) when mounted in
     // full-page mode; we render those actions in the desktop header bar.
     let chat_header_ctx: Signal<Option<ChatHeaderCtx>> = use_context_provider(|| Signal::new(None));
+
+    // Provide the shared conversation-refresh trigger. ChatPanel (a descendant
+    // via `children`) bumps it; Sidebar (a direct child) reads it to re-fetch
+    // its recent-conversations list. See [`ConversationRefresh`].
+    use_context_provider(|| ConversationRefresh(Signal::new(0u64)));
 
     let on_close = move |_: ()| {
         sidebar_open.set(false);

--- a/crates/ui/src/components/chat_panel/mod.rs
+++ b/crates/ui/src/components/chat_panel/mod.rs
@@ -21,6 +21,7 @@ use pentest_core::terminal::TerminalLine;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use super::app_layout::ConversationRefresh;
 use super::button::{Button, ButtonSize, ButtonVariant};
 use agent_selector::ChatHeader;
 pub use agent_selector::{ChatHeaderActions, ChatHeaderCtx};
@@ -28,7 +29,7 @@ use constants::*;
 use history::HistoryDropdown;
 use input::ChatInput;
 use messages::MessageList;
-use polling::{poll_and_update, ChatNoticeKind};
+use polling::{notify_conversations_changed, poll_and_update, ChatNoticeKind};
 pub use render::format_relative_time;
 use render::{CHART_PROCESSOR_JS, UTILS_JS};
 
@@ -187,6 +188,11 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
     // Context signal for sharing chat header actions with AppLayout (full-page mode).
     // AppLayout provides this via use_context_provider; ChatPanel writes when full_page.
     let mut chat_header_ctx: Signal<Option<ChatHeaderCtx>> = use_context();
+
+    // Shared sidebar-refresh trigger (provided by AppLayout). We bump it when a
+    // conversation is created or a turn completes so the sidebar's recent-
+    // conversations list re-fetches instead of staying frozen at its initial load.
+    let refresh_convos = use_context::<ConversationRefresh>().0;
 
     // Reset closing when panel becomes visible again
     if props.visible && closing() {
@@ -558,6 +564,7 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
                                         agent_status_text,
                                         error_msg,
                                         chat_notice,
+                                        refresh_convos,
                                     )
                                     .await;
                                 }
@@ -628,6 +635,8 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
                             agent_conversations
                                 .write()
                                 .insert(agent.id.clone(), id.clone());
+                            // New conversation exists — refresh the sidebar list.
+                            notify_conversations_changed(refresh_convos);
                             id
                         }
                         Err(e) => {
@@ -671,6 +680,7 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
                             agent_status_text,
                             error_msg,
                             chat_notice,
+                            refresh_convos,
                         )
                         .await;
                     }
@@ -729,6 +739,7 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
                                     agent_status_text,
                                     error_msg,
                                     chat_notice,
+                                    refresh_convos,
                                 )
                                 .await;
                             }
@@ -912,6 +923,8 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
                         agent_conversations
                             .write()
                             .insert(validator_agent.id.clone(), id.clone());
+                        // New conversation exists — refresh the sidebar list.
+                        notify_conversations_changed(refresh_convos);
                         id
                     }
                     Err(e) => {
@@ -952,6 +965,7 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
                             agent_status_text,
                             error_msg,
                             chat_notice,
+                            refresh_convos,
                         )
                         .await;
 
@@ -1056,6 +1070,8 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
                         agent_conversations
                             .write()
                             .insert(report_agent.id.clone(), id.clone());
+                        // New conversation exists — refresh the sidebar list.
+                        notify_conversations_changed(refresh_convos);
                         id
                     }
                     Err(e) => {
@@ -1089,6 +1105,7 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
                             agent_status_text,
                             error_msg,
                             chat_notice,
+                            refresh_convos,
                         )
                         .await;
                     }
@@ -1131,6 +1148,7 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
                                 agent_status_text,
                                 error_msg,
                                 chat_notice,
+                                refresh_convos,
                             )
                             .await;
                         }

--- a/crates/ui/src/components/chat_panel/polling.rs
+++ b/crates/ui/src/components/chat_panel/polling.rs
@@ -77,7 +77,20 @@ fn strip_port_suffix(rest: &str, port_suffix: &str) -> Option<String> {
     Some(format!("{}{}", stripped_host, path_part))
 }
 
+/// Bump the shared conversation-refresh trigger so the sidebar re-fetches its
+/// recent-conversations list. `Signal` is `Copy`, so callers pass it by value
+/// (including from inside spawned tasks). Only the *change* matters, so we
+/// wrap on overflow rather than saturate.
+pub(super) fn notify_conversations_changed(mut trigger: Signal<u64>) {
+    trigger.with_mut(|n| *n = n.wrapping_add(1));
+}
+
 /// Poll a conversation until the agent finishes, updating signals along the way.
+///
+/// `conversations_refresh` is the shared sidebar-refresh trigger; it is bumped
+/// once whenever a turn reaches a terminal state (reply landed or errored),
+/// since that moves the conversation's `updated_at`. Centralising the bump here
+/// covers every caller instead of every poll call-site having to remember.
 #[allow(clippy::too_many_arguments)]
 pub async fn poll_and_update(
     client: Arc<MatrixChatClient>,
@@ -88,6 +101,7 @@ pub async fn poll_and_update(
     mut agent_status_text: Signal<String>,
     mut error_msg: Signal<Option<String>>,
     mut chat_notice: Signal<Option<ChatNotice>>,
+    conversations_refresh: Signal<u64>,
 ) {
     /// Check if the UI is currently showing this conversation.
     fn is_active(active: &Signal<Option<String>>, conv_id: &str) -> bool {
@@ -177,16 +191,19 @@ pub async fn poll_and_update(
                         chat_notice.set(Some(notice));
                         agent_thinking.set(false);
                         agent_status_text.set(String::new());
+                        notify_conversations_changed(conversations_refresh);
                         return;
                     }
 
                     if done && has_agent_msg {
                         agent_thinking.set(false);
                         agent_status_text.set(String::new());
+                        notify_conversations_changed(conversations_refresh);
                         return;
                     }
                 } else if saw_error || (done && has_agent_msg) {
                     // Conversation finished (success or error) while user was viewing another one.
+                    notify_conversations_changed(conversations_refresh);
                     return;
                 }
             }

--- a/crates/ui/src/components/sidebar.rs
+++ b/crates/ui/src/components/sidebar.rs
@@ -4,6 +4,7 @@ use dioxus::prelude::*;
 use pentest_core::matrix::{ChatClient, ConversationInfo, MatrixChatClient};
 use std::sync::Arc;
 
+use super::app_layout::ConversationRefresh;
 use super::chat_panel::format_relative_time;
 use super::icons::{
     Bolt, FileText, Folder, House, MessageSquare, ScrollText, Settings, Terminal, Wrench,
@@ -109,7 +110,17 @@ pub fn Sidebar(
 
     let mut recent_convos: Signal<Vec<ConversationInfo>> = use_signal(Vec::new);
 
+    // Shared trigger bumped by the chat panel when conversations change. Reading
+    // it inside the effect subscribes us, so a bump re-runs the fetch below —
+    // without it, this list would load once and never update (the api_url/token
+    // deps are stable for the whole session).
+    let convo_refresh = use_context::<ConversationRefresh>();
+
     use_effect(move || {
+        // Subscribe to the refresh trigger. Read it first, before the early
+        // return, so the subscription is always registered even while we're
+        // still waiting on credentials.
+        let _refresh_tick = convo_refresh.0();
         let url = sig_api_url.read().clone();
         let token = sig_auth_token.read().clone();
         if url.is_empty() || token.is_empty() {


### PR DESCRIPTION
## Summary
- The left sidebar's recent-conversations list loaded once at connect and never refreshed. Its fetch `use_effect` (`sidebar.rs`) depended only on `api_url`/`auth_token` — both stable for the whole session — and the fetch runs inside a `spawn`, whose reads don't subscribe the effect. New conversations and `updated_at` bumps never appeared until a reload, while the chat panel's own (disjoint) history dropdown updated normally, so the sidebar looked stuck.
- Added a shared `ConversationRefresh(Signal<u64>)` trigger provided by `AppLayout` — the common ancestor of both `Sidebar` and `ChatPanel` in both app roots. `ChatPanel` bumps it on each `create_conversation` success (new conversation appears immediately) and at turn completion inside `poll_and_update` (one choke point covering all six poll call-sites, so replies/`updated_at` bumps reorder the list). `Sidebar`'s fetch effect reads the trigger, so a bump re-runs the fetch and the list stays current. No self-retrigger: the effect never reads `recent_convos`.

## Test plan
- [x] `cargo check --workspace --locked --features pentest-platform/desktop-pcap` — clean
- [x] `cargo clippy --workspace --locked --features pentest-platform/desktop-pcap -- -D warnings` — clean
- [x] `pentest-ui` unit tests — 95 passed / 0 failed
- [ ] Manual: send a message / receive an agent reply and confirm the sidebar list updates (new conversation appears, ordering/timestamp refresh) without a page reload. This is Dioxus reactive wiring with no behavioural logic to unit-test, and the crate has no render-test harness, so a component-level test is intentionally omitted rather than added as a tautology.