### PR TITLE
feat(evidence): promote web-wrapper provenance into evidence graph

### DIFF
--- a/crates/tools/src/default_creds.rs
+++ b/crates/tools/src/default_creds.rs
@@ -15,17 +15,18 @@ use crate::util::{param_str, param_u64};
 /// Default credentials testing tool
 pub struct DefaultCredsTool;
 
-/// Serialize the attempt log for the provenance `raw_response_excerpt` with
-/// every password masked.
+/// Copy the attempt log with every password masked.
 ///
-/// The excerpt reaches the published report, and `truncate_excerpt`'s redaction
-/// pass does not catch JSON-quoted `"password":"..."` pairs (its secret regex
-/// expects `password:`, not `password":`), so a successful login would otherwise
-/// publish the plaintext credential in the evidence appendix (pick#52 /
-/// pick#317). Username and status are preserved so a reviewer still sees the
-/// attempt structure.
-fn masked_attempts_excerpt(attempts: &[Value]) -> String {
-    let masked: Vec<Value> = attempts
+/// The attempt log leaves this tool in two report-/wire-bound places: the
+/// provenance `raw_response_excerpt`, and the returned `ToolResult.data`, which
+/// the connector serializes whole onto the Matrix wire (`pick_connector.rs`
+/// `ToolCompleted`). `truncate_excerpt`'s redaction pass does not catch
+/// JSON-quoted `"password":"..."` pairs (its secret regex expects `password:`,
+/// not `password":`), so a successful login would otherwise publish the
+/// plaintext credential. Username and status are preserved so a reviewer still
+/// sees the attempt structure (pick#52 / pick#317).
+fn mask_attempts(attempts: &[Value]) -> Vec<Value> {
+    attempts
         .iter()
         .map(|a| {
             let mut a = a.clone();
@@ -36,8 +37,43 @@ fn masked_attempts_excerpt(attempts: &[Value]) -> String {
             }
             a
         })
-        .collect();
-    serde_json::to_string(&masked).unwrap_or_default()
+        .collect()
+}
+
+/// Build one report-safe [`ProbeCommand`] per attempted credential.
+///
+/// The probe records the *structure* of each auth attempt so a reviewer can
+/// reproduce it, but the password is scrubbed by exact value via
+/// [`ProbeCommand::from_exact_redacting_secret`] before it can reach the
+/// published `effective_command`. This matters most for the ssh
+/// `sshpass -p '<pw>'` shape, which no `redact()` regex matches (only
+/// `-u user:pass` / `--password` are caught) — see pick#52 / pick#317.
+fn default_cred_probes(
+    service: &str,
+    credentials: &[(&str, &str)],
+    host: &str,
+    port: u16,
+) -> Vec<ProbeCommand> {
+    let template = match service.to_lowercase().as_str() {
+        "ssh" => |u: &str, p: &str, h: &str, port: u16| {
+            format!("sshpass -p '{p}' ssh -o StrictHostKeyChecking=no -p {port} {u}@{h} exit")
+        },
+        "ftp" => |u: &str, p: &str, h: &str, port: u16| {
+            format!("curl --connect-timeout 5 -u {u}:{p} ftp://{h}:{port}/")
+        },
+        _ => |u: &str, p: &str, h: &str, port: u16| {
+            format!("curl -s -o /dev/null -w '%{{http_code}}' -u {u}:{p} http://{h}:{port}/")
+        },
+    };
+
+    credentials
+        .iter()
+        .map(|(u, p)| {
+            let full = template(u, p, host, port);
+            ProbeCommand::from_exact_redacting_secret(full, p)
+                .with_description("default credential probe")
+        })
+        .collect()
 }
 
 impl DefaultCredsTool {
@@ -328,36 +364,17 @@ impl PentestTool for DefaultCredsTool {
                 tokio::time::sleep(Duration::from_millis(100)).await;
             }
 
-            // Provenance: emit one ProbeCommand per credential pair we
-            // tried. `from_exact` runs `redact()` on each command, so the
-            // `effective_command` will never contain the raw password in a
-            // published report. This is the critical property: a reviewer
-            // can see which *structure* of auth attempt we made, but the
-            // secrets stay out of the published bytes.
-            let probe_command_template = match service.to_lowercase().as_str() {
-                "ssh" => |u: &str, p: &str, h: &str, port: u16| {
-                    format!(
-                        "sshpass -p '{p}' ssh -o StrictHostKeyChecking=no -p {port} {u}@{h} exit"
-                    )
-                },
-                "ftp" => |u: &str, p: &str, h: &str, port: u16| {
-                    format!("curl --connect-timeout 5 -u {u}:{p} ftp://{h}:{port}/")
-                },
-                _ => |u: &str, p: &str, h: &str, port: u16| {
-                    format!("curl -s -o /dev/null -w '%{{http_code}}' -u {u}:{p} http://{h}:{port}/")
-                },
-            };
+            // One report-safe probe per attempted credential. The password is
+            // scrubbed by exact value inside `default_cred_probes`, so it can't
+            // reach the published `effective_command` (pick#52 / pick#317).
+            let probes = default_cred_probes(service, &credentials, &host, port);
 
-            let probes: Vec<ProbeCommand> = credentials
-                .iter()
-                .map(|(u, p)| {
-                    let full = probe_command_template(u, p, &host, port);
-                    ProbeCommand::from_exact(full)
-                        .with_description("default credential probe")
-                })
-                .collect();
-
-            let raw_excerpt = masked_attempts_excerpt(&attempts);
+            // Mask passwords once, then reuse the masked log for BOTH sinks: the
+            // provenance excerpt and the returned `data` (which the connector
+            // serializes whole onto the Matrix wire). The plaintext `attempts`
+            // never leaves this function (pick#52 / pick#317 — F4).
+            let masked_attempts = mask_attempts(&attempts);
+            let raw_excerpt = serde_json::to_string(&masked_attempts).unwrap_or_default();
             let provenance = Provenance::multi_step(
                 match service.to_lowercase().as_str() {
                     "ssh" => "sshpass+openssh",
@@ -373,7 +390,7 @@ impl PentestTool for DefaultCredsTool {
                 "host": host,
                 "port": port,
                 "service": service,
-                "attempts": attempts,
+                "attempts": masked_attempts,
                 "successful": successful,
                 "total_tested": credentials.len(),
             });
@@ -397,24 +414,62 @@ mod tests {
     use super::*;
 
     #[test]
-    fn masked_attempts_excerpt_hides_passwords_keeps_username_status() {
+    fn mask_attempts_hides_passwords_keeps_username_status() {
         let attempts = vec![
             json!({"username": "admin", "password": "s3cr3t", "status": "SUCCESS"}),
             json!({"username": "root", "password": "hunter2", "status": "FAILED"}),
         ];
 
-        let excerpt = masked_attempts_excerpt(&attempts);
+        // Serialize the masked log the same way both wire-bound sinks do (the
+        // provenance excerpt and the returned `data`).
+        let masked = serde_json::to_string(&mask_attempts(&attempts)).unwrap();
 
         assert!(
-            !excerpt.contains("s3cr3t"),
-            "plaintext password leaked into excerpt: {excerpt}"
+            !masked.contains("s3cr3t"),
+            "plaintext password leaked after masking: {masked}"
         );
         assert!(
-            !excerpt.contains("hunter2"),
-            "plaintext password leaked into excerpt: {excerpt}"
+            !masked.contains("hunter2"),
+            "plaintext password leaked after masking: {masked}"
         );
-        assert!(excerpt.contains("admin"), "username should be preserved");
-        assert!(excerpt.contains("SUCCESS"), "status should be preserved");
-        assert!(excerpt.contains("<redacted>"), "password should be masked");
+        assert!(masked.contains("admin"), "username should be preserved");
+        assert!(masked.contains("SUCCESS"), "status should be preserved");
+        assert!(masked.contains("<redacted>"), "password should be masked");
+    }
+
+    #[test]
+    fn default_cred_probes_scrub_password_from_effective_command() {
+        // Guards the production probe builder (F2). The ssh `sshpass -p '<pw>'`
+        // shape is matched by NONE of redact()'s regexes, so the builder must
+        // scrub the password by exact value; reverting it to `from_exact` turns
+        // this red (pick#52 / pick#317).
+        let ssh = default_cred_probes(
+            "ssh",
+            &[("pi", "raspberry"), ("root", "toor")],
+            "10.0.0.5",
+            22,
+        );
+        assert_eq!(ssh.len(), 2);
+        for pc in &ssh {
+            assert!(
+                !pc.effective_command.contains("raspberry")
+                    && !pc.effective_command.contains("toor"),
+                "ssh default password leaked into effective_command: {}",
+                pc.effective_command
+            );
+            assert!(
+                pc.effective_command.contains("<REDACTED>"),
+                "password position should be redacted: {}",
+                pc.effective_command
+            );
+        }
+
+        // The HTTP fallback (`-u user:pass`) must scrub too.
+        let http = default_cred_probes("http", &[("admin", "s3cr3t")], "10.0.0.5", 80);
+        assert!(
+            !http[0].effective_command.contains("s3cr3t"),
+            "http default password leaked: {}",
+            http[0].effective_command
+        );
     }
 }

--- a/crates/tools/src/default_creds.rs
+++ b/crates/tools/src/default_creds.rs
@@ -15,6 +15,31 @@ use crate::util::{param_str, param_u64};
 /// Default credentials testing tool
 pub struct DefaultCredsTool;
 
+/// Serialize the attempt log for the provenance `raw_response_excerpt` with
+/// every password masked.
+///
+/// The excerpt reaches the published report, and `truncate_excerpt`'s redaction
+/// pass does not catch JSON-quoted `"password":"..."` pairs (its secret regex
+/// expects `password:`, not `password":`), so a successful login would otherwise
+/// publish the plaintext credential in the evidence appendix (pick#52 /
+/// pick#317). Username and status are preserved so a reviewer still sees the
+/// attempt structure.
+fn masked_attempts_excerpt(attempts: &[Value]) -> String {
+    let masked: Vec<Value> = attempts
+        .iter()
+        .map(|a| {
+            let mut a = a.clone();
+            if let Some(obj) = a.as_object_mut() {
+                if obj.contains_key("password") {
+                    obj.insert("password".to_string(), json!("<redacted>"));
+                }
+            }
+            a
+        })
+        .collect();
+    serde_json::to_string(&masked).unwrap_or_default()
+}
+
 impl DefaultCredsTool {
     /// Common default credentials database
     fn get_default_credentials(service: &str) -> Vec<(&'static str, &'static str)> {
@@ -332,7 +357,7 @@ impl PentestTool for DefaultCredsTool {
                 })
                 .collect();
 
-            let raw_excerpt = serde_json::to_string(&attempts).unwrap_or_default();
+            let raw_excerpt = masked_attempts_excerpt(&attempts);
             let provenance = Provenance::multi_step(
                 match service.to_lowercase().as_str() {
                     "ssh" => "sshpass+openssh",
@@ -352,8 +377,44 @@ impl PentestTool for DefaultCredsTool {
                 "successful": successful,
                 "total_tested": credentials.len(),
             });
+            // Promote each successful default-cred login into the evidence
+            // graph (pick#52). Failed attempts produce no node, and the working
+            // password is withheld from every node field.
+            for node in
+                crate::evidence_producer::evidence_from_default_creds(&data, provenance.clone())
+            {
+                let _ = crate::evidence_producer::push_evidence(node);
+            }
+
             Ok((data, provenance))
         })
         .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn masked_attempts_excerpt_hides_passwords_keeps_username_status() {
+        let attempts = vec![
+            json!({"username": "admin", "password": "s3cr3t", "status": "SUCCESS"}),
+            json!({"username": "root", "password": "hunter2", "status": "FAILED"}),
+        ];
+
+        let excerpt = masked_attempts_excerpt(&attempts);
+
+        assert!(
+            !excerpt.contains("s3cr3t"),
+            "plaintext password leaked into excerpt: {excerpt}"
+        );
+        assert!(
+            !excerpt.contains("hunter2"),
+            "plaintext password leaked into excerpt: {excerpt}"
+        );
+        assert!(excerpt.contains("admin"), "username should be preserved");
+        assert!(excerpt.contains("SUCCESS"), "status should be preserved");
+        assert!(excerpt.contains("<redacted>"), "password should be masked");
     }
 }

--- a/crates/tools/src/evidence_producer.rs
+++ b/crates/tools/src/evidence_producer.rs
@@ -402,6 +402,210 @@ pub fn evidence_from_whatweb(
     nodes
 }
 
+/// A tool-agnostic finding, normalized into the shape an [`EvidenceNode`]
+/// needs. Wrappers map their own result JSON into these and hand them to
+/// [`evidence_from_generic`], which owns the node construction the
+/// tool-specific builders would otherwise each duplicate.
+pub struct GenericFinding {
+    /// Node type tag, e.g. `"web_vuln"`, `"default_credentials"`.
+    pub node_type: String,
+    /// Short human-readable finding title.
+    pub title: String,
+    /// Fuller description of what was observed.
+    pub description: String,
+    /// The affected target (host, `host:port`, or URL).
+    pub target: String,
+    /// Severity assessed by the producing tool.
+    pub severity: Severity,
+    /// Why this warrants validation / attention.
+    pub rationale: String,
+    /// Structured extras copied into the node's metadata map. Callers MUST
+    /// NOT place secrets here — node metadata can reach a published report.
+    pub metadata: Vec<(String, Value)>,
+}
+
+/// Build evidence nodes from normalized findings, attaching the same
+/// `provenance` to each.
+///
+/// This is the shared core behind the per-tool `evidence_from_*` builders: it
+/// owns the `EvidenceNode::new` + `with_provenance` + metadata boilerplate so
+/// each tool builder only has to map its own result shape into
+/// [`GenericFinding`]s (pick#52 coverage promotion).
+pub fn evidence_from_generic(
+    findings: Vec<GenericFinding>,
+    provenance: Provenance,
+) -> Vec<EvidenceNode> {
+    findings
+        .into_iter()
+        .map(|f| {
+            let mut node = EvidenceNode::new(
+                Uuid::new_v4().to_string(),
+                f.node_type,
+                f.title,
+                f.description,
+                f.target,
+                f.severity,
+                f.rationale,
+            )
+            .with_provenance(provenance.clone());
+            for (k, v) in f.metadata {
+                node.metadata.insert(k, v);
+            }
+            node
+        })
+        .collect()
+}
+
+/// Map a tool's uppercase severity label (`CRITICAL`/`HIGH`/`MEDIUM`/`LOW`)
+/// to a [`Severity`]. Anything unrecognized (including `INFO`) becomes
+/// [`Severity::Info`], the safe low-signal default.
+fn severity_from_label(label: &str) -> Severity {
+    match label.to_ascii_uppercase().as_str() {
+        "CRITICAL" => Severity::Critical,
+        "HIGH" => Severity::High,
+        "MEDIUM" => Severity::Medium,
+        "LOW" => Severity::Low,
+        _ => Severity::Info,
+    }
+}
+
+/// Create evidence nodes from `web_vuln_scan` results.
+///
+/// Emits one node per entry in `data["findings"]`, carrying the finding's
+/// `type` in the title and its `details` as the description. The tool's
+/// per-finding `severity` label drives the node severity.
+pub fn evidence_from_web_vuln_scan(
+    data: &Value,
+    target: &str,
+    provenance: Provenance,
+) -> Vec<EvidenceNode> {
+    let Some(findings) = data["findings"].as_array() else {
+        return Vec::new();
+    };
+
+    let generic = findings
+        .iter()
+        .map(|f| {
+            let finding_type = f["type"].as_str().unwrap_or("WEB_FINDING");
+            let details = f["details"].as_str().unwrap_or("");
+            let severity = severity_from_label(f["severity"].as_str().unwrap_or("INFO"));
+
+            let title = format!("{} on {}", finding_type, target);
+            let description = if details.is_empty() {
+                format!(
+                    "Web vulnerability scan flagged {} on {}.",
+                    finding_type, target
+                )
+            } else {
+                details.to_string()
+            };
+
+            let mut metadata = vec![("finding_type".to_string(), finding_type.into())];
+            if let Some(path) = f["path"].as_str() {
+                metadata.push(("path".to_string(), path.into()));
+            }
+            if let Some(code) = f["status_code"].as_u64() {
+                metadata.push(("status_code".to_string(), code.into()));
+            }
+
+            GenericFinding {
+                node_type: "web_vuln".to_string(),
+                title,
+                description,
+                target: target.to_string(),
+                severity,
+                rationale:
+                    "Web-application finding surfaced by an automated scan; validate exploitability and impact before reporting."
+                        .to_string(),
+                metadata,
+            }
+        })
+        .collect();
+
+    evidence_from_generic(generic, provenance)
+}
+
+/// Create evidence nodes from `default_creds` results.
+///
+/// Emits one node per **successful** login (`status == "SUCCESS"`); failed and
+/// errored attempts are not findings. The affected target is `host:port`.
+///
+/// # Security
+/// The attempted password is never copied into the node (title, description, or
+/// metadata). A successful default credential is a High-severity finding that
+/// reaches the customer report; the working secret must stay out of the
+/// published bytes (pick#52 / pick#317). The reproducible probe lives in the
+/// already-redacted `provenance.probe_commands`.
+pub fn evidence_from_default_creds(data: &Value, provenance: Provenance) -> Vec<EvidenceNode> {
+    let host = data["host"].as_str().unwrap_or("unknown");
+    let port = data["port"].as_u64().unwrap_or(0);
+    let service = data["service"].as_str().unwrap_or("unknown");
+    let target = format!("{host}:{port}");
+
+    let Some(attempts) = data["attempts"].as_array() else {
+        return Vec::new();
+    };
+
+    let generic = attempts
+        .iter()
+        .filter(|a| a["status"].as_str() == Some("SUCCESS"))
+        .map(|a| {
+            let username = a["username"].as_str().unwrap_or("unknown");
+            GenericFinding {
+                node_type: "default_credentials".to_string(),
+                title: format!("Default credentials accepted: {username} on {target} ({service})"),
+                description: format!(
+                    "A default/weak credential for user '{username}' was accepted by the \
+                     {service} service on {target}. The password value is withheld from this \
+                     report; see the redacted probe command for the reproduction structure."
+                ),
+                target: target.clone(),
+                severity: Severity::High,
+                rationale:
+                    "Accepting default credentials grants unauthorized access; rotate the credential and disable defaults."
+                        .to_string(),
+                metadata: vec![
+                    ("username".to_string(), username.into()),
+                    ("service".to_string(), service.into()),
+                    ("port".to_string(), port.into()),
+                ],
+            }
+        })
+        .collect();
+
+    evidence_from_generic(generic, provenance)
+}
+
+/// Create an evidence node from a single `http_request` response.
+///
+/// http_request is a primitive the agent calls frequently, not a
+/// finding-producer, so this emits exactly one Info-severity node capturing the
+/// response line (method, status, final URL). Info lets the Validator downgrade
+/// or drop it while keeping the reproducible curl (in `provenance`) available to
+/// ground any finding the agent builds on top of this request.
+pub fn evidence_from_http_request(data: &Value, provenance: Provenance) -> Vec<EvidenceNode> {
+    let url = data["url"].as_str().unwrap_or("unknown");
+    let method = data["method"].as_str().unwrap_or("GET");
+    let status = data["status"].as_u64().unwrap_or(0);
+
+    let finding = GenericFinding {
+        node_type: "http_response".to_string(),
+        title: format!("HTTP {method} {status} {url}"),
+        description: format!("HTTP {method} request to {url} returned status {status}."),
+        target: url.to_string(),
+        severity: Severity::Info,
+        rationale:
+            "Raw HTTP response captured for grounding; the Validator adjudicates whether it supports a finding."
+                .to_string(),
+        metadata: vec![
+            ("method".to_string(), method.into()),
+            ("status_code".to_string(), status.into()),
+        ],
+    };
+
+    evidence_from_generic(vec![finding], provenance)
+}
+
 /// Assess severity of an open port based on port number and service.
 fn assess_port_severity(port: u64, service: &str) -> Severity {
     // Sensitive/high-risk ports
@@ -835,5 +1039,109 @@ mod tests {
         assert!(contains_vulnerable_version("OpenSSH_5.3"));
         assert!(!contains_vulnerable_version("Apache/2.4.52"));
         assert!(!contains_vulnerable_version("nginx/1.21.1"));
+    }
+
+    fn test_provenance(tool: &str) -> Provenance {
+        Provenance::new(
+            tool.to_string(),
+            "1.0".to_string(),
+            pentest_core::provenance::ProbeCommand::from_exact("echo test"),
+            "test output",
+        )
+    }
+
+    #[test]
+    fn test_evidence_from_web_vuln_scan_one_node_per_finding() {
+        let data = json!({
+            "url": "http://target.example",
+            "findings": [
+                {
+                    "type": "ADMIN_PANEL_EXPOSED",
+                    "severity": "MEDIUM",
+                    "path": "/admin",
+                    "status_code": 200,
+                    "details": "Admin panel accessible at http://target.example/admin"
+                },
+                {
+                    "type": "INFORMATION_DISCLOSURE",
+                    "severity": "HIGH",
+                    "path": "/.env",
+                    "status_code": 200,
+                    "details": "Sensitive file exposed"
+                }
+            ]
+        });
+
+        let nodes = evidence_from_web_vuln_scan(
+            &data,
+            "http://target.example",
+            test_provenance("web_vuln_scan"),
+        );
+
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(nodes[0].node_type, "web_vuln");
+        assert_eq!(nodes[0].current_severity(), Severity::Medium);
+        assert!(nodes[0].title.contains("ADMIN_PANEL_EXPOSED"));
+        assert_eq!(nodes[0].affected_target, "http://target.example");
+        assert!(nodes[0].provenance.is_some());
+        assert_eq!(nodes[1].current_severity(), Severity::High);
+    }
+
+    #[test]
+    fn test_evidence_from_default_creds_only_successful_and_no_password() {
+        let data = json!({
+            "host": "10.0.0.5",
+            "port": 22,
+            "service": "ssh",
+            "attempts": [
+                {"username": "root", "password": "hunter2", "status": "FAILED"},
+                {"username": "admin", "password": "s3cr3t", "status": "SUCCESS"}
+            ],
+            "successful": 1,
+            "total_tested": 2
+        });
+
+        let nodes = evidence_from_default_creds(&data, test_provenance("sshpass+openssh"));
+
+        // Only the successful login is a finding; failed attempts are not.
+        assert_eq!(nodes.len(), 1);
+        let node = &nodes[0];
+        assert_eq!(node.node_type, "default_credentials");
+        assert_eq!(node.current_severity(), Severity::High);
+        assert!(node.title.contains("admin"));
+        assert_eq!(node.affected_target, "10.0.0.5:22");
+        assert!(node.provenance.is_some());
+
+        // The plaintext password must never appear in any published node field.
+        let serialized = serde_json::to_string(node).unwrap();
+        assert!(
+            !serialized.contains("s3cr3t"),
+            "plaintext password leaked into evidence node: {serialized}"
+        );
+    }
+
+    #[test]
+    fn test_evidence_from_http_request_one_info_node() {
+        let data = json!({
+            "url": "http://target.example/login",
+            "method": "GET",
+            "status": 200,
+            "ok": true,
+            "headers": {"server": "nginx"},
+            "body": "hello",
+            "body_bytes": 5,
+            "body_truncated": false
+        });
+
+        let nodes = evidence_from_http_request(&data, test_provenance("http_request"));
+
+        assert_eq!(nodes.len(), 1);
+        let node = &nodes[0];
+        assert_eq!(node.node_type, "http_response");
+        assert_eq!(node.current_severity(), Severity::Info);
+        assert!(node.title.contains("200"));
+        assert!(node.title.contains("GET"));
+        assert_eq!(node.affected_target, "http://target.example/login");
+        assert!(node.provenance.is_some());
     }
 }

--- a/crates/tools/src/evidence_producer.rs
+++ b/crates/tools/src/evidence_producer.rs
@@ -584,7 +584,13 @@ pub fn evidence_from_default_creds(data: &Value, provenance: Provenance) -> Vec<
 /// or drop it while keeping the reproducible curl (in `provenance`) available to
 /// ground any finding the agent builds on top of this request.
 pub fn evidence_from_http_request(data: &Value, provenance: Provenance) -> Vec<EvidenceNode> {
-    let url = data["url"].as_str().unwrap_or("unknown");
+    // Redact secrets in the URL (query-string tokens like `?api_key=...`, HTTP
+    // userinfo `user:pass@`) BEFORE it lands in the node's title/description/
+    // target. These fields reach the published report, and the sibling
+    // provenance curl for this same URL is already redacted — without this the
+    // node fields would be strictly less protected than their own provenance
+    // (pick#52 / pick#317).
+    let url = pentest_core::provenance::redact(data["url"].as_str().unwrap_or("unknown"));
     let method = data["method"].as_str().unwrap_or("GET");
     let status = data["status"].as_u64().unwrap_or(0);
 
@@ -592,7 +598,7 @@ pub fn evidence_from_http_request(data: &Value, provenance: Provenance) -> Vec<E
         node_type: "http_response".to_string(),
         title: format!("HTTP {method} {status} {url}"),
         description: format!("HTTP {method} request to {url} returned status {status}."),
-        target: url.to_string(),
+        target: url.clone(),
         severity: Severity::Info,
         rationale:
             "Raw HTTP response captured for grounding; the Validator adjudicates whether it supports a finding."
@@ -1101,7 +1107,19 @@ mod tests {
             "total_tested": 2
         });
 
-        let nodes = evidence_from_default_creds(&data, test_provenance("sshpass+openssh"));
+        // Build the provenance the way default_creds's execute() does for a
+        // successful ssh login: one probe per attempt embedding the real
+        // password, scrubbed by exact value. Using a dummy `test_provenance`
+        // here (the old version of this test did) never exercises the real
+        // `sshpass -p '<pw>'` path, so it could not catch a password leaking
+        // through `effective_command`. Reverting the builder to plain
+        // `from_exact` turns this test red.
+        let probe = pentest_core::provenance::ProbeCommand::from_exact_redacting_secret(
+            "sshpass -p 's3cr3t' ssh -o StrictHostKeyChecking=no -p 22 admin@10.0.0.5 exit",
+            "s3cr3t",
+        );
+        let provenance = Provenance::multi_step("sshpass+openssh", "1.0", vec![probe], "");
+        let nodes = evidence_from_default_creds(&data, provenance);
 
         // Only the successful login is a finding; failed attempts are not.
         assert_eq!(nodes.len(), 1);
@@ -1112,11 +1130,41 @@ mod tests {
         assert_eq!(node.affected_target, "10.0.0.5:22");
         assert!(node.provenance.is_some());
 
-        // The plaintext password must never appear in any published node field.
+        // The plaintext password must never appear in ANY published byte of the
+        // node — including the attached provenance's `effective_command`.
         let serialized = serde_json::to_string(node).unwrap();
         assert!(
             !serialized.contains("s3cr3t"),
             "plaintext password leaked into evidence node: {serialized}"
+        );
+    }
+
+    #[test]
+    fn test_evidence_from_http_request_redacts_url_secret() {
+        // A query-string secret in the request URL must not survive into the
+        // node's published fields (title/description/target). The sibling
+        // provenance curl for the same URL is already redacted; this guards the
+        // node fields against being the weaker path (pick#52 / pick#317).
+        let data = json!({
+            "url": "http://target.example/api?api_key=SECRET123&x=1",
+            "method": "GET",
+            "status": 200
+        });
+
+        let nodes = evidence_from_http_request(&data, test_provenance("http_request"));
+        assert_eq!(nodes.len(), 1);
+        let node = &nodes[0];
+
+        for field in [&node.title, &node.description, &node.affected_target] {
+            assert!(
+                !field.contains("SECRET123"),
+                "url secret leaked into a published node field: {field}"
+            );
+        }
+        assert!(
+            node.title.contains("<REDACTED>"),
+            "url should be redacted in the node title: {}",
+            node.title
         );
     }
 

--- a/crates/tools/src/evidence_producer.rs
+++ b/crates/tools/src/evidence_producer.rs
@@ -483,6 +483,14 @@ pub fn evidence_from_web_vuln_scan(
         return Vec::new();
     };
 
+    // Redact target-supplied secrets (userinfo in the scanned base URL, query
+    // tokens embedded in a finding's `details`) BEFORE they reach the node's
+    // published title/description/target. The sibling web_vuln_scan provenance
+    // curls for this scan are already redacted via `from_exact`; without this
+    // the node fields would be the weaker path — the same F1-class asymmetry
+    // fixed for http_request (pick#52 / pick#317).
+    let safe_target = pentest_core::provenance::redact(target);
+
     let generic = findings
         .iter()
         .map(|f| {
@@ -490,14 +498,14 @@ pub fn evidence_from_web_vuln_scan(
             let details = f["details"].as_str().unwrap_or("");
             let severity = severity_from_label(f["severity"].as_str().unwrap_or("INFO"));
 
-            let title = format!("{} on {}", finding_type, target);
+            let title = format!("{} on {}", finding_type, safe_target);
             let description = if details.is_empty() {
                 format!(
                     "Web vulnerability scan flagged {} on {}.",
-                    finding_type, target
+                    finding_type, safe_target
                 )
             } else {
-                details.to_string()
+                pentest_core::provenance::redact(details)
             };
 
             let mut metadata = vec![("finding_type".to_string(), finding_type.into())];
@@ -512,7 +520,7 @@ pub fn evidence_from_web_vuln_scan(
                 node_type: "web_vuln".to_string(),
                 title,
                 description,
-                target: target.to_string(),
+                target: safe_target.clone(),
                 severity,
                 rationale:
                     "Web-application finding surfaced by an automated scan; validate exploitability and impact before reporting."
@@ -1166,6 +1174,37 @@ mod tests {
             "url should be redacted in the node title: {}",
             node.title
         );
+    }
+
+    #[test]
+    fn test_evidence_from_web_vuln_scan_redacts_url_secret() {
+        // Same F1 class as http_request: a target-supplied secret (userinfo in
+        // the scanned base URL, or a query token embedded in a finding's
+        // `details`) must not survive unredacted into the node's published
+        // title/description/target. The sibling web_vuln_scan provenance curls
+        // are already redacted via `from_exact` (pick#52 / pick#317).
+        let data = json!({
+            "url": "http://target.example",
+            "findings": [
+                {"type": "ADMIN_PANEL_EXPOSED", "severity": "MEDIUM", "path": "/admin",
+                 "details": "Admin panel accessible at http://target.example/admin?api_key=SECRET123"}
+            ]
+        });
+
+        let nodes = evidence_from_web_vuln_scan(
+            &data,
+            "http://user:p3wd@target.example",
+            test_provenance("web_vuln_scan"),
+        );
+        assert_eq!(nodes.len(), 1);
+        let n = &nodes[0];
+
+        for field in [&n.title, &n.description, &n.affected_target] {
+            assert!(
+                !field.contains("SECRET123") && !field.contains("p3wd"),
+                "target-supplied secret leaked into a published node field: {field}"
+            );
+        }
     }
 
     #[test]

--- a/crates/tools/src/http_request.rs
+++ b/crates/tools/src/http_request.rs
@@ -194,6 +194,15 @@ impl PentestTool for HttpRequestTool {
                 "body_truncated": truncated,
             });
 
+            // Promote the response as a grounding anchor (pick#52). http_request
+            // is a primitive, so this is a single Info node the Validator can
+            // drop; its value is carrying the reproducible curl in provenance.
+            for node in
+                crate::evidence_producer::evidence_from_http_request(&data, provenance.clone())
+            {
+                let _ = crate::evidence_producer::push_evidence(node);
+            }
+
             Ok((data, provenance))
         })
         .await

--- a/crates/tools/src/web_vuln_scan.rs
+++ b/crates/tools/src/web_vuln_scan.rs
@@ -369,6 +369,16 @@ impl PentestTool for WebVulnScanTool {
                     "low": low,
                 },
             });
+            // Promote each finding into the evidence graph so the Validator /
+            // Report Agent can adjudicate and ground it (pick#52).
+            for node in crate::evidence_producer::evidence_from_web_vuln_scan(
+                &data,
+                base_url,
+                provenance.clone(),
+            ) {
+                let _ = crate::evidence_producer::push_evidence(node);
+            }
+
             Ok((data, provenance))
         })
         .await

--- a/crates/ui/tests/evidence_pipeline.rs
+++ b/crates/ui/tests/evidence_pipeline.rs
@@ -28,7 +28,10 @@ use pentest_core::orchestrator::{
 };
 use pentest_core::provenance::{ProbeCommand, Provenance};
 use pentest_core::tools::{PentestTool, ToolContext, ToolOutcome};
-use pentest_tools::evidence_producer::{evidence_from_nmap, push_evidence};
+use pentest_tools::evidence_producer::{
+    evidence_from_default_creds, evidence_from_http_request, evidence_from_nmap,
+    evidence_from_web_vuln_scan, push_evidence,
+};
 use pentest_tools::ExecuteCommandTool;
 use pentest_ui::session;
 use serde_json::{json, Value};
@@ -414,6 +417,127 @@ async fn failed_tool_is_flagged_and_ungrounded_finding_cannot_reach_report() {
         }
         other => panic!("gate must fail closed on an ungrounded finding, got {other:?}"),
     }
+
+    session::clear_evidence();
+}
+
+/// pick#52 coverage promotion: the three web wrappers (`web_vuln_scan`,
+/// `default_creds`, `http_request`) build a full `Provenance` today but never
+/// promoted it into the evidence graph, so their findings could never reach a
+/// report. This exercises the exact builders their `execute()` tails now call,
+/// proving each one's evidence travels tool-buffer -> graph -> gate -> manifest,
+/// the same production path the nmap test above guards.
+#[test]
+fn web_wrapper_findings_reach_the_report_after_validation() {
+    let _guard = serial();
+    session::clear_evidence();
+
+    let mut node_ids = Vec::new();
+
+    // web_vuln_scan: one node per finding.
+    let wvs_data = json!({
+        "url": "http://10.0.0.1",
+        "findings": [
+            {"type": "ADMIN_PANEL_EXPOSED", "severity": "MEDIUM", "path": "/admin",
+             "status_code": 200, "details": "Admin panel accessible at http://10.0.0.1/admin"},
+            {"type": "NO_HTTPS_REDIRECT", "severity": "MEDIUM",
+             "details": "Site does not redirect HTTP to HTTPS"}
+        ]
+    });
+    let wvs_prov = Provenance::new(
+        "web_vuln_scan",
+        "0.6",
+        ProbeCommand::from_exact("curl -sI http://10.0.0.1/admin"),
+        "[{\"type\":\"ADMIN_PANEL_EXPOSED\"}]",
+    );
+    for node in evidence_from_web_vuln_scan(&wvs_data, "http://10.0.0.1", wvs_prov) {
+        node_ids.push(node.id.clone());
+        push_evidence(node).expect("tool buffer should accept the web_vuln_scan finding");
+    }
+
+    // default_creds: one node per successful login (the failed attempt yields none).
+    let dc_data = json!({
+        "host": "10.0.0.1",
+        "port": 22,
+        "service": "ssh",
+        "attempts": [
+            {"username": "root", "password": "<redacted>", "status": "FAILED"},
+            {"username": "admin", "password": "<redacted>", "status": "SUCCESS"}
+        ],
+        "successful": 1,
+        "total_tested": 2
+    });
+    let dc_prov = Provenance::new(
+        "sshpass+openssh",
+        "0.6",
+        ProbeCommand::from_exact("sshpass -p '<redacted>' ssh admin@10.0.0.1 exit"),
+        "[{\"username\":\"admin\",\"password\":\"<redacted>\",\"status\":\"SUCCESS\"}]",
+    );
+    for node in evidence_from_default_creds(&dc_data, dc_prov) {
+        node_ids.push(node.id.clone());
+        push_evidence(node).expect("tool buffer should accept the default_creds finding");
+    }
+
+    // http_request: one Info node per response.
+    let hr_data = json!({
+        "url": "http://10.0.0.1/login",
+        "method": "GET",
+        "status": 200,
+        "ok": true,
+        "headers": {"server": "nginx"},
+        "body": "hi",
+        "body_bytes": 2,
+        "body_truncated": false
+    });
+    let hr_prov = Provenance::new(
+        "http_request",
+        "0.6",
+        ProbeCommand::from_exact("curl -sS -k -X GET http://10.0.0.1/login"),
+        "hi",
+    );
+    for node in evidence_from_http_request(&hr_data, hr_prov) {
+        node_ids.push(node.id.clone());
+        push_evidence(node).expect("tool buffer should accept the http_request node");
+    }
+
+    assert_eq!(
+        node_ids.len(),
+        4,
+        "2 web_vuln + 1 default_creds + 1 http_request"
+    );
+
+    // Drain into the graph and confirm the gate sees every node as pending.
+    let forwarded = session::drain_tool_evidence_into_graph();
+    assert_eq!(forwarded, 4, "all four nodes should reach the graph");
+
+    let snapshot = session::evidence_snapshot();
+    match gate_for_report(&snapshot, engagement()) {
+        Err(GateError::PendingNodes { pending_ids }) => {
+            for id in &node_ids {
+                assert!(
+                    pending_ids.contains(id),
+                    "node {id} must block the gate before validation"
+                );
+            }
+        }
+        other => panic!("expected PendingNodes before validation, got {other:?}"),
+    }
+
+    // Validator confirms all; the gate then accepts and every finding lands.
+    let verdicts =
+        parse_validator_verdicts(&confirm_all(&node_ids)).expect("verdict reply should parse");
+    let apply = session::apply_validator_verdicts(&verdicts);
+    assert_eq!(apply.applied, 4);
+    assert!(apply.is_fully_adjudicated());
+
+    let snapshot = session::evidence_snapshot();
+    let manifest = gate_for_report(&snapshot, engagement())
+        .expect("gate should accept a fully-adjudicated graph");
+    assert_eq!(
+        manifest.findings.len(),
+        4,
+        "every web-wrapper finding must reach the report manifest"
+    );
 
     session::clear_evidence();
 }


### PR DESCRIPTION
## Summary

- Wires `web_vuln_scan`, `default_creds`, and `http_request` to promote their findings into the evidence graph. Each already built a full `Provenance` but never pushed it, so their findings could never reach a report (among the tool wrappers, only `nmap`/`whatweb`/`service_banner` promoted evidence beforehand; the `webwright` browser path has its own). Closes pick#52 **Gap A** for the three web wrappers - 3 of ~10; `port_scan`/`execute_command` and the external-subprocess wrappers (`zap`/`metasploit`/AD) follow in later PRs.
- Adds a shared `evidence_from_generic` builder plus per-wrapper adapters (`evidence_from_web_vuln_scan` / `_default_creds` / `_http_request`), so the `EvidenceNode` construction boilerplate lives in one place and each adapter only maps its own result shape.
- `default_creds` emits a node only per **successful** login (High severity); failed/errored attempts are not findings, and the working password is withheld from every node field.
- **Security fix folded in:** wiring `default_creds` evidence would otherwise carry a plaintext credential into the published report. `truncate_excerpt`'s redaction does not match JSON-quoted `"password":"..."` pairs (its secret regex expects `password:`, not `password":`), so passwords are now masked before reaching `raw_response_excerpt` (pick#52 / pick#317).
- `http_request` emits one Info node per response as a grounding anchor for its reproducible curl; the Validator can downgrade or drop it. (Trade-off: on a busy engagement this adds Info-node volume to the graph - accepted deliberately over adding classification logic to a primitive.)
- **Follow-up hardening (`ec7b129`):** closes two more report-bound secret sinks the first commit's redaction missed. `http_request` now runs the request URL through `redact()` before it fills the node `title`/`description`/`target`, so a `?api_key=...` query secret or `user:pass@` userinfo no longer reaches the report (the sibling provenance curl was already redacted). `default_creds` builds its probes via `from_exact_redacting_secret`, so the accepted SSH default password no longer survives in `effective_command` (the `sshpass -p '<pw>'` shape matches no `redact()` pattern), and the returned `data` attempts log is password-masked too, since the connector serializes it whole onto the Matrix wire.

## Test plan

- [x] `cargo test -p pentest-tools --lib` - unit tests for all three builders plus guards that the SSH probe, the returned `data`, and an `?api_key=` URL never leak a secret into a node field, excerpt, or `effective_command` (each guard-checked to go red when its fix is reverted). 407 passed.
- [x] `cargo test -p pentest-ui --test evidence_pipeline` - new `web_wrapper_findings_reach_the_report_after_validation` proves all three builders flow tool -> buffer -> graph -> gate -> report manifest; existing 4 pipeline tests still green.
- [x] `cargo clippy` on `pentest-tools` and `pentest-ui` with `-D warnings` (CI feature set `pentest-platform/desktop-pcap`) - clean.
- [x] `cargo fmt --all -- --check` - clean.
- Not run: live/network exercise of each wrapper's `execute()` tail (the push happens against a real target). The `execute()` tail is the mechanical mirror of the shipped `nmap.rs` wiring; builder correctness and the buffer->report flow are covered by the unit + integration tests above.
