### PR TITLE
fix(security): close chart post-processor XSS + pin CDN deps with SRI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,19 @@ jobs:
       # failure still fails the job.
       - run: cargo test --workspace --locked --no-fail-fast --features pentest-platform/desktop-pcap
 
+  chart-xss-guard:
+    name: Chart XSS Guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      # Behavioral regression guard for the chart_processor.js ECharts option
+      # sanitizer (#371). No JS toolchain otherwise exists here; this is a
+      # dependency-free `node` self-test, so it needs no install step.
+      - run: node crates/ui/src/assets/chart_processor.test.js
+
   check-macos:
     name: Check (macOS)
     runs-on: macos-latest

--- a/crates/ui/src/assets/chart_processor.js
+++ b/crates/ui/src/assets/chart_processor.js
@@ -2,23 +2,81 @@
     if (window.__chatChartsInit) return;
     window.__chatChartsInit = true;
 
+    // CDN dependencies. Pinned to exact versions with Subresource Integrity so a
+    // compromised or swapped CDN artifact fails closed instead of executing in the
+    // app origin (#367 review, finding #5). Bump the version AND the integrity hash
+    // together — recompute with:
+    //   curl -sS <url> | openssl dgst -sha384 -binary | openssl base64 -A
+    var MERMAID_SRC = 'https://cdn.jsdelivr.net/npm/mermaid@11.16.1/dist/mermaid.min.js';
+    var MERMAID_SRI = 'sha384-aBQXj4hK6Jm05i7aQAsUV3bLdSUrHX1BGYfMB0166TtWt/RRaw+h0Eelme9OCOvy';
+    var ECHARTS_SRC = 'https://cdn.jsdelivr.net/npm/echarts@5.6.0/dist/echarts.min.js';
+    var ECHARTS_SRI = 'sha384-pPi0zxBAoDu6+JXW/C68UZLvBUUtU+7zonhif43rqj7pxsGyqyqzcian2Rj37Rss';
+
+    // Load a CDN script with SRI. crossOrigin is required for the browser to
+    // verify integrity on a cross-origin resource.
+    function loadScript(src, integrity, onload) {
+        var s = document.createElement('script');
+        s.src = src;
+        s.integrity = integrity;
+        s.crossOrigin = 'anonymous';
+        s.onload = onload;
+        s.onerror = function() {
+            console.error('[PentestConnector] failed to load (SRI or network): ' + src);
+        };
+        document.head.appendChild(s);
+    }
+
+    // Render an error message as TEXT, never HTML. mermaid/jison errors and JSON
+    // parse errors embed a snippet of the offending (untrusted) input, so building
+    // this via innerHTML was a stored-XSS sink (#367 review, finding #2).
+    function showVizError(container, message) {
+        container.textContent = '';
+        var err = document.createElement('div');
+        err.style.cssText = 'color:#f38ba8;font-size:0.75rem;';
+        err.textContent = message;
+        container.appendChild(err);
+    }
+
+    // ECharts renders a `formatter` (e.g. tooltip.formatter) as raw HTML, so
+    // untrusted chart JSON like {"tooltip":{"formatter":"<img src=x onerror=...>"}}
+    // is XSS on hover. Drop every `formatter` regardless of type — a string, or an
+    // array of strings (valid multi-series syntax) — since untrusted content has no
+    // business supplying one; charts still render with the default, escaped tooltip
+    // content. Also force any renderMode to the non-HTML 'richText' engine
+    // (#367 review, finding #2). Note: the confirmed HTML sink is the tooltip
+    // formatter; ECharts 5.6.0 has no `type:'html'` graphic element (verified
+    // against the bundle: every "html" literal is the tooltip renderMode).
+    function stripHtmlSinks(node) {
+        if (Array.isArray(node)) {
+            for (var i = 0; i < node.length; i++) stripHtmlSinks(node[i]);
+        } else if (node && typeof node === 'object') {
+            Object.keys(node).forEach(function(key) {
+                if (key === 'formatter') {
+                    delete node[key];
+                } else if (key === 'renderMode') {
+                    node[key] = 'richText';
+                } else {
+                    stripHtmlSinks(node[key]);
+                }
+            });
+        }
+    }
+
     // Load Mermaid
     if (!window.mermaid) {
-        var ms = document.createElement('script');
-        ms.src = 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js';
-        ms.onload = function() {
-            window.mermaid.initialize({ startOnLoad: false, theme: 'dark' });
+        loadScript(MERMAID_SRC, MERMAID_SRI, function() {
+            // securityLevel:'strict' is the mermaid default; set it explicitly so a
+            // future default change cannot silently disable output sanitization.
+            window.mermaid.initialize({ startOnLoad: false, theme: 'dark', securityLevel: 'strict' });
             console.log('[PentestConnector] Mermaid loaded');
-        };
-        document.head.appendChild(ms);
+        });
     }
 
     // Load ECharts
     if (!window.echarts) {
-        var es = document.createElement('script');
-        es.src = 'https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js';
-        es.onload = function() { console.log('[PentestConnector] ECharts loaded'); };
-        document.head.appendChild(es);
+        loadScript(ECHARTS_SRC, ECHARTS_SRI, function() {
+            console.log('[PentestConnector] ECharts loaded');
+        });
     }
 
     // Chart processor: finds unprocessed code blocks and renders them
@@ -39,14 +97,18 @@
                 div.style.cssText = 'background:rgba(0,0,0,0.3);border-radius:6px;padding:12px;margin:8px 0;overflow:auto;width:100%;box-sizing:border-box;';
                 try {
                     window.mermaid.render(div.id + '-svg', code).then(function(result) {
+                        // result.svg is produced by mermaid in strict mode, which
+                        // sanitizes its output with DOMPurify. This innerHTML sink
+                        // therefore relies on that upstream sanitization; a DOMPurify
+                        // bypass in mermaid would make it a sink (#367 review).
                         div.innerHTML = result.svg;
                         var svg = div.querySelector('svg');
                         if (svg) { svg.style.display='block'; svg.style.width='100%'; svg.style.height='auto'; svg.style.minHeight='80px'; }
                     }).catch(function(err) {
-                        div.innerHTML = '<div style="color:#f38ba8;font-size:0.75rem;">Mermaid error: ' + err.message + '</div>';
+                        showVizError(div, 'Mermaid error: ' + err.message);
                     });
                 } catch(e) {
-                    div.innerHTML = '<div style="color:#f38ba8;font-size:0.75rem;">Mermaid error: ' + e.message + '</div>';
+                    showVizError(div, 'Mermaid error: ' + e.message);
                 }
                 pre.parentNode.replaceChild(div, pre);
             });
@@ -64,6 +126,7 @@
                 div.style.cssText = 'width:100%;min-height:180px;height:220px;background:rgba(0,0,0,0.3);border-radius:6px;margin:8px 0;box-sizing:border-box;';
                 try {
                     var option = JSON.parse(code);
+                    stripHtmlSinks(option);
                     pre.parentNode.replaceChild(div, pre);
                     setTimeout(function() {
                         var chart = window.echarts.init(div, 'dark');
@@ -79,7 +142,7 @@
                 } catch(e) {
                     div.style.height = 'auto';
                     div.style.padding = '8px';
-                    div.innerHTML = '<div style="color:#f38ba8;font-size:0.75rem;">ECharts error: ' + e.message + '</div>';
+                    showVizError(div, 'ECharts error: ' + e.message);
                     pre.parentNode.replaceChild(div, pre);
                 }
             });

--- a/crates/ui/src/assets/chart_processor.js
+++ b/crates/ui/src/assets/chart_processor.js
@@ -42,16 +42,18 @@
     // is XSS on hover. Drop every `formatter` regardless of type — a string, or an
     // array of strings (valid multi-series syntax) — since untrusted content has no
     // business supplying one; charts still render with the default, escaped tooltip
-    // content. Also force any renderMode to the non-HTML 'richText' engine
-    // (#367 review, finding #2). Note: the confirmed HTML sink is the tooltip
-    // formatter; ECharts 5.6.0 has no `type:'html'` graphic element (verified
-    // against the bundle: every "html" literal is the tooltip renderMode).
+    // content. Also drop `extraCssText`: ECharts injects it as raw inline CSS on the
+    // tooltip DOM, so `background-image:url(...)` beacons on hover (#371 review).
+    // And force any renderMode to the non-HTML 'richText' engine (#367 review,
+    // finding #2). Note: the confirmed HTML sink is the tooltip formatter; ECharts
+    // 5.6.0 has no `type:'html'` graphic element (verified against the bundle:
+    // every "html" literal is the tooltip renderMode).
     function stripHtmlSinks(node) {
         if (Array.isArray(node)) {
             for (var i = 0; i < node.length; i++) stripHtmlSinks(node[i]);
         } else if (node && typeof node === 'object') {
             Object.keys(node).forEach(function(key) {
-                if (key === 'formatter') {
+                if (key === 'formatter' || key === 'extraCssText') {
                     delete node[key];
                 } else if (key === 'renderMode') {
                     node[key] = 'richText';
@@ -60,6 +62,16 @@
                 }
             });
         }
+    }
+
+    // Node/test bootstrap: expose the sanitizer to the regression test and skip
+    // the browser wiring below. In the browser there is no CommonJS `module`
+    // (Pick injects this file as a raw <script> via include_str!, no bundler), so
+    // this is a no-op and rendering proceeds normally. Keeps stripHtmlSinks under
+    // test so a future edit that reopens the XSS fails CI (#371 review).
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = { stripHtmlSinks: stripHtmlSinks };
+        return;
     }
 
     // Load Mermaid

--- a/crates/ui/src/assets/chart_processor.test.js
+++ b/crates/ui/src/assets/chart_processor.test.js
@@ -1,0 +1,89 @@
+// Regression guard for the chart_processor.js ECharts option sanitizer (#371).
+//
+// This exercises the REAL stripHtmlSinks shipped in chart_processor.js — not a
+// copy and not a source-grep — so a future edit that breaks the recursion, the
+// `delete`, or the renderMode override turns this test RED. That is the guard
+// the #367/#371 review asked for: the XSS fix must fail loudly if reopened.
+//
+// Run:  node crates/ui/src/assets/chart_processor.test.js
+// The file is an IIFE that reads `window` on its first line; stub it so `require`
+// reaches the CommonJS export shim (which returns before any DOM wiring).
+
+'use strict';
+
+const assert = require('node:assert');
+
+// Minimal stub: chart_processor.js checks `window.__chatChartsInit` before it
+// hits the node export shim. No `document` is needed — the shim returns early.
+global.window = {};
+
+const { stripHtmlSinks } = require('./chart_processor.js');
+
+assert.strictEqual(
+    typeof stripHtmlSinks,
+    'function',
+    'chart_processor.js must export stripHtmlSinks for this guard to run'
+);
+
+let passed = 0;
+function check(name, fn) {
+    fn();
+    passed++;
+    console.log('  ok - ' + name);
+}
+
+// --- formatter is an XSS sink: dropped regardless of shape --------------------
+
+check('string formatter is dropped', () => {
+    const opt = { tooltip: { formatter: '<img src=x onerror=alert(1)>' } };
+    stripHtmlSinks(opt);
+    assert.ok(!('formatter' in opt.tooltip), 'string formatter must be deleted');
+});
+
+check('array formatter is dropped', () => {
+    const opt = { tooltip: { formatter: ['<img src=x onerror=alert(1)>', 'ok'] } };
+    stripHtmlSinks(opt);
+    assert.ok(!('formatter' in opt.tooltip), 'array formatter must be deleted');
+});
+
+check('deeply nested formatter is dropped', () => {
+    const opt = { series: [{ data: [{ tooltip: { formatter: '<script>x</script>' } }] }] };
+    stripHtmlSinks(opt);
+    assert.ok(
+        !('formatter' in opt.series[0].data[0].tooltip),
+        'formatter nested in an array-of-objects must be deleted'
+    );
+});
+
+// --- extraCssText is a CSS-injection / beacon sink: dropped (#371) ------------
+
+check('extraCssText is dropped', () => {
+    const opt = { tooltip: { extraCssText: 'background-image:url(https://evil/beacon)' } };
+    stripHtmlSinks(opt);
+    assert.ok(!('extraCssText' in opt.tooltip), 'extraCssText must be deleted');
+});
+
+// --- renderMode is forced to the non-HTML engine ------------------------------
+
+check("renderMode is forced to 'richText'", () => {
+    const opt = { tooltip: { renderMode: 'html' } };
+    stripHtmlSinks(opt);
+    assert.strictEqual(opt.tooltip.renderMode, 'richText', "renderMode must be forced to 'richText'");
+});
+
+// --- safe fields survive: sanitizer must not gut legitimate charts ------------
+
+check('safe fields (title, data, type) are preserved', () => {
+    const opt = {
+        title: { text: 'Open ports by host' },
+        xAxis: { type: 'category', data: ['10.0.0.1', '10.0.0.2'] },
+        series: [{ type: 'bar', data: [3, 7] }],
+    };
+    stripHtmlSinks(opt);
+    assert.strictEqual(opt.title.text, 'Open ports by host');
+    assert.deepStrictEqual(opt.xAxis.data, ['10.0.0.1', '10.0.0.2']);
+    assert.strictEqual(opt.series[0].type, 'bar');
+    assert.deepStrictEqual(opt.series[0].data, [3, 7]);
+});
+
+console.log('\nchart_processor sanitizer: ' + passed + ' checks passed');


### PR DESCRIPTION
## Summary
- Closes the remaining XSS sinks in the chat chart post-processor (`chart_processor.js`) — the out-of-diff half of the #365 class flagged in the #367 review (finding #2).
- Mermaid/ECharts **error messages now render via `textContent`, not `innerHTML`**. A malformed ` ```mermaid ` / ` ```echarts ` fence embeds the offending (untrusted) input in the error message, which was reaching `innerHTML`.
- **ECharts options are sanitized before `setOption`**: every `formatter` (string *or* array — ECharts renders these as raw HTML in tooltips) is dropped, and any `renderMode` is forced to the non-HTML `richText` engine.
- Mermaid `securityLevel: 'strict'` is now set explicitly, so a future default change can't silently disable its DOMPurify output sanitization.
- **Supply chain (#367 review, finding #5):** mermaid/echarts were loaded from jsdelivr on floating majors (`@11` / `@5`) with no integrity check. Pinned to `11.16.1` / `5.6.0` with Subresource Integrity (sha384) + `crossorigin`, so a swapped CDN artifact fails closed.

## Verification
- `node --check` clean; a behavioral test of the option sanitizer confirms string + array formatters and event-handler payloads are neutralized and `renderMode` is forced, while safe fields (titles, data) are preserved.
- The `graphic type:'html'` vector raised in security review was **verified to be a non-sink** against the pinned `echarts@5.6.0` bundle: there is no such graphic element type (every `"html"` literal is the tooltip `renderMode`; graphic text renders on canvas, not HTML). Documented inline.
- Rust build is unaffected — the file is embedded as a string via `include_str!`.

## Residual (follow-up, out of scope)
- ECharts rendered from untrusted JSON is a broad surface (`title.link` phishing; interactive `toolbox`/`dataView`). Deeper isolation (dropping interactive components, CSP) can be a follow-up.
- Remote `https` images/links are allowed by design and can act as tracking beacons on view (same residual noted on #367).

## Test plan
- [x] `node --check crates/ui/src/assets/chart_processor.js`
- [x] Option-sanitizer behavioral test (formatter string/array, graphic, renderMode)
- [x] SRI hashes recomputed for the pinned versions
- [ ] CI green

Closes #365.