### PR TITLE
ci(release): default desktop + headless release builds to easy mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -382,7 +382,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y protobuf-compiler libpcap-dev
 
+      # Easy-mode-first: bake PICK_EASY_MODE so the served LiveView UI defaults to
+      # easy mode (resolve_easy_mode: persisted setting > build-time PICK_EASY_MODE
+      # > app default). This is the agent StrikeHub embeds (registry asset
+      # pentest-agent-{os}-{arch}), so the released StrikeHub connector matches a
+      # local easy-mode build. No STRIKE48_HOST is baked: under StrikeHub the host
+      # arrives over IPC, and standalone `pentest-agent connect <url>` supplies it.
       - name: Build
+        env:
+          PICK_EASY_MODE: "true"
         run: cargo build --locked --package pentest-headless --release --features pentest-platform/desktop-pcap
 
       - name: Package
@@ -410,7 +418,10 @@ jobs:
           version: "27.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Easy-mode-first headless build (see the Linux headless job for rationale).
       - name: Build
+        env:
+          PICK_EASY_MODE: "true"
         run: cargo build --locked --package pentest-headless --release
 
       - name: Sign Windows binary
@@ -460,7 +471,10 @@ jobs:
       - name: Install protobuf
         run: brew install protobuf
 
+      # Easy-mode-first headless build (see the Linux headless job for rationale).
       - name: Build
+        env:
+          PICK_EASY_MODE: "true"
         run: cargo build --locked --package pentest-headless --release --target ${{ matrix.target }} --features pentest-platform/desktop-pcap
 
       - name: Import Apple certificate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,15 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev protobuf-compiler libpcap-dev libxdo-dev
 
+      # Desktop release binaries ship easy-mode-first: bake PICK_EASY_MODE and the
+      # studio PLG host at build time (via option_env!) so a distributed binary
+      # with no runtime .env boots into easy mode and auto-connects to studio,
+      # matching the Android build. Web and headless deliberately stay neutral
+      # (compiled easy_mode=false, host resolved from the runtime env).
       - name: Build
+        env:
+          PICK_EASY_MODE: "true"
+          STRIKE48_HOST: https://studio.strike48.com
         run: cargo build --locked --package pentest-desktop --release --features pentest-platform/desktop-pcap
 
       - name: Package
@@ -80,7 +88,11 @@ jobs:
           version: "27.x"
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Easy-mode-first desktop build (see the Linux desktop job for rationale).
       - name: Build
+        env:
+          PICK_EASY_MODE: "true"
+          STRIKE48_HOST: https://studio.strike48.com
         run: cargo build --locked --package pentest-desktop --release
 
       - name: Sign Windows binary
@@ -130,7 +142,11 @@ jobs:
       - name: Install protobuf
         run: brew install protobuf
 
+      # Easy-mode-first desktop build (see the Linux desktop job for rationale).
       - name: Build
+        env:
+          PICK_EASY_MODE: "true"
+          STRIKE48_HOST: https://studio.strike48.com
         run: cargo build --locked --package pentest-desktop --release --target ${{ matrix.target }} --features pentest-platform/desktop-pcap
 
       - name: Import Apple certificate


### PR DESCRIPTION
## What

Bakes `PICK_EASY_MODE=true` into the **desktop** (×3) and **headless agent** (×3) release jobs. Desktop additionally bakes `STRIKE48_HOST=https://studio.strike48.com`.

## Why

Only the **Android** artifacts previously shipped easy-mode-first. Two gaps:

- **Desktop**: shipped neutral. A distributed desktop binary (no runtime `.env`) had no host to auto-connect to, so easy-mode fell through to the connect form. Now it boots into easy mode and auto-connects to studio, matching Android.
- **Headless agent**: this is the artifact **StrikeHub embeds** (registry asset `pentest-agent-{os}-{arch}`, `binary_hint: pentest-agent`). It serves the LiveView workspace UI, whose easy-mode resolves as *persisted setting > build-time `PICK_EASY_MODE` > app default (`false`)*. So a **local** easy-mode build of `pentest-agent` showed easy mode, but the **released** one booted non-easy — StrikeHub inherited that. Baking `PICK_EASY_MODE=true` makes the released agent match.

## Scope / deliberately unchanged

- **Web** stays neutral (compiled `easy_mode=false`, host from runtime env).
- **Headless bakes the flag only, not `STRIKE48_HOST`**: under StrikeHub the host arrives over the IPC socket (`ipc_runner.rs`), and standalone `pentest-agent connect <url>` supplies it via the onboarding flow.
- **iOS** unchanged (disabled).
- Env is set at each **Build step**, so it doesn't leak into signing/packaging.

## Bake matrix after this PR

| Job | `PICK_EASY_MODE` | `STRIKE48_HOST` |
|---|---|---|
| desktop ×3 | ✅ | ✅ studio |
| headless ×3 | ✅ | ❌ (IPC / connect supplies) |
| android | ✅ (justfile default) | ✅ studio (pre-existing) |
| web | ❌ | ❌ |
| iOS | disabled | — |

## Verification

- `yq` parses the workflow; per-job `awk` map confirms the flags land only on the six intended jobs, web/release untouched.