### PR TITLE
test: stabilize evidence buffer race and align macOS capability assert (#359, #360)

### DIFF
--- a/crates/core/tests/tool_integration.rs
+++ b/crates/core/tests/tool_integration.rs
@@ -565,9 +565,16 @@ fn all_tools_registered() {
     let caps = c.capabilities();
     let registered: Vec<&str> = caps.iter().map(|t| t.task_type_id.as_str()).collect();
 
-    for name in pentest_tools::tool_names() {
+    // Compare against the host-supported set, not every registered tool.
+    // `capabilities()` is built from `supported_schemas()` (platform + desktop
+    // OS gated, see #183), so asserting against all `tool_names()` would fail on
+    // hosts where some tools are filtered out - e.g. Linux-only tools
+    // (wifi_scan_detailed, autopwn_crack) on the macOS CI lane. Iterate
+    // `supported_names()`, which applies the same gating. See #360.
+    let registry = pentest_tools::create_tool_registry();
+    for name in registry.supported_names() {
         assert!(
-            registered.contains(&name.as_str()),
+            registered.contains(&name),
             "tool '{name}' not in capabilities: {registered:?}"
         );
     }

--- a/crates/tools/src/evidence_producer.rs
+++ b/crates/tools/src/evidence_producer.rs
@@ -590,6 +590,7 @@ mod tests {
     ///
     /// Note: Uses unique IDs to avoid interference from parallel tests.
     #[test]
+    #[ignore = "Requires exclusive access to global buffer - run with --test-threads=1"]
     fn multiple_push_single_drain() {
         // Act: Push 10 nodes with unique IDs
         for i in 0..10 {


### PR DESCRIPTION
## Summary

Two small test-health fixes; no production code changes.

- **#359** (`crates/tools/src/evidence_producer.rs`): `multiple_push_single_drain` was a plain `#[test]` but mutates the global `PENDING_EVIDENCE` buffer, racing its three siblings (`push_is_non_blocking`, `evidence_buffer_enforces_capacity_limit`, `evidence_buffer_near_full_detection`) which are already `#[ignore]`. Marked it `#[ignore]` with the identical reason string so the default suite is deterministic. It still runs under `cargo test --package pentest-tools --lib evidence_producer -- --ignored --test-threads=1`.
- **#360** (`crates/core/tests/tool_integration.rs`): `all_tools_registered` asserted that every *registered* tool (`pentest_tools::tool_names()`) appears in `capabilities()` -- but `capabilities()` is built from `supported_schemas()`, the host-gated set (platform + desktop OS, see #183). On any host with unsupported tools the sets diverge and the assert fails (the Linux-only `wifi_scan_detailed` / `autopwn_crack` on macOS). Now iterates `supported_names()`, which applies the identical `is_supported_logged()` filter as `supported_schemas()`, so the compared sets align on any host. This is exactly the fix suggested in #360.

## Verification (Linux host)

- `#359`: confirmed `multiple_push_single_drain` now reports `ignored` in the default `cargo test` run alongside its three siblings, and still passes under `--ignored --test-threads=1`.
- `#360`: `all_tools_registered` passes; `supported_names()` returns 115 tools on this host, so the assertion loop is not vacuous. Verified in `crates/core/src/tools.rs` that `supported_names()` (L939) and `supported_schemas()` (L891) filter through the same `is_supported_logged()` function, so the two sets are gated identically.
- `cargo fmt --all` clean; `cargo clippy --package pentest-core --package pentest-tools --all-targets -- -D warnings` clean.

## Known limitation (deferred, not introduced by this PR)

The `#360` guard runs only on the **Linux** lane (`cargo test --workspace`). The `check-macos` lane uses `cargo test ... --lib`, which excludes `tests/` integration targets -- so `all_tools_registered` does not run on macOS, the very platform where the OS-gating divergence appears. This is a pre-existing CI-scope gap noted in #360's own description, not something this PR changes. Closing it would mean running the full `tool_integration` binary (which exercises network-touching tools: port_scan, arp_table, ssdp_discover, wifi_scan) on macOS, or extracting this one assertion into a `--lib`-visible unit test -- a larger, riskier change out of scope for a test-health fix. Recommend a follow-up issue for macOS integration-test coverage.

## Test plan

- [x] `cargo test --package pentest-tools --lib evidence_producer` -- `multiple_push_single_drain` shows `ignored`
- [x] `cargo test --package pentest-tools --lib evidence_producer -- --ignored --test-threads=1` -- passes
- [x] `cargo test --package pentest-core --test tool_integration all_tools_registered` -- passes
- [x] `cargo clippy --package pentest-core --package pentest-tools --all-targets -- -D warnings` -- clean
- [ ] macOS lane: `all_tools_registered` not run there (see Known limitation)

Closes #359
Closes #360