### PR TITLE
feat(onboarding): pick connect <url> for one-command Studio setup

### DIFF
--- a/apps/headless/Cargo.toml
+++ b/apps/headless/Cargo.toml
@@ -12,7 +12,7 @@ path = "src/main.rs"
 
 [dependencies]
 # Crates
-pentest-core = { workspace = true }
+pentest-core = { workspace = true, features = ["browser-auth"] }
 pentest-platform = { workspace = true, features = ["desktop"] }
 pentest-ui = { workspace = true, features = ["connector", "shell-ws", "desktop"] }
 pentest-tools = { workspace = true, features = ["desktop"] }

--- a/apps/headless/src/main.rs
+++ b/apps/headless/src/main.rs
@@ -45,8 +45,10 @@ async fn main() -> anyhow::Result<()> {
         };
         match pentest_core::onboarding::connect_to_studio(&url).await {
             Ok(conn) => {
-                // Edition 2021: set_var is safe here. Runs at startup before any
-                // task reads the environment.
+                // SAFETY: mutating the environment is sound here because we are
+                // still in single-threaded startup — no tokio tasks have been
+                // spawned yet, so nothing reads the environment concurrently.
+                // (edition 2021 also does not require `unsafe` for set_var.)
                 std::env::set_var("STRIKE48_HOST", &conn.config.host);
                 std::env::set_var("STRIKE48_API_URL", &conn.api_url);
                 std::env::set_var("STRIKE48_TENANT", &conn.config.tenant_id);

--- a/apps/headless/src/main.rs
+++ b/apps/headless/src/main.rs
@@ -32,7 +32,54 @@ async fn main() -> anyhow::Result<()> {
 
     let is_strikehub = std::env::var("STRIKEHUB_SOCKET").is_ok();
 
-    let args: Vec<String> = std::env::args().collect();
+    let mut args: Vec<String> = std::env::args().collect();
+
+    // `pentest-agent connect <studio-url>` — one-command onboarding: browser
+    // sign-in, tenant discovery, and self-registration against any Prospector
+    // Studio. The discovered settings are pushed into the environment (and
+    // persisted) so the standard startup path below connects with them.
+    if args.get(1).map(String::as_str) == Some("connect") {
+        let Some(url) = args.get(2).cloned() else {
+            eprintln!("Usage: pentest-agent connect <studio-url>");
+            std::process::exit(1);
+        };
+        match pentest_core::onboarding::connect_to_studio(&url).await {
+            Ok(conn) => {
+                // Edition 2021: set_var is safe here. Runs at startup before any
+                // task reads the environment.
+                std::env::set_var("STRIKE48_HOST", &conn.config.host);
+                std::env::set_var("STRIKE48_API_URL", &conn.api_url);
+                std::env::set_var("STRIKE48_TENANT", &conn.config.tenant_id);
+                std::env::set_var("STRIKE48_INSTANCE_ID", &conn.config.instance_id);
+                std::env::set_var(
+                    "STRIKE48_TLS",
+                    if conn.config.use_tls { "true" } else { "false" },
+                );
+                if let Some(ott) = &conn.ott {
+                    std::env::set_var("STRIKE48_REGISTRATION_TOKEN", ott);
+                }
+                match conn.mode {
+                    pentest_core::onboarding::RegistrationMode::PreApproved => tracing::info!(
+                        "connect: onboarded to {} (pre-approved) as {}",
+                        conn.api_url,
+                        conn.config.instance_id
+                    ),
+                    pentest_core::onboarding::RegistrationMode::PendingApproval => tracing::info!(
+                        "connect: onboarded to {} — approve connector '{}' in Studio to finish",
+                        conn.api_url,
+                        conn.config.instance_id
+                    ),
+                }
+                // Fall through to the normal startup path using the env just set.
+                args.truncate(1);
+            }
+            Err(e) => {
+                eprintln!("connect failed: {e:#}");
+                std::process::exit(1);
+            }
+        }
+    }
+
     let config = match load_connector_config(&args) {
         ConfigLoadResult::Ok(c) => c,
         ConfigLoadResult::Help => {

--- a/apps/headless/src/main.rs
+++ b/apps/headless/src/main.rs
@@ -51,21 +51,30 @@ async fn main() -> anyhow::Result<()> {
                 // (edition 2021 also does not require `unsafe` for set_var.)
                 std::env::set_var("STRIKE48_HOST", &conn.config.host);
                 std::env::set_var("STRIKE48_API_URL", &conn.api_url);
+                // The in-app LLM chat and connector read the MATRIX_* aliases
+                // exclusively (llm_proxy.rs, liveview_connector/mod.rs,
+                // connector_app.rs); without MATRIX_API_URL a first-run operator
+                // registers fine but chat is silently dead.
+                std::env::set_var("MATRIX_API_URL", &conn.api_url);
                 std::env::set_var("STRIKE48_TENANT", &conn.config.tenant_id);
+                // MATRIX_TENANT_ID leads TENANT_ENV_VARS (config.rs): without it,
+                // a stale value already in the environment out-ranks the tenant we
+                // just resolved — the credential-replay class this feature fixes.
+                std::env::set_var("MATRIX_TENANT_ID", &conn.config.tenant_id);
                 std::env::set_var("STRIKE48_INSTANCE_ID", &conn.config.instance_id);
                 std::env::set_var(
                     "STRIKE48_TLS",
                     if conn.config.use_tls { "true" } else { "false" },
                 );
-                if let Some(ott) = &conn.ott {
-                    std::env::set_var("STRIKE48_REGISTRATION_TOKEN", ott);
-                }
-                match conn.mode {
-                    pentest_core::onboarding::RegistrationMode::PreApproved => tracing::info!(
-                        "connect: onboarded to {} (pre-approved) as {}",
-                        conn.api_url,
-                        conn.config.instance_id
-                    ),
+                match &conn.mode {
+                    pentest_core::onboarding::RegistrationMode::PreApproved { ott } => {
+                        std::env::set_var("STRIKE48_REGISTRATION_TOKEN", ott);
+                        tracing::info!(
+                            "connect: onboarded to {} (pre-approved) as {}",
+                            conn.api_url,
+                            conn.config.instance_id
+                        );
+                    }
                     pentest_core::onboarding::RegistrationMode::PendingApproval => tracing::info!(
                         "connect: onboarded to {} — approve connector '{}' in Studio to finish",
                         conn.api_url,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -43,7 +43,6 @@ pub mod prelude {
     pub use crate::export::{
         EvidenceFile, Finding, SessionExport, SessionMetadata, Severity, ToolExecution,
     };
-    pub use crate::onboarding::{connect_to_studio, RegistrationMode, StudioConnection};
     pub use crate::orchestrator::{
         build_pending_evidence_manifest, build_report_agent_seed_message,
         build_validator_seed_message, gate_for_report, parse_validator_verdicts, EngagementInfo,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -13,6 +13,7 @@ pub mod file_browser;
 pub mod jwt_validator;
 pub mod logging;
 pub mod matrix;
+pub mod onboarding;
 pub mod orchestrator;
 pub mod paths;
 pub mod provenance;
@@ -42,6 +43,7 @@ pub mod prelude {
     pub use crate::export::{
         EvidenceFile, Finding, SessionExport, SessionMetadata, Severity, ToolExecution,
     };
+    pub use crate::onboarding::{connect_to_studio, RegistrationMode, StudioConnection};
     pub use crate::orchestrator::{
         build_pending_evidence_manifest, build_report_agent_seed_message,
         build_validator_seed_message, gate_for_report, parse_validator_verdicts, EngagementInfo,

--- a/crates/core/src/onboarding.rs
+++ b/crates/core/src/onboarding.rs
@@ -1,0 +1,307 @@
+//! One-command onboarding: connect Pick to any Prospector Studio from a URL.
+//!
+//! `pick connect <url>` should be all a first-time operator needs. This module
+//! turns a single Studio URL into a registered connector:
+//!
+//! 1. Validate + normalize the URL into an HTTP API base and a WebSocket host.
+//! 2. Obtain a Keycloak bearer token via the browser ([`crate::matrix::fetch_matrix_token_browser`]).
+//!    That reuses the proven `{api}/auth/login` mediation — Matrix runs the full
+//!    OIDC/PKCE dance server-side, so we never touch Keycloak endpoints, realms,
+//!    or client-redirect whitelists directly.
+//! 3. Resolve the tenant from the authenticated session ([`fetch_tenant_id`]).
+//! 4. Mint a pre-approved OTT ([`create_pre_approved_token`]) so registration is
+//!    auto-approved. If the Studio has that endpoint disabled, degrade to the
+//!    post-approval flow (register pending, approve once in Studio).
+//! 5. Persist a [`ConnectorConfig`] (with a URL-scoped instance id, so a new
+//!    Studio never replays another tenant's saved credential).
+//!
+//! The browser step requires the `browser-auth` feature and a local browser;
+//! remote/headless hosts use the post-approval flow or `scripts/connect.sh`.
+
+use crate::config::ConnectorConfig;
+
+/// SDK connector type for Pick (matches the credential-file / gateway naming).
+#[cfg(feature = "browser-auth")]
+const CONNECTOR_TYPE: &str = "pentest-connector";
+
+/// How the connector will authenticate to the Studio after onboarding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegistrationMode {
+    /// A pre-approved OTT was minted; the connector self-registers with no
+    /// manual step. Carries the OTT JSON for `STRIKE48_REGISTRATION_TOKEN`.
+    PreApproved,
+    /// The Studio has no pre-approve endpoint; the connector registers in
+    /// pending state and an operator must approve it in Studio once.
+    PendingApproval,
+}
+
+/// The result of onboarding: everything a caller needs to start the connector.
+#[derive(Debug, Clone)]
+pub struct StudioConnection {
+    /// HTTP API base, e.g. `https://studio.example.com` (no trailing slash).
+    pub api_url: String,
+    /// Persisted connector config (host, tenant, instance id, TLS).
+    pub config: ConnectorConfig,
+    /// OTT JSON for `STRIKE48_REGISTRATION_TOKEN`, when [`RegistrationMode::PreApproved`].
+    pub ott: Option<String>,
+    /// Whether registration is auto-approved or awaits Studio approval.
+    pub mode: RegistrationMode,
+}
+
+/// Validate and normalize a user-typed Studio URL into an HTTP(S) API base.
+///
+/// Defaults a bare host to `https://`, trims a trailing slash, and rejects
+/// userinfo (`user:pass@host`) to avoid confusion attacks. Returns `None` for
+/// anything that is not a plausible `http(s)://host` URL. Ported from StrikeHub.
+pub fn validate_studio_url(raw: &str) -> Option<String> {
+    let mut u = raw.trim().to_string();
+    if u.is_empty() {
+        return None;
+    }
+    if !u.starts_with("http://") && !u.starts_with("https://") {
+        u = format!("https://{u}");
+    }
+    let u = u.trim_end_matches('/').to_string();
+    let host_part = u
+        .strip_prefix("https://")
+        .or_else(|| u.strip_prefix("http://"))
+        .unwrap_or("");
+    let authority = host_part.split('/').next().unwrap_or("");
+    if authority.is_empty() {
+        return None;
+    }
+    // Reject userinfo (raw `@` or percent-encoded `%40`) in the authority.
+    if authority.contains('@') || authority.to_lowercase().contains("%40") {
+        return None;
+    }
+    if u.len() > 2048 {
+        return None;
+    }
+    Some(u)
+}
+
+/// Derive the WebSocket host and TLS flag from a validated HTTP API base.
+///
+/// `https://host[:port]` -> (`wss://host[:port]`, true); `http://...` -> (`ws://...`, false).
+///
+/// Ungated (with pure `parse_tenant_id`) so their unit tests run on every CI
+/// lane, not only where `browser-auth` is unified in; `allow(dead_code)` covers
+/// the non-`browser-auth` build where only the tests exercise it.
+#[cfg_attr(not(feature = "browser-auth"), allow(dead_code))]
+fn derive_ws_host(api_url: &str) -> (String, bool) {
+    if let Some(rest) = api_url.strip_prefix("https://") {
+        (format!("wss://{rest}"), true)
+    } else if let Some(rest) = api_url.strip_prefix("http://") {
+        (format!("ws://{rest}"), false)
+    } else {
+        // validate_studio_url guarantees a scheme, but stay total.
+        (format!("wss://{api_url}"), true)
+    }
+}
+
+#[cfg(feature = "browser-auth")]
+fn http_client() -> reqwest::Client {
+    let insecure = std::env::var("MATRIX_TLS_INSECURE")
+        .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+        .unwrap_or(false);
+    reqwest::Client::builder()
+        .danger_accept_invalid_certs(insecure)
+        .timeout(std::time::Duration::from_secs(15))
+        .build()
+        .unwrap_or_else(|_| reqwest::Client::new())
+}
+
+/// Resolve the tenant UUID for the authenticated session via the Studio's
+/// GraphQL API (`userDetails.details.domain.id`). Ported from StrikeHub.
+#[cfg(feature = "browser-auth")]
+async fn fetch_tenant_id(api_url: &str, jwt: &str) -> anyhow::Result<String> {
+    let url = format!("{}/api/v1alpha/graphql", api_url.trim_end_matches('/'));
+    let query = serde_json::json!({ "query": "query { userDetails { details } }" });
+    let body = http_client()
+        .post(&url)
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&query)
+        .send()
+        .await?
+        .text()
+        .await?;
+    parse_tenant_id(&body)
+        .ok_or_else(|| anyhow::anyhow!("could not resolve tenant id from userDetails response"))
+}
+
+/// Extract `data.userDetails.details.domain.id` from a GraphQL response.
+/// `details` may arrive as an object or as a stringified JSON blob.
+#[cfg_attr(not(feature = "browser-auth"), allow(dead_code))]
+fn parse_tenant_id(raw: &str) -> Option<String> {
+    let v: serde_json::Value = serde_json::from_str(raw).ok()?;
+    let details = v.pointer("/data/userDetails/details")?;
+    let details = if let Some(s) = details.as_str() {
+        serde_json::from_str::<serde_json::Value>(s).ok()?
+    } else {
+        details.clone()
+    };
+    details.pointer("/domain/id")?.as_str().map(String::from)
+}
+
+/// Mint a pre-approved OTT via the Studio's `/api/connectors/pre-approve`
+/// endpoint. Returns the OTT as JSON `{"token","matrix_url"}` embedding the real
+/// API base (the SDK register-with-ott path requires it, and a mismatched origin
+/// is refused). `Ok(None)` means the endpoint is absent/forbidden — the caller
+/// should fall back to the post-approval flow. Ported from StrikeHub.
+#[cfg(feature = "browser-auth")]
+async fn create_pre_approved_token(
+    api_url: &str,
+    jwt: &str,
+    connector_type: &str,
+) -> anyhow::Result<Option<String>> {
+    let base = api_url.trim_end_matches('/');
+    let url = format!("{base}/api/connectors/pre-approve");
+    let payload = serde_json::json!({ "connector_type": connector_type, "ttl_minutes": 5 });
+    let resp = http_client()
+        .post(&url)
+        .header("Authorization", format!("Bearer {jwt}"))
+        .json(&payload)
+        .send()
+        .await?;
+
+    let status = resp.status();
+    if status == reqwest::StatusCode::NOT_FOUND || status == reqwest::StatusCode::FORBIDDEN {
+        tracing::warn!(
+            "pre-approve endpoint unavailable ({status}); falling back to post-approval"
+        );
+        return Ok(None);
+    }
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        let snippet: String = body.chars().take(300).collect();
+        anyhow::bail!("pre-approve failed: {status} — {snippet}");
+    }
+
+    let body: serde_json::Value = resp.json().await?;
+    let token = body
+        .get("token")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("no token in pre-approve response"))?;
+    Ok(Some(
+        serde_json::json!({ "token": token, "matrix_url": base }).to_string(),
+    ))
+}
+
+/// Build and persist the connector config for a resolved Studio + tenant.
+/// Uses a URL-scoped instance id so a new Studio never replays another tenant's
+/// saved credential (the recurring "Registration failed" cause).
+#[cfg(feature = "browser-auth")]
+fn persist_config(api_url: &str, tenant_id: String) -> anyhow::Result<ConnectorConfig> {
+    let (ws_host, use_tls) = derive_ws_host(api_url);
+
+    let mut settings = crate::settings::load_settings();
+    settings.ensure_device_id();
+    let instance_id = ConnectorConfig::env_scoped_instance_id(&settings.device_id, &ws_host);
+
+    let mut config = ConnectorConfig::new(ws_host).tenant_id(tenant_id);
+    config.instance_id = instance_id;
+    config.use_tls = use_tls;
+
+    settings.last_config = Some(config.clone());
+    settings.auto_connect = true;
+    crate::settings::save_settings(&settings)?;
+    Ok(config)
+}
+
+/// Onboard Pick to a Prospector Studio from just a URL: browser login, tenant
+/// discovery, pre-approve, and config persistence. Requires the `browser-auth`
+/// feature and a local browser.
+#[cfg(feature = "browser-auth")]
+pub async fn connect_to_studio(raw_url: &str) -> anyhow::Result<StudioConnection> {
+    let api_url = validate_studio_url(raw_url)
+        .ok_or_else(|| anyhow::anyhow!("not a valid Studio URL: {raw_url}"))?;
+
+    tracing::info!("onboarding: opening browser to sign in at {api_url}");
+    let jwt = crate::matrix::fetch_matrix_token_browser(&api_url).await?;
+
+    let tenant_id = fetch_tenant_id(&api_url, &jwt).await?;
+    tracing::info!("onboarding: resolved tenant {tenant_id}");
+
+    let (ott, mode) = match create_pre_approved_token(&api_url, &jwt, CONNECTOR_TYPE).await? {
+        Some(token) => (Some(token), RegistrationMode::PreApproved),
+        None => (None, RegistrationMode::PendingApproval),
+    };
+
+    let config = persist_config(&api_url, tenant_id)?;
+    Ok(StudioConnection {
+        api_url,
+        config,
+        ott,
+        mode,
+    })
+}
+
+/// Stub when the `browser-auth` feature is disabled: interactive login needs a
+/// browser. Remote/headless hosts use the post-approval flow or `scripts/connect.sh`.
+#[cfg(not(feature = "browser-auth"))]
+pub async fn connect_to_studio(_raw_url: &str) -> anyhow::Result<StudioConnection> {
+    anyhow::bail!(
+        "`pick connect <url>` requires a browser (build with the `browser-auth` feature); \
+         on a headless/remote host use scripts/connect.sh plus Studio approval"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_studio_url_defaults_https_and_trims_slash() {
+        assert_eq!(
+            validate_studio_url("discoball.example.com"),
+            Some("https://discoball.example.com".to_string())
+        );
+        assert_eq!(
+            validate_studio_url("https://foo.example.com/"),
+            Some("https://foo.example.com".to_string())
+        );
+        assert_eq!(
+            validate_studio_url("http://localhost:4000"),
+            Some("http://localhost:4000".to_string())
+        );
+    }
+
+    #[test]
+    fn validate_studio_url_rejects_userinfo_and_empty() {
+        assert_eq!(validate_studio_url(""), None);
+        assert_eq!(
+            validate_studio_url("https://user:pass@evil.example.com"),
+            None
+        );
+        assert_eq!(
+            validate_studio_url("https://evil.example.com%40attacker"),
+            None
+        );
+    }
+
+    #[test]
+    fn derive_ws_host_maps_scheme_and_tls() {
+        assert_eq!(
+            derive_ws_host("https://foo.example.com"),
+            ("wss://foo.example.com".to_string(), true)
+        );
+        assert_eq!(
+            derive_ws_host("http://localhost:4000"),
+            ("ws://localhost:4000".to_string(), false)
+        );
+    }
+
+    #[test]
+    fn parse_tenant_id_handles_object_and_stringified_details() {
+        let object = r#"{"data":{"userDetails":{"details":{"domain":{"id":"tid-123"}}}}}"#;
+        assert_eq!(parse_tenant_id(object), Some("tid-123".to_string()));
+
+        let stringified =
+            r#"{"data":{"userDetails":{"details":"{\"domain\":{\"id\":\"tid-456\"}}"}}}"#;
+        assert_eq!(parse_tenant_id(stringified), Some("tid-456".to_string()));
+
+        assert_eq!(parse_tenant_id(r#"{"data":{"userDetails":null}}"#), None);
+        assert_eq!(parse_tenant_id("not json"), None);
+    }
+}

--- a/crates/core/src/onboarding.rs
+++ b/crates/core/src/onboarding.rs
@@ -18,6 +18,9 @@
 //! The browser step requires the `browser-auth` feature and a local browser;
 //! remote/headless hosts use the post-approval flow or `scripts/connect.sh`.
 
+#[cfg(feature = "browser-auth")]
+use anyhow::Context;
+
 use crate::config::ConnectorConfig;
 
 /// SDK connector type for Pick (matches the credential-file / gateway naming).
@@ -50,23 +53,35 @@ pub struct StudioConnection {
 
 /// Validate and normalize a user-typed Studio URL into an HTTP(S) API base.
 ///
-/// Defaults a bare host to `https://`, trims a trailing slash, and rejects
-/// userinfo (`user:pass@host`) to avoid confusion attacks. Returns `None` for
-/// anything that is not a plausible `http(s)://host` URL. Ported from StrikeHub.
+/// The scheme is detected case-insensitively: a bare host and any non-`http`
+/// scheme (`https`, `wss`, `grpcs`, uppercase, ...) normalize to `https://`;
+/// only an explicit `http` scheme stays plaintext (local dev). Trims a trailing
+/// slash and rejects userinfo (`user:pass@host`) to avoid confusion attacks.
+/// Returns `None` for anything without a host or over 2048 chars. Derived from
+/// StrikeHub's validator.
 pub fn validate_studio_url(raw: &str) -> Option<String> {
-    let mut u = raw.trim().to_string();
-    if u.is_empty() {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
         return None;
     }
-    if !u.starts_with("http://") && !u.starts_with("https://") {
-        u = format!("https://{u}");
-    }
-    let u = u.trim_end_matches('/').to_string();
-    let host_part = u
-        .strip_prefix("https://")
-        .or_else(|| u.strip_prefix("http://"))
-        .unwrap_or("");
-    let authority = host_part.split('/').next().unwrap_or("");
+
+    // Split an existing scheme case-insensitively. The API base must be
+    // http(s); coerce ws/wss/grpc-style (and unknown) schemes to https so a
+    // pasted connector URL doesn't become `https://wss://host`.
+    let (scheme, rest) = match trimmed.find("://") {
+        Some(i) => {
+            let scheme = if trimmed[..i].eq_ignore_ascii_case("http") {
+                "http"
+            } else {
+                "https"
+            };
+            (scheme, &trimmed[i + 3..])
+        }
+        None => ("https", trimmed),
+    };
+
+    let rest = rest.trim_end_matches('/');
+    let authority = rest.split('/').next().unwrap_or("");
     if authority.is_empty() {
         return None;
     }
@@ -74,10 +89,12 @@ pub fn validate_studio_url(raw: &str) -> Option<String> {
     if authority.contains('@') || authority.to_lowercase().contains("%40") {
         return None;
     }
-    if u.len() > 2048 {
+
+    let normalized = format!("{scheme}://{rest}");
+    if normalized.len() > 2048 {
         return None;
     }
-    Some(u)
+    Some(normalized)
 }
 
 /// Derive the WebSocket host and TLS flag from a validated HTTP API base.
@@ -100,15 +117,17 @@ fn derive_ws_host(api_url: &str) -> (String, bool) {
 }
 
 #[cfg(feature = "browser-auth")]
-fn http_client() -> reqwest::Client {
+fn http_client() -> anyhow::Result<reqwest::Client> {
     let insecure = std::env::var("MATRIX_TLS_INSECURE")
         .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
         .unwrap_or(false);
+    // Propagate builder failure rather than silently falling back to a default
+    // client that would drop the TLS-insecure setting and the 15s timeout.
     reqwest::Client::builder()
         .danger_accept_invalid_certs(insecure)
         .timeout(std::time::Duration::from_secs(15))
         .build()
-        .unwrap_or_else(|_| reqwest::Client::new())
+        .context("failed to build HTTP client for onboarding")
 }
 
 /// Resolve the tenant UUID for the authenticated session via the Studio's
@@ -117,7 +136,7 @@ fn http_client() -> reqwest::Client {
 async fn fetch_tenant_id(api_url: &str, jwt: &str) -> anyhow::Result<String> {
     let url = format!("{}/api/v1alpha/graphql", api_url.trim_end_matches('/'));
     let query = serde_json::json!({ "query": "query { userDetails { details } }" });
-    let body = http_client()
+    let body = http_client()?
         .post(&url)
         .header("Authorization", format!("Bearer {jwt}"))
         .json(&query)
@@ -140,7 +159,11 @@ fn parse_tenant_id(raw: &str) -> Option<String> {
     } else {
         details.clone()
     };
-    details.pointer("/domain/id")?.as_str().map(String::from)
+    details
+        .pointer("/domain/id")?
+        .as_str()
+        .filter(|s| !s.is_empty())
+        .map(String::from)
 }
 
 /// Mint a pre-approved OTT via the Studio's `/api/connectors/pre-approve`
@@ -157,7 +180,7 @@ async fn create_pre_approved_token(
     let base = api_url.trim_end_matches('/');
     let url = format!("{base}/api/connectors/pre-approve");
     let payload = serde_json::json!({ "connector_type": connector_type, "ttl_minutes": 5 });
-    let resp = http_client()
+    let resp = http_client()?
         .post(&url)
         .header("Authorization", format!("Bearer {jwt}"))
         .json(&payload)
@@ -178,14 +201,21 @@ async fn create_pre_approved_token(
     }
 
     let body: serde_json::Value = resp.json().await?;
-    let token = body
+    Ok(Some(build_ott_json(&body, base)?))
+}
+
+/// Build the OTT JSON the SDK expects (`{"token","matrix_url"}`) from a
+/// pre-approve response, embedding the real API base (a mismatched origin is
+/// refused by the register-with-ott path). Errors if the response carries no
+/// non-empty `token`. Pure, so it is unit-tested on every CI lane.
+#[cfg_attr(not(feature = "browser-auth"), allow(dead_code))]
+fn build_ott_json(response: &serde_json::Value, api_base: &str) -> anyhow::Result<String> {
+    let token = response
         .get("token")
         .and_then(|v| v.as_str())
         .filter(|s| !s.is_empty())
         .ok_or_else(|| anyhow::anyhow!("no token in pre-approve response"))?;
-    Ok(Some(
-        serde_json::json!({ "token": token, "matrix_url": base }).to_string(),
-    ))
+    Ok(serde_json::json!({ "token": token, "matrix_url": api_base }).to_string())
 }
 
 /// Build and persist the connector config for a resolved Studio + tenant.
@@ -303,5 +333,58 @@ mod tests {
 
         assert_eq!(parse_tenant_id(r#"{"data":{"userDetails":null}}"#), None);
         assert_eq!(parse_tenant_id("not json"), None);
+        // Empty, non-string, and missing ids resolve to None (never Some("")).
+        assert_eq!(
+            parse_tenant_id(r#"{"data":{"userDetails":{"details":{"domain":{"id":""}}}}}"#),
+            None
+        );
+        assert_eq!(
+            parse_tenant_id(r#"{"data":{"userDetails":{"details":{"domain":{"id":123}}}}}"#),
+            None
+        );
+        assert_eq!(
+            parse_tenant_id(r#"{"data":{"userDetails":{"details":{"domain":{}}}}}"#),
+            None
+        );
+    }
+
+    #[test]
+    fn validate_studio_url_normalizes_scheme_and_rejects_overlong() {
+        // Scheme detected case-insensitively; the value carries a lowercase scheme
+        // (host case preserved).
+        assert_eq!(
+            validate_studio_url("HTTPS://Studio.example.com"),
+            Some("https://Studio.example.com".to_string())
+        );
+        // Non-http(s) schemes coerce to https (the API base) — not double-prefixed.
+        assert_eq!(
+            validate_studio_url("wss://studio.example.com"),
+            Some("https://studio.example.com".to_string())
+        );
+        // Explicit http stays plaintext (local dev), case-insensitively.
+        assert_eq!(
+            validate_studio_url("HTTP://localhost:4000"),
+            Some("http://localhost:4000".to_string())
+        );
+        // Over-length is rejected.
+        assert_eq!(
+            validate_studio_url(&format!("https://{}", "a".repeat(2100))),
+            None
+        );
+    }
+
+    #[test]
+    fn build_ott_json_requires_nonempty_token() {
+        let ok = build_ott_json(
+            &serde_json::json!({ "token": "ott_abc" }),
+            "https://studio.example.com",
+        )
+        .unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&ok).unwrap();
+        assert_eq!(parsed["token"], "ott_abc");
+        assert_eq!(parsed["matrix_url"], "https://studio.example.com");
+
+        assert!(build_ott_json(&serde_json::json!({ "token": "" }), "https://x").is_err());
+        assert!(build_ott_json(&serde_json::json!({ "other": "x" }), "https://x").is_err());
     }
 }

--- a/crates/core/src/onboarding.rs
+++ b/crates/core/src/onboarding.rs
@@ -28,11 +28,15 @@ use crate::config::ConnectorConfig;
 const CONNECTOR_TYPE: &str = "pentest-connector";
 
 /// How the connector will authenticate to the Studio after onboarding.
+///
+/// The OTT is carried by the `PreApproved` variant so the illegal pairing
+/// (pre-approved with no token, or pending-approval with one) cannot be
+/// constructed.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RegistrationMode {
     /// A pre-approved OTT was minted; the connector self-registers with no
-    /// manual step. Carries the OTT JSON for `STRIKE48_REGISTRATION_TOKEN`.
-    PreApproved,
+    /// manual step. Holds the OTT JSON for `STRIKE48_REGISTRATION_TOKEN`.
+    PreApproved { ott: String },
     /// The Studio has no pre-approve endpoint; the connector registers in
     /// pending state and an operator must approve it in Studio once.
     PendingApproval,
@@ -45,9 +49,8 @@ pub struct StudioConnection {
     pub api_url: String,
     /// Persisted connector config (host, tenant, instance id, TLS).
     pub config: ConnectorConfig,
-    /// OTT JSON for `STRIKE48_REGISTRATION_TOKEN`, when [`RegistrationMode::PreApproved`].
-    pub ott: Option<String>,
-    /// Whether registration is auto-approved or awaits Studio approval.
+    /// Whether registration is auto-approved (carrying the OTT) or awaits
+    /// Studio approval.
     pub mode: RegistrationMode,
 }
 
@@ -59,7 +62,12 @@ pub struct StudioConnection {
 /// slash and rejects userinfo (`user:pass@host`) to avoid confusion attacks.
 /// Returns `None` for anything without a host or over 2048 chars. Derived from
 /// StrikeHub's validator.
-pub fn validate_studio_url(raw: &str) -> Option<String> {
+///
+/// The only non-test caller is `connect_to_studio` (gated on `browser-auth`);
+/// `allow(dead_code)` covers the build where only the tests exercise it, as with
+/// the sibling pure helpers below.
+#[cfg_attr(not(feature = "browser-auth"), allow(dead_code))]
+pub(crate) fn validate_studio_url(raw: &str) -> Option<String> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         return None;
@@ -118,7 +126,12 @@ fn derive_ws_host(api_url: &str) -> (String, bool) {
 
 #[cfg(feature = "browser-auth")]
 fn http_client() -> anyhow::Result<reqwest::Client> {
+    // Honor both carriers, matching the canonical client (`matrix/client.rs`)
+    // and the browser-login step (`matrix/auth.rs` reads `MATRIX_INSECURE`); a
+    // single-var check here would fail TLS on a self-signed Studio that login
+    // just succeeded against.
     let insecure = std::env::var("MATRIX_TLS_INSECURE")
+        .or_else(|_| std::env::var("MATRIX_INSECURE"))
         .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
         .unwrap_or(false);
     // Propagate builder failure rather than silently falling back to a default
@@ -136,14 +149,25 @@ fn http_client() -> anyhow::Result<reqwest::Client> {
 async fn fetch_tenant_id(api_url: &str, jwt: &str) -> anyhow::Result<String> {
     let url = format!("{}/api/v1alpha/graphql", api_url.trim_end_matches('/'));
     let query = serde_json::json!({ "query": "query { userDetails { details } }" });
-    let body = http_client()?
+    let resp = http_client()?
         .post(&url)
         .header("Authorization", format!("Bearer {jwt}"))
         .json(&query)
         .send()
-        .await?
-        .text()
         .await?;
+
+    // Check status before parsing: a 401 (expired browser token), 403, or 5xx
+    // returns a body with no `userDetails`, which would otherwise collapse to a
+    // misleading "could not resolve tenant id" — pointing at tenant data when
+    // the real cause is auth/availability. Mirrors `create_pre_approved_token`.
+    let status = resp.status();
+    if !status.is_success() {
+        let body = resp.text().await.unwrap_or_default();
+        let snippet: String = body.chars().take(300).collect();
+        anyhow::bail!("tenant lookup failed: {status} — {snippet}");
+    }
+
+    let body = resp.text().await?;
     parse_tenant_id(&body)
         .ok_or_else(|| anyhow::anyhow!("could not resolve tenant id from userDetails response"))
 }
@@ -253,16 +277,15 @@ pub async fn connect_to_studio(raw_url: &str) -> anyhow::Result<StudioConnection
     let tenant_id = fetch_tenant_id(&api_url, &jwt).await?;
     tracing::info!("onboarding: resolved tenant {tenant_id}");
 
-    let (ott, mode) = match create_pre_approved_token(&api_url, &jwt, CONNECTOR_TYPE).await? {
-        Some(token) => (Some(token), RegistrationMode::PreApproved),
-        None => (None, RegistrationMode::PendingApproval),
+    let mode = match create_pre_approved_token(&api_url, &jwt, CONNECTOR_TYPE).await? {
+        Some(ott) => RegistrationMode::PreApproved { ott },
+        None => RegistrationMode::PendingApproval,
     };
 
     let config = persist_config(&api_url, tenant_id)?;
     Ok(StudioConnection {
         api_url,
         config,
-        ott,
         mode,
     })
 }
@@ -300,6 +323,9 @@ mod tests {
     #[test]
     fn validate_studio_url_rejects_userinfo_and_empty() {
         assert_eq!(validate_studio_url(""), None);
+        // A scheme with no authority is not a usable base.
+        assert_eq!(validate_studio_url("https://"), None);
+        assert_eq!(validate_studio_url("   "), None);
         assert_eq!(
             validate_studio_url("https://user:pass@evil.example.com"),
             None
@@ -319,6 +345,12 @@ mod tests {
         assert_eq!(
             derive_ws_host("http://localhost:4000"),
             ("ws://localhost:4000".to_string(), false)
+        );
+        // Scheme-less input is a defensive fallback (validate_studio_url always
+        // supplies a scheme upstream): default to the secure wss host.
+        assert_eq!(
+            derive_ws_host("foo.example.com"),
+            ("wss://foo.example.com".to_string(), true)
         );
     }
 
@@ -386,5 +418,109 @@ mod tests {
 
         assert!(build_ott_json(&serde_json::json!({ "token": "" }), "https://x").is_err());
         assert!(build_ott_json(&serde_json::json!({ "other": "x" }), "https://x").is_err());
+    }
+}
+
+/// Exercises `create_pre_approved_token`'s status handling against a real HTTP
+/// round trip — the 404/403 -> `Ok(None)` branch is the pivot that decides
+/// `PreApproved` vs `PendingApproval`, and there is no seam to unit-test it
+/// without a socket. `browser-auth` is unified on in the Linux `--workspace`
+/// lane, so these run there (same gating as `matrix/auth.rs`'s tests).
+#[cfg(all(test, feature = "browser-auth"))]
+mod http_tests {
+    use super::{create_pre_approved_token, fetch_tenant_id};
+
+    const PRE_APPROVE: &str = "/api/connectors/pre-approve";
+    const GRAPHQL: &str = "/api/v1alpha/graphql";
+
+    /// Serve one canned `(status, body)` response for `POST <path>` from a local
+    /// socket and return its base URL. The task is aborted when the returned
+    /// handle is dropped at end of test.
+    async fn stub(
+        path: &'static str,
+        status: u16,
+        body: serde_json::Value,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind stub");
+        let port = listener.local_addr().expect("addr").port();
+        let code = axum::http::StatusCode::from_u16(status).expect("valid status");
+        let app = axum::Router::new().route(
+            path,
+            axum::routing::post(move || {
+                let body = body.clone();
+                async move { (code, axum::Json(body)) }
+            }),
+        );
+        let handle = tokio::spawn(async move {
+            let _ = axum::serve(listener, app).await;
+        });
+        (format!("http://127.0.0.1:{port}"), handle)
+    }
+
+    #[tokio::test]
+    async fn pre_approve_ok_with_token_yields_ott_embedding_base() {
+        let (base, _srv) = stub(PRE_APPROVE, 200, serde_json::json!({ "token": "ott_live" })).await;
+        let out = create_pre_approved_token(&base, "jwt", "pentest-connector")
+            .await
+            .expect("200 must not error");
+        let json: serde_json::Value = serde_json::from_str(&out.expect("Some(ott)")).unwrap();
+        assert_eq!(json["token"], "ott_live");
+        // The OTT must embed the real base, or register-with-ott refuses it.
+        assert_eq!(json["matrix_url"], base);
+    }
+
+    #[tokio::test]
+    async fn pre_approve_not_found_degrades_to_none() {
+        let (base, _srv) = stub(PRE_APPROVE, 404, serde_json::json!({ "error": "no route" })).await;
+        let out = create_pre_approved_token(&base, "jwt", "pentest-connector")
+            .await
+            .expect("404 must degrade, not error");
+        assert!(out.is_none(), "404 -> post-approval fallback");
+    }
+
+    #[tokio::test]
+    async fn pre_approve_forbidden_degrades_to_none() {
+        let (base, _srv) = stub(PRE_APPROVE, 403, serde_json::json!({ "error": "disabled" })).await;
+        let out = create_pre_approved_token(&base, "jwt", "pentest-connector")
+            .await
+            .expect("403 must degrade, not error");
+        assert!(out.is_none(), "403 -> post-approval fallback");
+    }
+
+    #[tokio::test]
+    async fn pre_approve_empty_token_is_error() {
+        let (base, _srv) = stub(PRE_APPROVE, 200, serde_json::json!({ "token": "" })).await;
+        let out = create_pre_approved_token(&base, "jwt", "pentest-connector").await;
+        assert!(
+            out.is_err(),
+            "200 with an empty token is a server contract violation"
+        );
+    }
+
+    #[tokio::test]
+    async fn pre_approve_server_error_is_error() {
+        let (base, _srv) = stub(PRE_APPROVE, 500, serde_json::json!({ "error": "boom" })).await;
+        let out = create_pre_approved_token(&base, "jwt", "pentest-connector").await;
+        let err = out.expect_err("5xx must surface, not degrade").to_string();
+        assert!(err.contains("500"), "error must name the status: {err}");
+    }
+
+    /// Guards the fix for the misleading-error bug: an auth failure on the tenant
+    /// lookup must surface the HTTP status, not collapse to "could not resolve
+    /// tenant id" (which points at tenant data when the cause is auth). Reverting
+    /// the status check in `fetch_tenant_id` turns this red.
+    #[tokio::test]
+    async fn tenant_lookup_auth_failure_surfaces_status() {
+        let (base, _srv) = stub(GRAPHQL, 401, serde_json::json!({ "error": "expired" })).await;
+        let err = fetch_tenant_id(&base, "stale-jwt")
+            .await
+            .expect_err("401 must surface as an auth error")
+            .to_string();
+        assert!(
+            err.contains("401") && !err.contains("could not resolve tenant id"),
+            "auth failure must name the status, not blame tenant data: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Adds a `pentest-core::onboarding` module and a `pentest-agent connect <url>` subcommand: from just a Studio URL, it does browser sign-in → tenant discovery → a pre-approved OTT → self-registration, and persists the config with a **URL-scoped instance id** so a new Studio never replays another tenant's saved credential (the recurring "Registration failed" cause).
- Reuses the proven `{api}/auth/login` browser mediation (`crate::matrix::fetch_matrix_token_browser`), so there's no direct Keycloak realm/redirect handling and no client-redirect-whitelist risk. No OIDC discovery needed — the mediation runs the OIDC/PKCE dance server-side.
- Degrades gracefully to the **post-approval** flow where a Studio has no `/api/connectors/pre-approve` endpoint (register pending → approve once in Studio).
- The browser/network path is gated behind the `browser-auth` feature (which `pentest-headless` now enables); the pure helpers stay ungated so their unit tests run on every CI lane, not only where `browser-auth` unifies in.

## Test plan

- [x] Unit tests (URL validation, userinfo rejection, ws-host/TLS derivation, tenant JSON incl. stringified `details`) — pass **with and without** `browser-auth`
- [x] `cargo clippy -D warnings` clean in **both** feature configs; `cargo fmt` clean
- [x] `cargo check`/`clippy`/`test` on the headless binary
- [x] **Live end-to-end** against a Studio: browser → tenant resolved → pre-approved OTT → "Registered successfully"; credential persisted for reconnect
- [ ] Reviewer: exercise the post-approval fallback on a Studio without the pre-approve endpoint

Part of #377. The desktop first-run wizard (same `onboarding` module, second surface) follows in a separate PR.