### PR TITLE
fix(ci): bump Termux proot pin to unbreak Android fetch-proot

### DIFF
--- a/justfile
+++ b/justfile
@@ -952,7 +952,7 @@ build-syscall-compat:
     echo "Done! syscall_compat shims built in android-jniLibs/"
 
 # Termux package versions
-proot_version := "5.1.107.91"
+proot_version := "5.1.107.92"
 talloc_version := "2.4.3"
 busybox_version := "1.38.0-1"
 shmem_version := "0.7"


### PR DESCRIPTION
## Summary

- Bump `proot_version` in `justfile` from `5.1.107.91` to `5.1.107.92`. Termux `termux-main` is a rolling repo that serves only the latest build; upstream superseded `.91`, so the pinned URL 404s and the `Android Build` lane fails at `just fetch-proot` with no change on our side.
- Verified against the live repo: proot `.91` returns 404 while `.92` returns 200 on both `aarch64` and `x86_64`; talloc/busybox/shmem pins still resolve, so proot was the only stale one.
- Stopgap to restore signal on the advisory Android lane. The durable fix (mirror pinned debs to an immutable location we control + checksum verify) remains tracked in #397.

## Test plan

- [ ] `Android Build` job passes `Fetch Android proot runtime` (`just fetch-proot`) on this PR
- [ ] `Build debug APK` step completes
- [ ] Other CI lanes unaffected (Rust-only change surface is nil; only justfile pin changed)

Related: #397 (durable immutable-mirror fix), #372 (download integrity), #252 (host-our-own-artifact pattern for desktop openat2 proot).