### PR TITLE
fix(tools): re-register autopwn_detect and autopwn_network_plan

### DIFF
--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -114,9 +114,11 @@ pub fn create_tool_registry() -> ToolRegistry {
     // WiFi tools
     registry.register(WifiScanTool);
     registry.register(WifiScanDetailedTool);
+    registry.register(AutoPwnOrchestratorTool); // Hardware detection + strategy (autopwn_detect)
     registry.register(AutoPwnPlanTool);
     registry.register(AutoPwnCaptureTool);
     registry.register(AutoPwnCrackTool);
+    registry.register(AutoPwnNetworkPlanTool); // Network-mode attack planning
 
     // Vulnerability assessment
     registry.register(ServiceBannerTool);

--- a/crates/tools/tests/tools_registration_test.rs
+++ b/crates/tools/tests/tools_registration_test.rs
@@ -1,0 +1,47 @@
+//! Registration guards: tools that must (or must not) be in the runtime registry.
+//!
+//! `all_tools_registered` (crates/core) checks registry -> capabilities, and the
+//! `tools_doc_sync` guard checks registry -> docs. Neither catches a tool whose
+//! `impl PentestTool` exists but whose `registry.register(...)` line was dropped,
+//! for example silently lost in a merge resolution. These tests pin the two
+//! known cases so the regression cannot recur unnoticed.
+
+use pentest_tools::create_tool_registry;
+
+/// `autopwn_detect` and `autopwn_network_plan` were registered when introduced,
+/// then silently lost their `register()` lines in the 3-way merge f280c01
+/// (pick#406). A shipped dashboard quick-action prompt directs the agent at
+/// `autopwn_network_plan`, so leaving them unregistered is a live unknown-tool
+/// bug, not just dead code. Guard against the regression recurring.
+#[test]
+fn autopwn_orchestration_tools_are_registered() {
+    let registry = create_tool_registry();
+    let names = registry.names();
+    for tool in ["autopwn_detect", "autopwn_network_plan"] {
+        assert!(
+            names.contains(&tool),
+            "tool '{tool}' is implemented but not registered in create_tool_registry() \
+             (pick#406) - its register() line was likely dropped in a merge again. \
+             Registered: {names:?}"
+        );
+    }
+}
+
+/// `credential_harvest` and `lateral_movement` are implemented but deliberately
+/// NOT registered, pending a security decision (pick#405): credential_harvest
+/// harvests the operator's own host credentials as written, and lateral_movement
+/// is an auto-Pass-the-Hash orchestrator. This is a tripwire, not an oversight -
+/// if you register either, resolve pick#405 first (rework/scope it) and remove
+/// the corresponding entry here.
+#[test]
+fn security_gated_tools_remain_unregistered() {
+    let registry = create_tool_registry();
+    let names = registry.names();
+    for tool in ["credential_harvest", "lateral_movement"] {
+        assert!(
+            !names.contains(&tool),
+            "tool '{tool}' is registered, but it is intentionally gated pending a security \
+             decision (pick#405). Resolve that issue before wiring it up, then update this test."
+        );
+    }
+}

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -76,9 +76,11 @@ reports from `name()` - the string an operator or the model invokes. See
 
 | Tool | Type | Description | Requires Root |
 |------|------|-------------|---------------|
+| `autopwn_detect` | Native | Detect available hardware and recommend the best autopwn strategy (WiFi vs Network) | No |
 | `autopwn_plan` | Native | Generate attack plan for WiFi target | Yes |
 | `autopwn_capture` | Native | Capture WPA handshakes | Yes |
 | `autopwn_crack` | Native | Crack captured handshakes | Yes |
+| `autopwn_network_plan` | Native | Plan a network-based penetration test attack sequence (discovery, scanning, exploitation) | No |
 | `aircrack-ng` | External | WEP/WPA/WPA2 cracking suite | Yes |
 | `bettercap` | External | Man-in-the-middle attack framework | Yes |
 | `responder` | External | LLMNR/NBT-NS/MDNS poisoning | Yes |


### PR DESCRIPTION
## Summary

- Re-registers `autopwn_detect` (`AutoPwnOrchestratorTool`) and `autopwn_network_plan` (`AutoPwnNetworkPlanTool`) in `create_tool_registry()`. Both are complete implementations whose `register()` lines were silently dropped in merge `f280c01`; only their `pub use` imports survived.
- Re-adds their two `docs/TOOLS.md` rows, which the `tools_doc_sync` guard from #403 now requires once they are registered.
- Adds `crates/tools/tests/tools_registration_test.rs` to guard against this class of silent un-registration recurring.

Stacked on #403 (`docs/tools-catalog-drift-362`); base should be retargeted to `main` once #403 merges. Closes #406.

## Why (root cause + live symptom)

`autopwn_detect` (`9285b02`) and `autopwn_network_plan` (`369dc11`) were registered when introduced, then lost their `registry.register(...)` lines in the 3-way merge `f280c01` ("Merge main into toolchain branch - resolve conflicts by keeping all tools"), which unioned the imports but dropped the register calls with no conflict marker. `git log -S` on `lib.rs` misses it because pickaxe skips merge diffs.

Live symptom (Lens 5 consumer trace): `crates/ui/src/components/dashboard.rs:120` ships an "AutoPwn" quick-action whose prompt tells the agent to *"Plan a full network penetration test (autopwn_network_plan)"*. With the tool unregistered, the agent is told to call a tool that does not exist. Re-registering resolves it.

## Guard design

`tools_registration_test` pins the two known cases the existing guards miss:

- `all_tools_registered` (crates/core) checks registry -> capabilities; `tools_doc_sync` (#403) checks registry -> docs. Neither catches an `impl PentestTool` whose `register()` line was dropped.
- `autopwn_orchestration_tools_are_registered` asserts both autopwn tools are present (regression guard).
- `security_gated_tools_remain_unregistered` asserts `credential_harvest` and `lateral_movement` stay unregistered, pending the security decision in #405 - a deliberate tripwire so they are not wired up without resolving that issue first.

Residual (honest): this pins named tools, not "every impl is registered." A general guard would need source parsing or a macro-based registry; that is the over-broad `impl PentestTool`-count approach #403 deliberately avoided. Out of scope here.

## Test plan

- [ ] `cargo test -p pentest-tools --test tools_registration_test` passes (autopwn registered; credential_harvest/lateral_movement still gated).
- [ ] `cargo test -p pentest-tools --test tools_doc_sync_test` still passes (rows added for the newly registered tools).
- [ ] Neutered check: deleting one `register()` line turns `autopwn_orchestration_tools_are_registered` red.
- [ ] `cargo fmt --all --check` and `cargo clippy -p pentest-tools --all-targets -- -D warnings` clean.
- [ ] Runs in the required `cargo test --workspace` Linux lane (plain `#[test]`, no feature gate).
