### PR TITLE
feat(agent): fact-first network discovery (inject subnets, scope hints)

### DIFF
--- a/crates/core/src/matrix/agent_defaults.rs
+++ b/crates/core/src/matrix/agent_defaults.rs
@@ -21,31 +21,14 @@ fn build_tool_configs(names: &[String]) -> serde_json::Value {
     serde_json::Value::Object(map)
 }
 
-/// Build the default CreateAgentInput for auto-creating a pentest-connector persona.
+/// Build the "tools available on THIS connector" preamble.
 ///
-/// `tenant_id` is the tenant/realm name (e.g. "non-prod") used to build the
-/// connector address pattern `{tenant}.{connector_name}.*` so the Matrix
-/// backend can match registered connector tools to this agent.
-///
-/// `connector_name` controls the gateway identity. Instances sharing the same
-/// name are round-robin'd; use a unique name (e.g. `pentest-connector-<hostname>`)
-/// to get a dedicated agent view.
-///
-/// `tool_names` are the registered tool names to auto-approve. Callers pass
-/// this explicitly (the Dioxus app sources it from its global session; the
-/// crux shell passes the tools it knows about) so this builder stays pure.
-/// Build the agent system message: the static red-team persona plus a dynamic
-/// preamble listing the tools THIS connector actually advertises. The persona
-/// documents tools like `nmap` / `execute_command` for the full desktop
-/// toolset, but a given connector (notably iOS — no fork/exec, no sandbox) only
-/// exposes a subset. Without being told, the agent reaches for tools it "knows"
-/// but that aren't advertised here, and those calls just fail (the observed
-/// "tried nmap / execute_command on iOS" behavior). Prepend the real list and
-/// tell it not to reach outside that set.
-fn system_message_with_available_tools(tool_names: &[String]) -> String {
-    if tool_names.is_empty() {
-        return RED_TEAM_SYSTEM_PROMPT.to_string();
-    }
+/// The persona documents the full desktop toolset (`nmap`, `execute_command`,
+/// …), but a given connector (notably iOS — no fork/exec, no sandbox) exposes
+/// only a subset. Listing the real set and telling the agent not to reach
+/// outside it prevents calls to tools this platform can't run (the observed
+/// "tried nmap / execute_command on iOS" behavior).
+fn available_tools_section(tool_names: &[String]) -> String {
     let mut names: Vec<&str> = tool_names.iter().map(String::as_str).collect();
     names.sort_unstable();
     format!(
@@ -58,17 +41,78 @@ fn system_message_with_available_tools(tool_names: &[String]) -> String {
          it — reach for a listed alternative (e.g. `port_scan`, `service_banner`, \
          `http_request`, `network_discover`) instead of calling the unavailable \
          one. System tools (document_*, *_guide, validate_*) are always \
-         available in addition to the above.\n\n\
-         ---\n\n{}",
+         available in addition to the above.",
         names.join(", "),
-        RED_TEAM_SYSTEM_PROMPT
     )
 }
 
+/// Render the live host-network-facts section injected at session start (#347).
+///
+/// Lists the connector's active subnets so the agent targets them directly
+/// instead of guessing a home range (the `192.168.1.0/24`-on-a-`10.0.x`
+/// failure). Empty input yields an empty string, so no section is emitted when
+/// the caller could not enumerate any subnet.
+fn host_network_facts_section(active_subnets: &[String]) -> String {
+    if active_subnets.is_empty() {
+        return String::new();
+    }
+    let list = active_subnets
+        .iter()
+        .map(|s| format!("- {s}"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    format!(
+        "# Host network facts (live, this connector)\n\n\
+         This connector is attached to the following active subnet(s). Use these \
+         as scan targets (or pass `target=\"auto\"` / `target=\"current\"`); do NOT \
+         invent other ranges:\n\n{list}"
+    )
+}
+
+/// Assemble the agent system message: optional live host-network facts (#347)
+/// and the connector's advertised tool list, each prepended to the shared
+/// red-team persona.
+///
+/// A given connector (notably iOS — no fork/exec, no sandbox) only exposes a
+/// subset of the toolset; without being told, the agent reaches for tools it
+/// "knows" but that aren't advertised, and those calls just fail. Either
+/// preamble is omitted when its input is empty; with neither, the bare persona
+/// is returned so pre-registration paths don't break.
+fn system_message_with_available_tools(tool_names: &[String], active_subnets: &[String]) -> String {
+    let mut sections: Vec<String> = Vec::new();
+    let facts = host_network_facts_section(active_subnets);
+    if !facts.is_empty() {
+        sections.push(facts);
+    }
+    if !tool_names.is_empty() {
+        sections.push(available_tools_section(tool_names));
+    }
+    if sections.is_empty() {
+        return RED_TEAM_SYSTEM_PROMPT.to_string();
+    }
+    sections.push(RED_TEAM_SYSTEM_PROMPT.to_string());
+    sections.join("\n\n---\n\n")
+}
+
+/// Build the default CreateAgentInput for auto-creating a pentest-connector persona.
+///
+/// `tenant_id` is the tenant/realm name (e.g. "non-prod") used to build the
+/// connector address pattern `{tenant}.{connector_name}.*` so the Matrix
+/// backend can match registered connector tools to this agent.
+///
+/// `connector_name` controls the gateway identity. Instances sharing the same
+/// name are round-robin'd; use a unique name (e.g. `pentest-connector-<hostname>`)
+/// to get a dedicated agent view.
+///
+/// `tool_names` are the registered tool names to auto-approve, and
+/// `active_subnets` are the connector's live subnet CIDRs injected into the
+/// persona (#347). Callers pass both explicitly (the Dioxus app sources them
+/// from its session / `network_context`) so this builder stays pure.
 pub fn default_pentest_agent_input(
     tenant_id: &str,
     connector_name: &str,
     tool_names: &[String],
+    active_subnets: &[String],
 ) -> CreateAgentInput {
     let connector_key = format!("{}.{}.*", tenant_id, connector_name);
     tracing::info!(
@@ -94,7 +138,10 @@ pub fn default_pentest_agent_input(
     CreateAgentInput {
         name: connector_name.to_string(),
         description: Some("Red team operational agent for penetration testing".to_string()),
-        system_message: Some(system_message_with_available_tools(tool_names)),
+        system_message: Some(system_message_with_available_tools(
+            tool_names,
+            active_subnets,
+        )),
         agent_greeting: Some("Ready for red team operations. What's the target?".to_string()),
         context: Some(serde_json::json!({
             "created_by": connector_name,
@@ -287,6 +334,18 @@ Detect everything that communicates on the target network. Use passive and activ
 - Service enumeration (port scanning, banner grabbing)
 - Wireless spectrum analysis (WiFi, BLE, Zigbee if applicable)
 - DNS reconnaissance and zone enumeration
+
+### Fact-First Targeting (mandatory)
+Before any CIDR or dash-range scan, target a network you have established as a
+fact, not one you assumed:
+- If a "Host network facts" section was injected at the top of this session, scan
+  those subnets. They are the connector's own live networks.
+- Otherwise pass `target="auto"` (or `target="current"`) so the scan resolves to
+  the connector's own subnets, or run a discovery tool first to learn them.
+- NEVER invent or default to a range such as `192.168.1.0/24`. A guessed range on
+  the wrong network is the single most common cause of a scan that finds nothing.
+- When a scan returns zero hosts, treat "I scanned the wrong network" as the first
+  hypothesis before "the network is empty", and re-target using the facts above.
 
 ### Phase 1: Surface Inflation
 Maximize the known attack surface:
@@ -645,7 +704,8 @@ mod tests {
 
     #[test]
     fn default_pentest_agent_input_is_pure_and_well_formed() {
-        let input = default_pentest_agent_input("non-prod", "pentest-connector", &["foo".into()]);
+        let input =
+            default_pentest_agent_input("non-prod", "pentest-connector", &["foo".into()], &[]);
 
         // Name matches the connector name.
         assert_eq!(input.name, "pentest-connector");
@@ -683,11 +743,14 @@ mod tests {
     fn system_message_lists_available_tools_and_gates_unavailable_ones() {
         // The connector's advertised tools get prepended so the agent doesn't
         // reach for tools this platform can't run (e.g. nmap on iOS).
-        let msg = system_message_with_available_tools(&[
-            "port_scan".into(),
-            "http_request".into(),
-            "network_discover".into(),
-        ]);
+        let msg = system_message_with_available_tools(
+            &[
+                "port_scan".into(),
+                "http_request".into(),
+                "network_discover".into(),
+            ],
+            &[],
+        );
         assert!(
             msg.contains("Tools available on THIS connector"),
             "should carry the availability preamble"
@@ -707,9 +770,62 @@ mod tests {
         );
         // Empty list -> bare persona (no preamble), so nothing breaks pre-registration.
         assert_eq!(
-            system_message_with_available_tools(&[]),
+            system_message_with_available_tools(&[], &[]),
             RED_TEAM_SYSTEM_PROMPT
         );
+    }
+
+    #[test]
+    fn system_message_injects_host_network_facts_when_present() {
+        // #347: the live subnets must be injected into the system message so the
+        // agent targets them instead of guessing a home range. Guard both the
+        // section header and every CIDR passed in.
+        let subnets = vec!["10.0.8.0/22".to_string(), "172.16.4.0/24".to_string()];
+        let msg = system_message_with_available_tools(&["port_scan".into()], &subnets);
+        assert!(
+            msg.contains("# Host network facts (live, this connector)"),
+            "should carry the injected host-network-facts section"
+        );
+        for cidr in &subnets {
+            assert!(msg.contains(cidr), "should list the active subnet {cidr}");
+        }
+        // The persona and the tool preamble still ride along.
+        assert!(msg.to_lowercase().contains("red team"));
+        assert!(msg.contains("Tools available on THIS connector"));
+    }
+
+    #[test]
+    fn system_message_omits_host_facts_when_no_subnets() {
+        // With no subnets enumerated, no facts section is emitted (the agent falls
+        // back to target="auto"/discovery per the prompt rule) — and an empty
+        // tools+subnets input still yields the bare persona.
+        let msg = system_message_with_available_tools(&["port_scan".into()], &[]);
+        assert!(
+            !msg.contains("# Host network facts (live, this connector)"),
+            "no facts section when no subnets are known"
+        );
+        assert_eq!(
+            system_message_with_available_tools(&[], &[]),
+            RED_TEAM_SYSTEM_PROMPT
+        );
+    }
+
+    #[test]
+    fn system_prompt_mandates_fact_first_targeting() {
+        // #347 AC: the persona must forbid guessing a range and steer to the
+        // injected facts / target="auto". If this regresses, the prompt rule that
+        // pairs with the injected facts is gone and the agent guesses again.
+        let sys = RED_TEAM_SYSTEM_PROMPT;
+        assert!(
+            sys.contains("Fact-First Targeting"),
+            "prompt should carry the fact-first targeting rule"
+        );
+        for needle in ["never invent", "192.168.1.0/24", "target=\"auto\""] {
+            assert!(
+                sys.to_lowercase().contains(&needle.to_lowercase()),
+                "fact-first rule should mention '{needle}'"
+            );
+        }
     }
 
     #[test]

--- a/crates/tools/src/external/nmap.rs
+++ b/crates/tools/src/external/nmap.rs
@@ -295,7 +295,25 @@ impl PentestTool for NmapTool {
             );
 
             // Parse nmap XML output
-            let data = parse_nmap_xml(&xml_output, &result.stderr)?;
+            let mut data = parse_nmap_xml(&xml_output, &result.stderr)?;
+
+            // #347: a zero-host sweep is far more often the wrong network than an
+            // empty one. Attach a scope hint naming the connector's real subnets
+            // (and any raw-socket degradation, #251) so the agent re-targets
+            // instead of reporting "nothing found".
+            if data.get("count").and_then(Value::as_u64) == Some(0) {
+                let active_subnets = crate::network_context::network_context()
+                    .await
+                    .unwrap_or_default();
+                let hint = crate::scan_scope_hint::zero_host_scope_hint(
+                    &target,
+                    &active_subnets,
+                    !unprivileged,
+                );
+                if let Some(obj) = data.as_object_mut() {
+                    obj.insert("scope_hint".to_string(), json!(hint));
+                }
+            }
 
             // Produce evidence nodes for the three-agent pipeline
             let evidence_nodes =

--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -26,6 +26,7 @@ pub mod read_file;
 pub mod registry; // Quick action registry for UI
 pub mod safety_check; // NEW: Network safety validation
 pub mod safety_check_tool; // NEW: Safety check tool wrapper
+pub mod scan_scope_hint; // Zero-host / degraded-scan scope hints (#347)
 pub mod scan_target; // Resolve auto/current/all target sentinels + out-of-subnet warning
 pub mod screenshot;
 pub mod service_banner;

--- a/crates/tools/src/scan_scope_hint.rs
+++ b/crates/tools/src/scan_scope_hint.rs
@@ -1,0 +1,99 @@
+//! Zero-host / degraded-scan scope hints (#347).
+//!
+//! When a sweep returns no hosts, the Red Team agent tends to report "the
+//! network is empty" when the real cause is almost always that it scanned the
+//! wrong network (the `192.168.1.0/24`-on-a-`10.0.x` failure) or that raw-socket
+//! host discovery was degraded inside the sandbox (#251). A scope hint turns
+//! that silent zero into a teachable signal: it names the connector's actual
+//! subnets and states any capability degradation, so the model re-targets
+//! instead of concluding nothing is there.
+
+use crate::network_context::Subnet;
+
+/// Build the hint appended to a scan result that found zero hosts.
+///
+/// `target` is the range that was scanned; `active_subnets` are the connector's
+/// live subnets (fact-first re-targeting); `raw_socket_available` is false when
+/// privileged host discovery was unavailable in-sandbox (#251), which is stated
+/// explicitly rather than masked as an empty network.
+pub fn zero_host_scope_hint(
+    target: &str,
+    active_subnets: &[Subnet],
+    raw_socket_available: bool,
+) -> String {
+    let mut parts = vec![format!(
+        "The scan of `{target}` returned zero hosts. Before concluding the network is empty, \
+         verify you scanned the right network."
+    )];
+
+    if active_subnets.is_empty() {
+        parts.push(
+            "No active host subnets could be enumerated; pass target=\"auto\" (or run a \
+             discovery tool) to scan this connector's own network rather than guessing a range."
+                .to_string(),
+        );
+    } else {
+        let list = active_subnets
+            .iter()
+            .map(|s| s.cidr.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        parts.push(format!(
+            "This connector's active subnet(s) are: {list}. Re-target one of these (or use \
+             target=\"auto\") if `{target}` is not among them."
+        ));
+    }
+
+    if !raw_socket_available {
+        parts.push(
+            "Raw-socket capability was unavailable in this sandbox, so privileged host \
+             discovery (SYN/ICMP sweeps) was degraded - a zero result here may reflect that \
+             degradation, not an empty network."
+                .to_string(),
+        );
+    }
+
+    parts.join(" ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn subnet(cidr: &str) -> Subnet {
+        Subnet {
+            cidr: cidr.to_string(),
+            interface: "eth0".to_string(),
+            is_primary: false,
+        }
+    }
+
+    #[test]
+    fn hint_names_active_subnets_and_the_scanned_target() {
+        let subnets = [subnet("10.0.8.0/22"), subnet("172.16.4.0/24")];
+        let hint = zero_host_scope_hint("192.168.1.0/24", &subnets, true);
+        assert!(hint.contains("192.168.1.0/24"), "names the scanned target");
+        assert!(hint.contains("10.0.8.0/22") && hint.contains("172.16.4.0/24"));
+        assert!(hint.contains("target=\"auto\""));
+        // Raw sockets available -> no degradation clause.
+        assert!(!hint.contains("degrad"));
+    }
+
+    #[test]
+    fn hint_states_raw_socket_degradation_when_unavailable() {
+        let hint = zero_host_scope_hint("10.0.8.0/22", &[subnet("10.0.8.0/22")], false);
+        assert!(
+            hint.to_lowercase().contains("raw-socket") && hint.contains("degrad"),
+            "must state the sandbox degradation, not mask it (#251)"
+        );
+    }
+
+    #[test]
+    fn hint_falls_back_to_auto_when_no_subnets_known() {
+        let hint = zero_host_scope_hint("192.168.1.0/24", &[], true);
+        assert!(
+            hint.contains("target=\"auto\""),
+            "with no known subnets, steer to auto/discovery"
+        );
+    }
+}

--- a/crates/ui/src/components/chat_panel/constants.rs
+++ b/crates/ui/src/components/chat_panel/constants.rs
@@ -32,12 +32,31 @@ pub const SUGGESTED_ACTIONS: &[(&str, &str)] = &[
 /// (`pentest_core::matrix::default_pentest_agent_input`); it only supplies the
 /// UI's session-derived tool names so the crux middleware and the Dioxus app
 /// share ONE implementation of the agent persona.
-pub fn default_pentest_agent_input(tenant_id: &str, connector_name: &str) -> CreateAgentInput {
+pub async fn default_pentest_agent_input(
+    tenant_id: &str,
+    connector_name: &str,
+) -> CreateAgentInput {
+    let active_subnets = active_subnet_cidrs().await;
     pentest_core::matrix::default_pentest_agent_input(
         tenant_id,
         connector_name,
         &crate::session::get_tool_names(),
+        &active_subnets,
     )
+}
+
+/// Best-effort enumeration of the connector's active IPv4 subnets as CIDR
+/// strings, for injection into the agent persona (#347). A failure degrades to
+/// an empty list — the persona then steers the agent to `target="auto"` rather
+/// than guessing a range.
+async fn active_subnet_cidrs() -> Vec<String> {
+    match pentest_tools::network_context::network_context().await {
+        Ok(subnets) => subnets.into_iter().map(|s| s.cidr).collect(),
+        Err(e) => {
+            tracing::warn!("could not enumerate host subnets for agent context: {e}");
+            Vec::new()
+        }
+    }
 }
 
 /// Suffix appended to the connector name to produce the Report Agent name.

--- a/crates/ui/src/components/chat_panel/mod.rs
+++ b/crates/ui/src/components/chat_panel/mod.rs
@@ -745,7 +745,8 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
                         // format, safety-verdict rubric, etc.); without pushing it here
                         // an agent created on an older build stays frozen on the old
                         // prompt forever (create sets it; update must too).
-                        let fresh_input = default_pentest_agent_input(&tenant_id, &connector_name);
+                        let fresh_input =
+                            default_pentest_agent_input(&tenant_id, &connector_name).await;
                         let update_input = UpdateAgentInput {
                             id: agent.id.clone(),
                             tools: fresh_input.tools,
@@ -791,7 +792,9 @@ pub fn ChatPanel(props: ChatPanelProps) -> Element {
                             connector_name
                         );
                         match client
-                            .create_agent(default_pentest_agent_input(&tenant_id, &connector_name))
+                            .create_agent(
+                                default_pentest_agent_input(&tenant_id, &connector_name).await,
+                            )
                             .await
                         {
                             Ok(new_agent) => {


### PR DESCRIPTION
## Summary

- Inject the connector's live subnets into the Red Team agent's system message at registration, and add a mandatory "Fact-First Targeting" rule to the persona, so the agent scans a known network (or `target="auto"`/`"current"`) instead of guessing a range like `192.168.1.0/24` - the root cause of the scan-nothing-on-the-wrong-subnet failure.
- On a zero-host nmap sweep, attach a `scope_hint` that names the host's actual subnets and, when raw-socket capability was unavailable in-sandbox, states the discovery was degraded (#251/#309) rather than masking it as an empty network.
- Closes #347 (child of #344). Subnets come from `network_context()` (the #348/#349 foundation); `pentest-core` stays dependency-clean because `core -> tools` is a dev-only dep, so the fetch lives in the `crates/ui` wrapper.

## Changes

- `crates/core/src/matrix/agent_defaults.rs`: `default_pentest_agent_input` takes `active_subnets`; new `host_network_facts_section`; extracted `available_tools_section`; "Fact-First Targeting (mandatory)" rule added to `RED_TEAM_SYSTEM_PROMPT`.
- `crates/ui/src/components/chat_panel/{constants.rs,mod.rs}`: wrapper is now async and sources subnets from `network_context()` (empty on error); two call sites await it.
- `crates/tools/src/scan_scope_hint.rs` (new, pure + unit-tested) wired into `crates/tools/src/external/nmap.rs` on the zero-host path.

## Test plan

- [x] `cargo test -p pentest-core --lib matrix::agent_defaults` - 7/7
- [x] `cargo test -p pentest-tools --lib scan_scope_hint` - 3/3
- [x] Guard mutations: neutering `host_network_facts_section`, the fact-first prompt text, and the degradation clause each reddens its test; all reverted
- [x] `cargo clippy --workspace --all-targets --features pentest-platform/desktop-pcap -- -D warnings` - clean
- [x] `cargo fmt --all` - clean
- [ ] Behavioral (AC #4, not unit-testable per the issue): run `./run-pentest.sh headless dev` against a live workspace and confirm the agent reads the injected subnets / uses `target="auto"` instead of guessing a range. Deferred as a documented manual step.

CI-scope note: `agent_defaults` tests run in both CI lanes; `scan_scope_hint` (pure) runs in the Linux workspace lane.