### PR TITLE
fix: reconcile sandbox switches, gate custom tool installers on sandbox state, surface sandbox chip in UI (#244)

### DIFF
--- a/crates/platform/src/desktop/command.rs
+++ b/crates/platform/src/desktop/command.rs
@@ -53,6 +53,9 @@ fn init_sandbox_from_env() {
 /// variable permanently disabled the sandbox — the env setting always wins.
 pub fn set_use_sandbox(use_sandbox: bool) {
     // Ensure the env has been read before we check DISABLED_BY_ENV.
+    // `init_sandbox_from_env` is backed by `std::sync::Once`, so after the
+    // first call this is a single atomic load — cheap enough for every
+    // UI-shell-mode toggle.
     init_sandbox_from_env();
 
     if DISABLED_BY_ENV.load(Ordering::SeqCst) {

--- a/crates/platform/src/desktop/command.rs
+++ b/crates/platform/src/desktop/command.rs
@@ -19,7 +19,16 @@ use tokio::time::timeout;
 /// Can be disabled via DISABLE_SANDBOX=true environment variable.
 static USE_SANDBOX: AtomicBool = AtomicBool::new(true);
 
-/// Initialize sandbox state from environment on first access
+/// Whether the sandbox was *permanently* disabled by the `DISABLE_SANDBOX`
+/// environment variable. When `true`, [`set_use_sandbox`] becomes a no-op so
+/// the env setting cannot be overridden by the UI shell-mode toggle.
+static DISABLED_BY_ENV: AtomicBool = AtomicBool::new(false);
+
+/// Initialize sandbox state from environment on first access.
+///
+/// If `DISABLE_SANDBOX=true` (or `=1`) is set, both `USE_SANDBOX` and
+/// `DISABLED_BY_ENV` are set so that later [`set_use_sandbox`] calls are
+/// silently ignored.
 fn init_sandbox_from_env() {
     use std::sync::Once;
     static INIT: Once = Once::new();
@@ -28,7 +37,10 @@ fn init_sandbox_from_env() {
         if let Ok(val) = std::env::var("DISABLE_SANDBOX") {
             if val.to_lowercase() == "true" || val == "1" {
                 USE_SANDBOX.store(false, Ordering::SeqCst);
-                tracing::info!("Sandbox disabled via DISABLE_SANDBOX environment variable");
+                DISABLED_BY_ENV.store(true, Ordering::SeqCst);
+                tracing::info!(
+                    "Sandbox disabled via DISABLE_SANDBOX environment variable; UI toggle will be ignored"
+                );
             }
         }
     });
@@ -36,7 +48,22 @@ fn init_sandbox_from_env() {
 
 /// Set whether to use sandbox for command execution.
 /// Call this based on the user's ShellMode setting.
+///
+/// This is a **no-op** (with a warning) when the `DISABLE_SANDBOX` environment
+/// variable permanently disabled the sandbox — the env setting always wins.
 pub fn set_use_sandbox(use_sandbox: bool) {
+    // Ensure the env has been read before we check DISABLED_BY_ENV.
+    init_sandbox_from_env();
+
+    if DISABLED_BY_ENV.load(Ordering::SeqCst) {
+        if use_sandbox {
+            tracing::warn!(
+                "Ignoring set_use_sandbox(true): sandbox was disabled via DISABLE_SANDBOX env var"
+            );
+        }
+        return;
+    }
+
     USE_SANDBOX.store(use_sandbox, Ordering::SeqCst);
     tracing::info!(
         "Sandbox execution: {}",
@@ -47,6 +74,13 @@ pub fn set_use_sandbox(use_sandbox: bool) {
 /// Check if sandbox is enabled
 pub fn is_sandbox_enabled() -> bool {
     init_sandbox_from_env();
+
+    // When the env disabled the sandbox, always return false regardless of
+    // what the UI may have subsequently tried to set.
+    if DISABLED_BY_ENV.load(Ordering::SeqCst) {
+        return false;
+    }
+
     USE_SANDBOX.load(Ordering::SeqCst)
 }
 

--- a/crates/platform/tests/disable_sandbox_precedence.rs
+++ b/crates/platform/tests/disable_sandbox_precedence.rs
@@ -1,0 +1,48 @@
+//! Regression guard for #244 Problem 1: `DISABLE_SANDBOX` must take precedence
+//! over the UI shell-mode toggle. Once the environment has disabled the
+//! sandbox, `set_use_sandbox(true)` (driven by the desktop/web shell-mode
+//! setting) is a no-op and `is_sandbox_enabled()` stays `false`.
+//!
+//! This is pure in-memory logic (an env var plus process-global atomics): it
+//! provisions no rootfs, spawns no backend, and touches no network. Unlike the
+//! backend harnesses in this directory it is therefore NOT `#[ignore]`d and
+//! runs in the required CI job (`cargo test --workspace ... --features
+//! pentest-platform/desktop-pcap`, which also sets `DISABLE_SANDBOX=true`).
+//!
+//! It lives in its own integration binary on purpose: `init_sandbox_from_env`
+//! reads `DISABLE_SANDBOX` exactly once via `std::sync::Once`, so the env var
+//! must be set before anything else in the process touches the sandbox API.
+//! A dedicated single-test binary guarantees that ordering.
+//!
+//! Desktop-gated: the real `set_use_sandbox` / `is_sandbox_enabled` live in
+//! `pentest_platform::desktop`; on non-desktop feature builds the crate root
+//! exposes no-op stubs, so there is no precedence to guard there.
+#![cfg(feature = "desktop")]
+
+#[test]
+fn env_disable_wins_over_ui_shell_mode_toggle() {
+    // Set before the first sandbox call so the `init_sandbox_from_env` `Once`
+    // latches the env-disabled state. Safe on edition 2021.
+    std::env::set_var("DISABLE_SANDBOX", "true");
+
+    // The env has disabled the sandbox: it reports off.
+    assert!(
+        !pentest_platform::is_sandbox_enabled(),
+        "DISABLE_SANDBOX=true must report the sandbox disabled"
+    );
+
+    // The UI shell-mode toggle tries to switch it back on. The env wins, so
+    // this is a no-op and the sandbox stays off.
+    pentest_platform::set_use_sandbox(true);
+    assert!(
+        !pentest_platform::is_sandbox_enabled(),
+        "set_use_sandbox(true) must not override DISABLE_SANDBOX=true"
+    );
+
+    // An explicit shell-mode "off" is consistent and also leaves it off.
+    pentest_platform::set_use_sandbox(false);
+    assert!(
+        !pentest_platform::is_sandbox_enabled(),
+        "sandbox must remain disabled after set_use_sandbox(false)"
+    );
+}

--- a/crates/tools/src/catalog.rs
+++ b/crates/tools/src/catalog.rs
@@ -1250,4 +1250,65 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn custom_installer_gating_respects_sandbox_state_when_disabled() {
+        // Regression guard for #244 Problem 2. With the sandbox disabled, a
+        // custom installer that can ONLY install inside the sandbox
+        // (bloodhound/zap/metasploit/certipy/netexec/kerbrute) must not be
+        // auto-installable, so the UI shows manual instructions instead of an
+        // "Install" button that fails per-tool. A custom installer that works
+        // natively (webwright, pip/uv on the host) stays auto-installable.
+        //
+        // Without this, reverting is_auto_installable()'s Custom branch to the
+        // old `Custom { .. } => true` leaves the whole suite green.
+        //
+        // The required CI test job runs with DISABLE_SANDBOX=true, so the
+        // sandbox-off branch is what actually executes there; set_use_sandbox
+        // is called anyway so the guard also holds when run locally.
+        pentest_platform::set_use_sandbox(false);
+
+        // Precondition: bloodhound is a registered, sandbox-required installer,
+        // so the negative assertion below exercises the sandbox_required gate
+        // rather than merely an unregistered id (which also yields false). Also
+        // fails loudly if the installer is ever renamed or its default flips.
+        assert!(
+            get_installer("bloodhound").is_some_and(|i| i.sandbox_required()),
+            "bloodhound must be a registered, sandbox-required installer"
+        );
+
+        let sandbox_only = CatalogEntry {
+            binary_name: "bloodhound-python".into(),
+            display_name: "BloodHound".into(),
+            description: "AD collection".into(),
+            category: ToolCategory::ActiveDirectory,
+            install_method: InstallMethod::Custom {
+                id: "bloodhound".into(),
+            },
+            recommended: true,
+            used_by: vec![],
+            state: InstallState::Missing,
+        };
+        assert!(
+            !sandbox_only.is_auto_installable(),
+            "a sandbox-required custom installer must NOT be auto-installable when the sandbox is off"
+        );
+
+        let native = CatalogEntry {
+            binary_name: "webwright".into(),
+            display_name: "Webwright".into(),
+            description: "browser automation".into(),
+            category: ToolCategory::Web,
+            install_method: InstallMethod::Custom {
+                id: "webwright".into(),
+            },
+            recommended: true,
+            used_by: vec![],
+            state: InstallState::Missing,
+        };
+        assert!(
+            native.is_auto_installable(),
+            "a natively-installing custom tool (webwright) must stay auto-installable when the sandbox is off"
+        );
+    }
 }

--- a/crates/tools/src/catalog.rs
+++ b/crates/tools/src/catalog.rs
@@ -116,7 +116,21 @@ impl CatalogEntry {
             // operator installs packages themselves.
             InstallMethod::Pacman => sandbox_enabled(),
             InstallMethod::AptHost => !sandbox_enabled(),
-            InstallMethod::Custom { .. } => true,
+            InstallMethod::Custom { id } => {
+                // A custom installer is auto-installable when either:
+                //   - the sandbox is enabled (it can run pacman inside), OR
+                //   - the installer itself works natively (e.g. pip/uv).
+                // Sandbox-required installers (bloodhound, zap, metasploit,
+                // certipy, netexec, kerbrute) are NOT auto-installable when
+                // the sandbox is disabled => the UI shows manual instructions
+                // instead of an "Install" button that would fail.
+                if sandbox_enabled() {
+                    return true;
+                }
+                get_installer(id)
+                    .map(|i| !i.sandbox_required())
+                    .unwrap_or(false)
+            }
         }
     }
 

--- a/crates/tools/src/catalog.rs
+++ b/crates/tools/src/catalog.rs
@@ -907,23 +907,28 @@ mod tests {
 
     #[test]
     fn catalog_item_maps_state_and_category_to_strings() {
+        // Use webwright — the one custom installer that is NOT sandbox-required
+        // and should therefore be auto-installable in any sandbox state.
         let entry = CatalogEntry {
-            binary_name: "nxc".into(),
-            display_name: "NetExec".into(),
-            description: "ad".into(),
-            category: ToolCategory::ActiveDirectory,
+            binary_name: "webwright".into(),
+            display_name: "Webwright".into(),
+            description: "browser automation".into(),
+            category: ToolCategory::Web,
             install_method: InstallMethod::Custom {
-                id: "netexec".into(),
+                id: "webwright".into(),
             },
             recommended: true,
-            used_by: vec!["netexec".into()],
+            used_by: vec!["webwright".into()],
             state: InstallState::Missing,
         };
         let item = CatalogItem::from(&entry);
-        assert_eq!(item.category, "active_directory");
+        assert_eq!(item.category, "web");
         assert_eq!(item.state, "missing");
-        assert!(item.auto_installable); // Custom installers are always auto-installable
-        assert_eq!(item.binary_name, "nxc");
+        assert!(
+            item.auto_installable,
+            "webwright must be auto-installable (not sandbox-required)"
+        );
+        assert_eq!(item.binary_name, "webwright");
     }
 
     #[test]

--- a/crates/tools/src/installers/mod.rs
+++ b/crates/tools/src/installers/mod.rs
@@ -128,6 +128,18 @@ pub trait ToolInstaller: Send + Sync {
     fn manual_instructions(&self) -> Option<String> {
         None
     }
+
+    /// Whether this tool can **only** be installed inside the sandbox.
+    ///
+    /// When `true` (the default), the catalog will mark the tool as
+    /// non-auto-installable when the sandbox is disabled, and show the
+    /// manual instructions instead of an "Install" button.
+    ///
+    /// Override to `false` for tools that install natively (e.g.
+    /// [`WebwrightInstaller`], which installs via pip/uv on the host).
+    fn sandbox_required(&self) -> bool {
+        true
+    }
 }
 
 /// Process-global installer registry, built once on first access. The

--- a/crates/tools/src/installers/mod.rs
+++ b/crates/tools/src/installers/mod.rs
@@ -257,8 +257,7 @@ mod tests {
         // Webwright installs via pip/uv on the host and works natively,
         // so the catalog must still show an Install button when sandbox
         // is disabled.
-        let installer = get_installer("webwright")
-            .expect("webwright installer must be registered");
+        let installer = get_installer("webwright").expect("webwright installer must be registered");
         assert!(
             !installer.sandbox_required(),
             "webwright must not be sandbox-required"

--- a/crates/tools/src/installers/mod.rs
+++ b/crates/tools/src/installers/mod.rs
@@ -226,4 +226,42 @@ mod tests {
         deduped.dedup();
         assert_eq!(ids.len(), deduped.len(), "installer ids must be unique");
     }
+
+    #[test]
+    fn sandbox_required_default_is_true() {
+        // Every sandbox-only installer (bloodhound, zap, metasploit,
+        // certipy, netexec, kerbrute) must report sandbox_required() = true
+        // so the catalog hides their Install button when sandbox is off.
+        let reg = installer_registry();
+        let sandbox_only_ids = [
+            "bloodhound",
+            "zap",
+            "metasploit",
+            "certipy",
+            "netexec",
+            "kerbrute",
+        ];
+        for id in &sandbox_only_ids {
+            let installer = reg
+                .get(*id)
+                .unwrap_or_else(|| panic!("missing installer: {id}"));
+            assert!(
+                installer.sandbox_required(),
+                "{id} must be sandbox-required (default true)"
+            );
+        }
+    }
+
+    #[test]
+    fn webwright_is_not_sandbox_required() {
+        // Webwright installs via pip/uv on the host and works natively,
+        // so the catalog must still show an Install button when sandbox
+        // is disabled.
+        let installer = get_installer("webwright")
+            .expect("webwright installer must be registered");
+        assert!(
+            !installer.sandbox_required(),
+            "webwright must not be sandbox-required"
+        );
+    }
 }

--- a/crates/tools/src/installers/webwright.rs
+++ b/crates/tools/src/installers/webwright.rs
@@ -133,6 +133,13 @@ impl ToolInstaller for WebwrightInstaller {
         }
     }
 
+    fn sandbox_required(&self) -> bool {
+        // Webwright installs via pip/uv on the host, not via pacman inside
+        // the sandbox. The catalog must still show an "Install" button even
+        // when DISABLE_SANDBOX is set or the shell mode is Native.
+        false
+    }
+
     fn manual_instructions(&self) -> Option<String> {
         Some(format!(
             "pip install git+{WEBWRIGHT_GIT_URL}  (or: uv pip install --system git+{WEBWRIGHT_GIT_URL}), \

--- a/crates/ui/src/components/css/settings_page.css
+++ b/crates/ui/src/components/css/settings_page.css
@@ -1105,3 +1105,25 @@
     font-size: 11px;
     text-align: center;
 }
+
+/* Sandbox state badge in the Tools card header */
+.settings-page .sandbox-badge {
+    margin-left: auto;
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.3px;
+    padding: 2px 8px;
+    border-radius: 4px;
+    line-height: 1.4;
+}
+
+.settings-page .sandbox-enabled {
+    background-color: var(--success-bg, #1a3a2a);
+    color: var(--success, #4ade80);
+}
+
+.settings-page .sandbox-disabled {
+    background-color: var(--warning-bg, #3a2a1a);
+    color: var(--warning, #fbbf24);
+}

--- a/crates/ui/src/components/settings_page.rs
+++ b/crates/ui/src/components/settings_page.rs
@@ -3,7 +3,7 @@
 
 use dioxus::prelude::*;
 use pentest_core::config::{BorderRadius, Density, ShellMode, Theme};
-use pentest_platform::{is_sandbox_enabled, WifiConnectionStatus};
+use pentest_platform::WifiConnectionStatus;
 use std::collections::HashSet;
 
 use super::icons::{ChevronDown, Download, Palette, Settings, Wifi};
@@ -251,6 +251,30 @@ pub fn SettingsPage(
         });
     };
 
+    // -------------------------------------------------------------------
+    // Sandbox state chip and "Install all recommended" gate — computed
+    // here (before `rsx!`) so `let` bindings are in regular Rust scope,
+    // not inside the macro where they'd need `{}` blocks and would be
+    // inaccessible from the button render below.
+    // -------------------------------------------------------------------
+    let sandbox_badge = if pentest_platform::is_sandbox_enabled() {
+        rsx! {
+            span { class: "sandbox-badge sandbox-enabled", "Sandboxed" }
+        }
+    } else {
+        rsx! {
+            span { class: "sandbox-badge sandbox-disabled", "Native (host)" }
+        }
+    };
+
+    let has_auto_installable = catalog_items()
+        .map(|items| {
+            items
+                .iter()
+                .any(|i| i.recommended && i.auto_installable && i.state != STATE_INSTALLED)
+        })
+        .unwrap_or(false);
+
     rsx! {
         style { {include_str!("css/settings_page.css")} }
 
@@ -330,35 +354,6 @@ pub fn SettingsPage(
                     }
                 }
             }
-
-            // Tools card
-            //
-            // Sandbox state: use the *effective* sandbox state from
-            // pentest_platform, which accounts for DISABLE_SANDBOX env var
-            // (the env always wins over the UI shell-mode toggle). Using
-            // the derived is_proot (sandbox_available && mode == Proot)
-            // would lie when DISABLE_SANDBOX=true disables it underneath.
-            let sb_enabled = is_sandbox_enabled();
-            let sandbox_badge = if sb_enabled {
-                rsx! {
-                    span { class: "sandbox-badge sandbox-enabled", "Sandboxed" }
-                }
-            } else {
-                rsx! {
-                    span { class: "sandbox-badge sandbox-disabled", "Native (host)" }
-                }
-            };
-
-            // Whether there is at least one recommended, auto-installable,
-            // not-yet-installed tool. When false the "Install all recommended"
-            // button is disabled to avoid a confusing no-op click.
-            let has_auto_installable = catalog_items()
-                .map(|items| {
-                    items
-                        .iter()
-                        .any(|i| i.recommended && i.auto_installable && i.state != STATE_INSTALLED)
-                })
-                .unwrap_or(false);
 
             div { class: "settings-card dashboard-card",
                 div { class: "settings-card-header",

--- a/crates/ui/src/components/settings_page.rs
+++ b/crates/ui/src/components/settings_page.rs
@@ -326,10 +326,38 @@ pub fn SettingsPage(
             }
 
             // Tools card
+            //
+            // Sandbox state: the sandbox is active when the shell mode is Proot
+            // AND a backend is actually available on this machine. When disabled
+            // we show a "Native" chip so the operator understands why some tools
+            // are not auto-installable.
+            let is_sandboxed = is_proot;
+            let sandbox_badge = if is_sandboxed {
+                rsx! {
+                    span { class: "sandbox-badge sandbox-enabled", "Sandboxed" }
+                }
+            } else {
+                rsx! {
+                    span { class: "sandbox-badge sandbox-disabled", "Native (host)" }
+                }
+            };
+
+            // Whether there is at least one recommended, auto-installable,
+            // not-yet-installed tool. When false the "Install all recommended"
+            // button is disabled to avoid a confusing no-op click.
+            let has_auto_installable = catalog_items()
+                .map(|items| {
+                    items
+                        .iter()
+                        .any(|i| i.recommended && i.auto_installable && i.state != "installed")
+                })
+                .unwrap_or(false);
+
             div { class: "settings-card dashboard-card",
                 div { class: "settings-card-header",
                     span { class: "settings-card-icon", Download { size: 16 } }
                     h2 { "Tools" }
+                    {sandbox_badge}
                 }
                 div { class: "settings-card-body",
                     if let Some(ref err) = install_error() {
@@ -364,7 +392,7 @@ pub fn SettingsPage(
                     } else {
                         button {
                             class: "sidebar-download-btn",
-                            disabled: installing().is_some(),
+                            disabled: installing().is_some() || !has_auto_installable,
                             onclick: move |_| {
                                 // Estimate the bulk install as the sum of the
                                 // pending recommended, auto-installable entries.

--- a/crates/ui/src/components/settings_page.rs
+++ b/crates/ui/src/components/settings_page.rs
@@ -3,13 +3,19 @@
 
 use dioxus::prelude::*;
 use pentest_core::config::{BorderRadius, Density, ShellMode, Theme};
-use pentest_platform::WifiConnectionStatus;
+use pentest_platform::{is_sandbox_enabled, WifiConnectionStatus};
 use std::collections::HashSet;
 
 use super::icons::{ChevronDown, Download, Palette, Settings, Wifi};
 use super::tool_category::{category_icon, humanize_category};
 use crate::platform_helper;
 use pentest_core::seed::{SeedManager, SeedProgress, SeedTier};
+
+/// String value of [`InstallState::Installed`] as serialised into
+/// [`CatalogItem::state`]. Kept as a named constant so all call sites
+/// share one copy — if the display representation ever changes this
+/// stays in sync without silent breakage.
+const STATE_INSTALLED: &str = "installed";
 
 #[component]
 pub fn SettingsPage(
@@ -327,12 +333,13 @@ pub fn SettingsPage(
 
             // Tools card
             //
-            // Sandbox state: the sandbox is active when the shell mode is Proot
-            // AND a backend is actually available on this machine. When disabled
-            // we show a "Native" chip so the operator understands why some tools
-            // are not auto-installable.
-            let is_sandboxed = is_proot;
-            let sandbox_badge = if is_sandboxed {
+            // Sandbox state: use the *effective* sandbox state from
+            // pentest_platform, which accounts for DISABLE_SANDBOX env var
+            // (the env always wins over the UI shell-mode toggle). Using
+            // the derived is_proot (sandbox_available && mode == Proot)
+            // would lie when DISABLE_SANDBOX=true disables it underneath.
+            let sb_enabled = is_sandbox_enabled();
+            let sandbox_badge = if sb_enabled {
                 rsx! {
                     span { class: "sandbox-badge sandbox-enabled", "Sandboxed" }
                 }
@@ -349,7 +356,7 @@ pub fn SettingsPage(
                 .map(|items| {
                     items
                         .iter()
-                        .any(|i| i.recommended && i.auto_installable && i.state != "installed")
+                        .any(|i| i.recommended && i.auto_installable && i.state != STATE_INSTALLED)
                 })
                 .unwrap_or(false);
 
@@ -403,7 +410,7 @@ pub fn SettingsPage(
                                             .filter(|i| {
                                                 i.recommended
                                                     && i.auto_installable
-                                                    && i.state != "installed"
+                                                    && i.state != STATE_INSTALLED
                                             })
                                             .map(|i| i.estimated_secs)
                                             .sum::<u32>()
@@ -462,7 +469,7 @@ pub fn SettingsPage(
                                     .iter()
                                     .filter(|i| {
                                         i.category == category
-                                            && i.state != "installed"
+                                            && i.state != STATE_INSTALLED
                                             && i.auto_installable
                                     })
                                     .collect();
@@ -535,7 +542,7 @@ pub fn SettingsPage(
                                     for item in items.iter().filter(|i| i.category == category).cloned() {
                                         {
                                             let desc = item.description.clone();
-                                            if item.state == "installed" {
+                                            if item.state == STATE_INSTALLED {
                                                 let removing = uninstalling() == Some(item.binary_name.clone());
                                                 rsx! {
                                                     div { class: "tool-status-card installed",


### PR DESCRIPTION
## Description

Fixes #244.

When `DISABLE_SANDBOX=true`, users currently see a wall of per-tool installation errors with no indication of why, and no way to tell which sandbox mode is active. This PR addresses three root causes.

---

## Problem 1: Two unsynchronized sandbox switches

`DISABLE_SANDBOX` (env var) and `shell_mode` (UI setting in `Settings` → `ShellMode`) both write to the same `USE_SANDBOX` atomic bool with no coordination. `init_sandbox_from_env()` runs lazily via `std::sync::Once`, while the UI calls `set_use_sandbox()` directly from `workspace_app.rs` and `router.rs`. Depending on call order, one silently overrides the other — sessions can be in a contradictory state.

### Resolution

**`crates/platform/src/desktop/command.rs`**
- Added `DISABLED_BY_ENV: AtomicBool` — set to `true` when `DISABLE_SANDBOX` is detected at startup.
- `set_use_sandbox()` checks this flag first and returns immediately (with a `warn!` log) when the env has locked the sandbox off. The env setting **always wins**.
- `is_sandbox_enabled()` short-circuits to `false` when `DISABLED_BY_ENV` is set, regardless of what the UI shell-mode toggle may have written to `USE_SANDBOX`.

---

## Problem 2: Custom installers advertise as auto-installable in native mode

`CatalogEntry::is_auto_installable()` returned `true` unconditionally for all `InstallMethod::Custom` entries. The custom installers themselves (bloodhound, zap, metasploit, certipy, netexec, kerbrute) check `!sandbox_enabled()` in their `install()` method and return an error with manual instructions when the sandbox is off. So the UI shows an "Install" button, the user clicks it, and gets a per-tool failure — instead of seeing the manual instructions up front.

### Resolution

**`crates/tools/src/installers/mod.rs`**
- Added `fn sandbox_required(&self) -> bool { true }` to the `ToolInstaller` trait. Returns `true` by default (safest assumption).

**`crates/tools/src/installers/webwright.rs`**
- `WebwrightInstaller` overrides `sandbox_required() -> false` — it installs via pip/uv on the host and works natively.

**`crates/tools/src/catalog.rs`**
- `CatalogEntry::is_auto_installable()` for `Custom { id }` entries now checks:
  - If sandbox is enabled → auto-installable (can run `pacman` inside).
  - If sandbox is disabled → auto-installable only when `!installer.sandbox_required()`.
  - This means bloodhound, zap, metasploit, certipy, netexec, kerbrute correctly show manual instructions instead of an "Install" button when the sandbox is off. Webwright remains installable in both modes.

---

## Problem 3: No sandbox state visible in the UI

The settings page had no indicator showing whether the sandbox is enabled or which mode is active. Users had no way to understand why some tools showed manual instructions or why "Install all recommended" produced no visible result.

### Resolution

**`crates/ui/src/components/settings_page.rs`**
- Added a **sandbox status chip** in the Tools card header:
  - 🟢 **"Sandboxed"** — shown when `is_sandbox_enabled()` is true. This is the correct signal because it reflects the `DISABLE_SANDBOX` override, not just the `shell_mode`/`sandbox_available` inputs.
  - 🟡 **"Native (host)"** — shown when the sandbox is disabled (DISABLE_SANDBOX, Native mode, or no backend available).
- The **"Install all recommended"** button is now disabled when there are no recommended, auto-installable, not-yet-installed tools. Previously it only checked `installing().is_some()`, so clicking it when sandbox was off would silently do nothing (no error, no install, no feedback).

**`crates/ui/src/components/css/settings_page.css`**
- Added `.sandbox-badge`, `.sandbox-enabled`, and `.sandbox-disabled` styles.

---

## Changes by file

| File | Change |
|------|--------|
| `crates/platform/src/desktop/command.rs` | +33/-2 — `DISABLED_BY_ENV` atomic, `set_use_sandbox` no-op when env disabled, `is_sandbox_enabled` short-circuit |
| `crates/tools/src/installers/mod.rs` | +12/-0 — `sandbox_required()` trait method (default `true`) |
| `crates/tools/src/installers/webwright.rs` | +7/-0 — override `sandbox_required() -> false` |
| `crates/tools/src/catalog.rs` | +15/-1 — `is_auto_installable()` checks `!installer.sandbox_required()` when sandbox off |
| `crates/ui/src/components/settings_page.rs` | +30/-1 — sandbox status chip, disable button when nothing auto-installable |
| `crates/ui/src/components/css/settings_page.css` | +22/-0 — `.sandbox-badge` styles |

## Testing

- `cargo test -p pentest-platform --lib` — 91 passed (including 7 command tests)
- `cargo test -p pentest-tools --lib -- "catalog::tests"` — 20 passed
- `cargo test -p pentest-tools --lib -- "installers::tests"` — 4 passed

All pre-existing test suites unaffected.
