### PR TITLE
feat(evidence): promote port_scan and execute_command into evidence graph (pick#52 PR2)

### DIFF
--- a/crates/tools/src/evidence_producer.rs
+++ b/crates/tools/src/evidence_producer.rs
@@ -620,6 +620,146 @@ pub fn evidence_from_http_request(data: &Value, provenance: Provenance) -> Vec<E
     evidence_from_generic(vec![finding], provenance)
 }
 
+/// Build a single `open_port` finding, sharing the severity/rationale logic
+/// across both `port_scan` result shapes.
+fn open_port_finding(host: &str, port: u64, service: &str) -> GenericFinding {
+    let severity = assess_port_severity(port, service);
+    let sensitivity = if is_sensitive_port(port) {
+        "sensitive"
+    } else {
+        "network"
+    };
+    GenericFinding {
+        node_type: "open_port".to_string(),
+        title: format!("Port {port}/tcp open on {host} - {service}"),
+        description: format!(
+            "Port scan found TCP port {port} open on {host} (service '{service}')."
+        ),
+        target: host.to_string(),
+        severity,
+        rationale: format!(
+            "Port {port} is commonly associated with {service}. Open {sensitivity} ports \
+             should be validated for necessity and exposure."
+        ),
+        metadata: vec![
+            ("port".to_string(), port.into()),
+            ("protocol".to_string(), "tcp".into()),
+            ("service".to_string(), service.into()),
+        ],
+    }
+}
+
+/// Create evidence nodes from `port_scan` results.
+///
+/// `port_scan` is a native TCP-connect scanner (no external binary), so the
+/// caller attaches a *synthesized* nmap-equivalent probe as provenance rather
+/// than a literal command. This builder promotes every open port into an
+/// `open_port` node, handling both result shapes the tool emits:
+/// * single-host (legacy flat shape):
+///   `{ "host", "ports": [{ "port", "service", "open" }] }`
+/// * multi-host:
+///   `{ "hosts": [{ "host", "open_ports": [{ "port", "service" }] }] }`
+///
+/// Only open ports become nodes. The published fields are validated
+/// IPs/hostnames, port numbers, and platform-derived service names — there is no
+/// user-supplied secret to redact here (contrast the URL-bearing web wrappers,
+/// which carry userinfo/query tokens).
+pub fn evidence_from_port_scan(data: &Value, provenance: Provenance) -> Vec<EvidenceNode> {
+    let mut findings: Vec<GenericFinding> = Vec::new();
+
+    // Multi-host shape: each host carries only its already-open ports.
+    if let Some(hosts) = data["hosts"].as_array() {
+        for h in hosts {
+            let host = h["host"].as_str().unwrap_or("unknown");
+            if let Some(open_ports) = h["open_ports"].as_array() {
+                for p in open_ports {
+                    let port = p["port"].as_u64().unwrap_or(0);
+                    let service = p["service"].as_str().unwrap_or("unknown");
+                    findings.push(open_port_finding(host, port, service));
+                }
+            }
+        }
+    }
+
+    // Single-host shape: a flat port list where each entry carries an `open` flag.
+    if let Some(ports) = data["ports"].as_array() {
+        let host = data["host"].as_str().unwrap_or("unknown");
+        for p in ports {
+            if p["open"].as_bool() != Some(true) {
+                continue; // Only open ports are findings.
+            }
+            let port = p["port"].as_u64().unwrap_or(0);
+            let service = p["service"].as_str().unwrap_or("unknown");
+            findings.push(open_port_finding(host, port, service));
+        }
+    }
+
+    evidence_from_generic(findings, provenance)
+}
+
+/// Create an evidence node from a completed `execute_command` run.
+///
+/// Like `http_request`, `execute_command` is a primitive the agent calls
+/// constantly, not a finding-producer, so this emits exactly one Info-severity
+/// node recording that a command ran and its exit status. Info lets the
+/// Validator downgrade or drop it while keeping the reproducible probe (in
+/// `provenance`) available to ground any finding the agent builds on the output.
+///
+/// # Security
+/// The node's command string is read from
+/// `provenance.probe_commands[0].effective_command`, which is already
+/// secret-scrubbed by value (identity injection, pick#317). Raw `stdout`/
+/// `stderr` are deliberately NOT copied into any node field: command output is
+/// arbitrary and may contain secrets the value-scrubber never saw, so it stays
+/// out of the published node (it remains in the provenance excerpt, which the
+/// report pipeline adjudicates). This keeps the node fields no less protected
+/// than their own provenance — the F1-class asymmetry guarded across pick#52.
+pub fn evidence_from_execute_command(data: &Value, provenance: Provenance) -> Vec<EvidenceNode> {
+    let command = provenance
+        .probe_commands
+        .first()
+        .map(|p| p.effective_command.as_str())
+        .unwrap_or("(command unavailable)");
+    let exit_code = data["exit_code"].as_i64();
+    let timed_out = data["timed_out"].as_bool().unwrap_or(false);
+
+    let status = if timed_out {
+        "a timeout".to_string()
+    } else {
+        match exit_code {
+            Some(c) => format!("exit code {c}"),
+            None => "an unknown exit status".to_string(),
+        }
+    };
+
+    let mut metadata: Vec<(String, Value)> = Vec::new();
+    if let Some(c) = exit_code {
+        metadata.push(("exit_code".to_string(), c.into()));
+    }
+    metadata.push(("timed_out".to_string(), timed_out.into()));
+    if let Some(d) = data["duration_ms"].as_u64() {
+        metadata.push(("duration_ms".to_string(), d.into()));
+    }
+
+    let finding = GenericFinding {
+        node_type: "command_execution".to_string(),
+        title: format!("Command executed: {command}"),
+        description: format!(
+            "Shell command '{command}' completed with {status}. Captured output is withheld \
+             from this node; the reproducible probe and output excerpt live in the attached \
+             provenance for grounding."
+        ),
+        target: command.to_string(),
+        severity: Severity::Info,
+        rationale:
+            "Raw command execution captured for grounding; the Validator adjudicates whether it supports a finding."
+                .to_string(),
+        metadata,
+    };
+
+    evidence_from_generic(vec![finding], provenance)
+}
+
 /// Assess severity of an open port based on port number and service.
 fn assess_port_severity(port: u64, service: &str) -> Severity {
     // Sensitive/high-risk ports
@@ -1230,5 +1370,149 @@ mod tests {
         assert!(node.title.contains("GET"));
         assert_eq!(node.affected_target, "http://target.example/login");
         assert!(node.provenance.is_some());
+    }
+
+    #[test]
+    fn test_evidence_from_port_scan_single_host_open_ports_only() {
+        // Single-host (flat) shape: only ports with `open == true` become nodes.
+        let data = json!({
+            "host": "10.0.0.5",
+            "ports": [
+                {"port": 22, "service": "ssh", "open": true},
+                {"port": 80, "service": "http", "open": true},
+                {"port": 3306, "service": "mysql", "open": false},
+            ],
+            "open_count": 2,
+        });
+
+        let nodes = evidence_from_port_scan(&data, test_provenance("port_scan"));
+
+        // Two open ports -> two nodes; the closed port is not a finding.
+        assert_eq!(nodes.len(), 2);
+        for node in &nodes {
+            assert_eq!(node.node_type, "open_port");
+            assert_eq!(node.affected_target, "10.0.0.5");
+            assert!(node.provenance.is_some());
+            assert_eq!(
+                node.metadata.get("protocol").and_then(|v| v.as_str()),
+                Some("tcp")
+            );
+        }
+        // 22/ssh is an administrative port -> Medium; 80/http -> Low.
+        assert_eq!(nodes[0].current_severity(), Severity::Medium);
+        assert_eq!(
+            nodes[0].metadata.get("port").and_then(|v| v.as_u64()),
+            Some(22)
+        );
+        assert_eq!(nodes[1].current_severity(), Severity::Low);
+        assert!(nodes
+            .iter()
+            .all(|n| n.metadata.get("port").and_then(|v| v.as_u64()) != Some(3306)));
+    }
+
+    #[test]
+    fn test_evidence_from_port_scan_multi_host_shape() {
+        // Multi-host shape: each host lists only its already-open ports.
+        let data = json!({
+            "hosts": [
+                {"host": "10.0.0.5", "open_ports": [{"port": 445, "service": "microsoft-ds"}], "open_count": 1},
+                {"host": "10.0.0.6", "open_ports": [{"port": 443, "service": "https"}], "open_count": 1},
+            ],
+            "hosts_scanned": 2,
+            "hosts_with_open_ports": 2,
+        });
+
+        let nodes = evidence_from_port_scan(&data, test_provenance("port_scan"));
+
+        assert_eq!(nodes.len(), 2);
+        assert_eq!(nodes[0].affected_target, "10.0.0.5");
+        assert_eq!(
+            nodes[0].metadata.get("port").and_then(|v| v.as_u64()),
+            Some(445)
+        );
+        // 445 is a sensitive port -> High.
+        assert_eq!(nodes[0].current_severity(), Severity::High);
+        assert_eq!(nodes[1].affected_target, "10.0.0.6");
+        assert_eq!(nodes[1].current_severity(), Severity::Low);
+    }
+
+    /// Build provenance the way `execute_command`'s `build_run_output` does:
+    /// a single `shell` probe whose `effective_command` is the (already-redacted)
+    /// command line.
+    fn execute_command_provenance(command: &str) -> Provenance {
+        Provenance::new(
+            "shell".to_string(),
+            "1.0".to_string(),
+            pentest_core::provenance::ProbeCommand::from_exact(command),
+            "",
+        )
+    }
+
+    #[test]
+    fn test_evidence_from_execute_command_info_node_no_output_leak() {
+        // SECURITY GUARD: raw stdout/stderr are arbitrary and may hold secrets
+        // the value-scrubber never saw, so they must NEVER be copied into a
+        // published node field. Only the (already-redacted) effective_command,
+        // exit status, and timing reach the node. Copying `data["stdout"]` into
+        // any node field turns this test red.
+        let data = json!({
+            "stdout": "db_password=TOPSECRET_OUTPUT_VALUE\nrows: 3",
+            "stderr": "",
+            "exit_code": 0,
+            "timed_out": false,
+            "duration_ms": 42,
+        });
+
+        let nodes =
+            evidence_from_execute_command(&data, execute_command_provenance("psql -c 'select 1'"));
+
+        assert_eq!(nodes.len(), 1);
+        let node = &nodes[0];
+        assert_eq!(node.node_type, "command_execution");
+        assert_eq!(node.current_severity(), Severity::Info);
+        assert!(node.title.contains("psql -c 'select 1'"));
+        assert_eq!(
+            node.metadata.get("exit_code").and_then(|v| v.as_i64()),
+            Some(0)
+        );
+        assert!(node.provenance.is_some());
+
+        // The command output must not survive into ANY published byte of the node.
+        let serialized = serde_json::to_string(node).unwrap();
+        assert!(
+            !serialized.contains("TOPSECRET_OUTPUT_VALUE"),
+            "command output leaked into evidence node: {serialized}"
+        );
+    }
+
+    #[test]
+    fn test_evidence_from_execute_command_uses_redacted_effective_command() {
+        // The node's command string must come from the provenance's
+        // already-redacted `effective_command`, never an independent (weaker)
+        // path. Here an injected bearer token is scrubbed by value in provenance;
+        // the node must inherit that redaction, so the raw token never appears.
+        let probe = pentest_core::provenance::ProbeCommand::from_exact_redacting_secret(
+            "curl -H 'Authorization: Bearer SEKRET_TOKEN' http://target.example",
+            "SEKRET_TOKEN",
+        );
+        let provenance = Provenance::multi_step("shell", "1.0", vec![probe], "");
+
+        let data = json!({
+            "stdout": "",
+            "stderr": "",
+            "exit_code": 0,
+            "timed_out": false,
+            "duration_ms": 5,
+        });
+
+        let nodes = evidence_from_execute_command(&data, provenance);
+        assert_eq!(nodes.len(), 1);
+        let node = &nodes[0];
+
+        let serialized = serde_json::to_string(node).unwrap();
+        assert!(
+            !serialized.contains("SEKRET_TOKEN"),
+            "injected token leaked into evidence node: {serialized}"
+        );
     }
 }

--- a/crates/tools/src/evidence_producer.rs
+++ b/crates/tools/src/evidence_producer.rs
@@ -667,8 +667,11 @@ fn open_port_finding(host: &str, port: u64, service: &str) -> GenericFinding {
 pub fn evidence_from_port_scan(data: &Value, provenance: Provenance) -> Vec<EvidenceNode> {
     let mut findings: Vec<GenericFinding> = Vec::new();
 
-    // Multi-host shape: each host carries only its already-open ports.
+    // The two shapes are mutually exclusive (port_scan emits one or the other),
+    // so a multi-host `hosts` payload is handled to the exclusion of the flat
+    // `ports` branch — a malformed payload carrying both keys never double-emits.
     if let Some(hosts) = data["hosts"].as_array() {
+        // Multi-host shape: each host carries only its already-open ports.
         for h in hosts {
             let host = h["host"].as_str().unwrap_or("unknown");
             if let Some(open_ports) = h["open_ports"].as_array() {
@@ -679,10 +682,8 @@ pub fn evidence_from_port_scan(data: &Value, provenance: Provenance) -> Vec<Evid
                 }
             }
         }
-    }
-
-    // Single-host shape: a flat port list where each entry carries an `open` flag.
-    if let Some(ports) = data["ports"].as_array() {
+    } else if let Some(ports) = data["ports"].as_array() {
+        // Single-host shape: a flat port list where each entry carries an `open` flag.
         let host = data["host"].as_str().unwrap_or("unknown");
         for p in ports {
             if p["open"].as_bool() != Some(true) {

--- a/crates/tools/src/execute_command.rs
+++ b/crates/tools/src/execute_command.rs
@@ -171,7 +171,19 @@ impl PentestTool for ExecuteCommandTool {
             };
 
             let full_command = format_full_command(command, &args);
-            Ok(build_run_output(full_command, result, &applied_identity))
+            let (data, provenance) = build_run_output(full_command, result, &applied_identity);
+
+            // Promote the run into the evidence graph so findings the agent
+            // builds on the output can be grounded (pick#52). One Info node per
+            // run; raw stdout/stderr stay out of the node (see
+            // evidence_from_execute_command).
+            for node in
+                crate::evidence_producer::evidence_from_execute_command(&data, provenance.clone())
+            {
+                let _ = crate::evidence_producer::push_evidence(node);
+            }
+
+            Ok((data, provenance))
         })
         .await?;
 

--- a/crates/tools/src/execute_command.rs
+++ b/crates/tools/src/execute_command.rs
@@ -176,11 +176,16 @@ impl PentestTool for ExecuteCommandTool {
             // Promote the run into the evidence graph so findings the agent
             // builds on the output can be grounded (pick#52). One Info node per
             // run; raw stdout/stderr stay out of the node (see
-            // evidence_from_execute_command).
-            for node in
-                crate::evidence_producer::evidence_from_execute_command(&data, provenance.clone())
-            {
-                let _ = crate::evidence_producer::push_evidence(node);
+            // evidence_from_execute_command). Gate on `is_ran_probe` so a failed
+            // or timed-out run — a #184 Failed outcome — never produces grounding
+            // evidence, matching how the outcome itself is classified below.
+            if is_ran_probe(&data) {
+                for node in crate::evidence_producer::evidence_from_execute_command(
+                    &data,
+                    provenance.clone(),
+                ) {
+                    let _ = crate::evidence_producer::push_evidence(node);
+                }
             }
 
             Ok((data, provenance))
@@ -292,26 +297,34 @@ fn classify_command_outcome(result: ToolResult) -> ToolResult {
         return result;
     }
 
-    let timed_out = result.data.get("timed_out").and_then(Value::as_bool) == Some(true);
-    let exit_code = result.data.get("exit_code").and_then(Value::as_i64);
-    let stdout_empty = result
-        .data
+    if is_ran_probe(&result.data) {
+        result
+    } else {
+        result.with_outcome(ToolOutcome::Failed)
+    }
+}
+
+/// Whether a completed subprocess counts as a genuine *ran probe* (vs a #184
+/// Failed outcome), decided from its captured `data`.
+///
+/// Shared by [`classify_command_outcome`] and the evidence-promotion gate so the
+/// two can never diverge: a run that is not a ran probe produces neither a
+/// [`ToolOutcome::Ran`] outcome nor grounding evidence. A run is NOT a ran probe
+/// when it timed out, its exit status is unreadable (fail closed — the tool body
+/// always writes `exit_code`, so `None` means an unexpected shape), or it exited
+/// nonzero with no stdout. A nonzero exit that still produced stdout stays a ran
+/// probe (grep/diff/test use nonzero as signal), as does a zero exit with empty
+/// stdout (a truthful empty result).
+fn is_ran_probe(data: &Value) -> bool {
+    let timed_out = data.get("timed_out").and_then(Value::as_bool) == Some(true);
+    let exit_code = data.get("exit_code").and_then(Value::as_i64);
+    let stdout_empty = data
         .get("stdout")
         .and_then(Value::as_str)
         .map(str::is_empty)
         .unwrap_or(true);
 
-    // Fail closed: a run whose exit status we cannot read is not a trustworthy
-    // completed probe. The tool body always writes `exit_code`, so `None` here
-    // means an unexpected data shape — treat it as Failed, never assume success.
-    let failed =
-        timed_out || exit_code.is_none() || (exit_code.is_some_and(|c| c != 0) && stdout_empty);
-
-    if failed {
-        result.with_outcome(ToolOutcome::Failed)
-    } else {
-        result
-    }
+    !(timed_out || exit_code.is_none() || (exit_code.is_some_and(|c| c != 0) && stdout_empty))
 }
 
 /// What `build_identity_injection` produced: the argv fragment to splice in,
@@ -638,6 +651,31 @@ mod tests {
         let r = classify_command_outcome(ran(1, "line-of-real-output\n", false));
         assert_eq!(r.outcome, ToolOutcome::Ran);
         assert!(r.success);
+    }
+
+    #[test]
+    fn is_ran_probe_gates_evidence_promotion_like_outcome_classification() {
+        // The evidence-promotion gate MUST agree with outcome classification: a
+        // failed/timed-out/unreadable run produces neither a Ran outcome nor a
+        // grounding evidence node. This is the shared predicate behind both.
+        assert!(is_ran_probe(
+            &json!({"exit_code": 0, "stdout": "", "timed_out": false})
+        ));
+        assert!(is_ran_probe(
+            &json!({"exit_code": 1, "stdout": "real output", "timed_out": false})
+        ));
+        assert!(
+            !is_ran_probe(&json!({"exit_code": 1, "stdout": "", "timed_out": false})),
+            "nonzero exit with no stdout is a failed probe -> no evidence"
+        );
+        assert!(
+            !is_ran_probe(&json!({"exit_code": 0, "stdout": "x", "timed_out": true})),
+            "a timed-out run is a failed probe -> no evidence"
+        );
+        assert!(
+            !is_ran_probe(&json!({"stdout": "x", "timed_out": false})),
+            "an unreadable exit status fails closed -> no evidence"
+        );
     }
 
     #[test]

--- a/crates/tools/src/port_scan.rs
+++ b/crates/tools/src/port_scan.rs
@@ -2,8 +2,10 @@
 
 use async_trait::async_trait;
 use pentest_core::error::Result;
+use pentest_core::provenance::{truncate_excerpt, ProbeCommand, Provenance};
 use pentest_core::tools::{
-    execute_timed, ParamType, PentestTool, Platform, ToolContext, ToolParam, ToolResult, ToolSchema,
+    execute_timed_with_provenance, ParamType, PentestTool, Platform, ToolContext, ToolParam,
+    ToolResult, ToolSchema,
 };
 use pentest_core::validation::{validate_port_spec, validate_target};
 use pentest_platform::{get_platform, HostReachability, NetworkOps, ScanConfig};
@@ -55,6 +57,34 @@ fn collect_hosts(params: &Value) -> std::result::Result<Vec<String>, pentest_cor
         ));
     }
     Ok(out)
+}
+
+/// Compact, human-reproducible target descriptor for the synthesized nmap
+/// provenance command. Reads the ORIGINAL params (a CIDR stays a CIDR) so a wide
+/// subnet scan does not expand into a multi-kilobyte host list in the report.
+/// `collect_hosts` has already validated these targets before we reach here, and
+/// they are IPs/hostnames/CIDRs — not secret-bearing — so no redaction is needed.
+fn scan_target_spec(params: &Value) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    let mut push = |s: &str| {
+        if !s.is_empty() {
+            parts.push(s.to_string());
+        }
+    };
+    if let Some(h) = params.get("host").and_then(|v| v.as_str()) {
+        push(h);
+    }
+    if let Some(arr) = params.get("hosts").and_then(|v| v.as_array()) {
+        for v in arr {
+            if let Some(h) = v.as_str() {
+                push(h);
+            }
+        }
+    }
+    if let Some(cidr) = params.get("subnet").and_then(|v| v.as_str()) {
+        push(cidr);
+    }
+    parts.join(" ")
 }
 
 /// Expand an IPv4 CIDR (e.g. "10.10.0.0/24") into its usable host addresses.
@@ -187,7 +217,7 @@ impl PentestTool for PortScanTool {
     }
 
     async fn execute(&self, params: Value, _ctx: &ToolContext) -> Result<ToolResult> {
-        execute_timed(|| async {
+        execute_timed_with_provenance(|| async {
             // Gather targets from host / hosts[] / subnet (CIDR).
             let hosts = collect_hosts(&params)?;
 
@@ -210,6 +240,10 @@ impl PentestTool for PortScanTool {
                     "No valid ports specified".into(),
                 ));
             }
+
+            // Compact target descriptor for the synthesized provenance command,
+            // captured before the scan (a CIDR stays a CIDR, not 254 hosts).
+            let target_spec = scan_target_spec(&params);
 
             // Scan each host concurrently, but cap the number of hosts in flight
             // so a /22 subnet doesn't open thousands of sockets at once (each
@@ -238,11 +272,13 @@ impl PentestTool for PortScanTool {
             });
             let results = futures::future::join_all(futures).await;
 
-            // Single-host callers get the flat legacy shape (full per-port list
-            // under `ports`) for backward compatibility.
-            if single_host {
-                return match results.into_iter().next().unwrap() {
-                    Ok(r) => Ok(json!({
+            // Build the agent-facing data payload; its shape depends on whether
+            // one host or many were scanned.
+            let data = if single_host {
+                // Single-host callers get the flat legacy shape (full per-port
+                // list under `ports`) for backward compatibility.
+                match results.into_iter().next().unwrap() {
+                    Ok(r) => json!({
                         "host": r.host,
                         "ports": r.ports,
                         "open_count": r.open_count,
@@ -259,65 +295,91 @@ impl PentestTool for PortScanTool {
                         // timed out -> down OR silently firewalled). See host_state_note.
                         "reachability": r.reachability,
                         "host_state_note": host_state_note(r.reachability),
-                    })),
+                    }),
                     Err((host, e)) => {
-                        Err(pentest_core::error::Error::Network(format!("{host}: {e}")))
+                        return Err(pentest_core::error::Error::Network(format!("{host}: {e}")))
                     }
-                };
+                }
+            } else {
+                // Multi-host: emit ONLY hosts that have open ports, and for those
+                // only the open ports (as {port, service}). A full 254-host ×
+                // all-ports dump is ~100k+ tokens and gets truncated by the platform
+                // summarizer — useless to the agent. This keeps the payload tiny and
+                // directly feeds the batched service_banner step.
+                let mut host_entries: Vec<Value> = Vec::new();
+                let mut hosts_scanned = 0usize;
+                // Hosts that no probe ever reached (every port Unreachable, none open).
+                // Aggregated as a COUNT, not a per-host list: on a 254-host subnet a
+                // mesh/routing failure can make hundreds unreachable, and listing each
+                // would blow the token budget the tiny-payload design exists to protect.
+                // The count lets the agent distinguish "scanned the subnet, nothing was
+                // open" from "couldn't reach most of the subnet" (#306).
+                let mut hosts_unreachable = 0usize;
+                let mut errors: Vec<Value> = Vec::new();
+                for r in results {
+                    match r {
+                        Ok(scan) => {
+                            hosts_scanned += 1;
+                            if scan.open_count == 0 {
+                                // Distinguish "reachable, nothing open" from "never
+                                // reached": a host is unreachable when every scanned
+                                // port failed to reach it.
+                                if scan.unreachable_count > 0
+                                    && scan.unreachable_count == scan.ports.len()
+                                {
+                                    hosts_unreachable += 1;
+                                }
+                                continue;
+                            }
+                            let open: Vec<Value> = scan
+                                .ports
+                                .iter()
+                                .filter(|p| p.open)
+                                .map(|p| json!({ "port": p.port, "service": p.service }))
+                                .collect();
+                            host_entries.push(json!({
+                                "host": scan.host,
+                                "open_ports": open,
+                                "open_count": scan.open_count,
+                            }));
+                        }
+                        Err((host, e)) => {
+                            errors.push(json!({ "host": host, "error": e.to_string() }))
+                        }
+                    }
+                }
+                json!({
+                    "hosts": host_entries,
+                    "hosts_scanned": hosts_scanned,
+                    "hosts_with_open_ports": host_entries.len(),
+                    "hosts_unreachable": hosts_unreachable,
+                    "errors": errors,
+                })
+            };
+
+            // port_scan is a native TCP-connect scanner with no real command
+            // line; attach a synthesized nmap-equivalent probe so the finding is
+            // reproducible, then promote each open port into the evidence graph
+            // (pick#52 coverage). The excerpt is the tool's own JSON payload — no
+            // secret-bearing input reaches it (targets are IPs/hostnames/CIDRs).
+            let provenance = Provenance::new(
+                "port_scan",
+                env!("CARGO_PKG_VERSION"),
+                ProbeCommand::from_exact(format!(
+                    "nmap -Pn -sT -p {ports_str} --open {target_spec}"
+                ))
+                .with_description(
+                    "equivalent nmap invocation; port_scan runs a native TCP-connect scanner",
+                ),
+                truncate_excerpt(&serde_json::to_string(&data).unwrap_or_default()),
+            );
+
+            for node in crate::evidence_producer::evidence_from_port_scan(&data, provenance.clone())
+            {
+                let _ = crate::evidence_producer::push_evidence(node);
             }
 
-            // Multi-host: emit ONLY hosts that have open ports, and for those
-            // only the open ports (as {port, service}). A full 254-host ×
-            // all-ports dump is ~100k+ tokens and gets truncated by the platform
-            // summarizer — useless to the agent. This keeps the payload tiny and
-            // directly feeds the batched service_banner step.
-            let mut host_entries: Vec<Value> = Vec::new();
-            let mut hosts_scanned = 0usize;
-            // Hosts that no probe ever reached (every port Unreachable, none open).
-            // Aggregated as a COUNT, not a per-host list: on a 254-host subnet a
-            // mesh/routing failure can make hundreds unreachable, and listing each
-            // would blow the token budget the tiny-payload design exists to protect.
-            // The count lets the agent distinguish "scanned the subnet, nothing was
-            // open" from "couldn't reach most of the subnet" (#306).
-            let mut hosts_unreachable = 0usize;
-            let mut errors: Vec<Value> = Vec::new();
-            for r in results {
-                match r {
-                    Ok(scan) => {
-                        hosts_scanned += 1;
-                        if scan.open_count == 0 {
-                            // Distinguish "reachable, nothing open" from "never
-                            // reached": a host is unreachable when every scanned
-                            // port failed to reach it.
-                            if scan.unreachable_count > 0
-                                && scan.unreachable_count == scan.ports.len()
-                            {
-                                hosts_unreachable += 1;
-                            }
-                            continue;
-                        }
-                        let open: Vec<Value> = scan
-                            .ports
-                            .iter()
-                            .filter(|p| p.open)
-                            .map(|p| json!({ "port": p.port, "service": p.service }))
-                            .collect();
-                        host_entries.push(json!({
-                            "host": scan.host,
-                            "open_ports": open,
-                            "open_count": scan.open_count,
-                        }));
-                    }
-                    Err((host, e)) => errors.push(json!({ "host": host, "error": e.to_string() })),
-                }
-            }
-            Ok(json!({
-                "hosts": host_entries,
-                "hosts_scanned": hosts_scanned,
-                "hosts_with_open_ports": host_entries.len(),
-                "hosts_unreachable": hosts_unreachable,
-                "errors": errors,
-            }))
+            Ok((data, provenance))
         })
         .await
     }
@@ -364,6 +426,20 @@ mod tests {
     fn collect_hosts_requires_a_target() {
         assert!(collect_hosts(&json!({})).is_err());
         assert!(collect_hosts(&json!({ "hosts": [] })).is_err());
+    }
+
+    #[test]
+    fn scan_target_spec_keeps_cidr_compact_and_joins_hosts() {
+        // A subnet stays a CIDR (not 254 expanded hosts) in the synthesized
+        // provenance command, and host + hosts[] are space-joined.
+        assert_eq!(
+            scan_target_spec(&json!({ "subnet": "10.10.0.0/24" })),
+            "10.10.0.0/24"
+        );
+        assert_eq!(
+            scan_target_spec(&json!({ "host": "10.0.0.1", "hosts": ["10.0.0.2"] })),
+            "10.0.0.1 10.0.0.2"
+        );
     }
 
     #[test]

--- a/crates/ui/tests/evidence_pipeline.rs
+++ b/crates/ui/tests/evidence_pipeline.rs
@@ -29,8 +29,8 @@ use pentest_core::orchestrator::{
 use pentest_core::provenance::{ProbeCommand, Provenance};
 use pentest_core::tools::{PentestTool, ToolContext, ToolOutcome};
 use pentest_tools::evidence_producer::{
-    evidence_from_default_creds, evidence_from_http_request, evidence_from_nmap,
-    evidence_from_web_vuln_scan, push_evidence,
+    evidence_from_default_creds, evidence_from_execute_command, evidence_from_http_request,
+    evidence_from_nmap, evidence_from_port_scan, evidence_from_web_vuln_scan, push_evidence,
 };
 use pentest_tools::ExecuteCommandTool;
 use pentest_ui::session;
@@ -537,6 +537,97 @@ fn web_wrapper_findings_reach_the_report_after_validation() {
         manifest.findings.len(),
         4,
         "every web-wrapper finding must reach the report manifest"
+    );
+
+    session::clear_evidence();
+}
+
+/// pick#52 PR2: extends the same production-path guard to `port_scan` and
+/// `execute_command`. `port_scan` (a native scanner) promotes each open port via
+/// a synthesized nmap-equivalent provenance; the `execute_command` primitive
+/// promotes one Info node per run. Both must travel tool-buffer -> graph -> gate
+/// -> manifest exactly like the nmap and web-wrapper cases above.
+#[test]
+fn port_scan_and_execute_command_findings_reach_the_report_after_validation() {
+    let _guard = serial();
+    session::clear_evidence();
+
+    let mut node_ids = Vec::new();
+
+    // port_scan (single-host shape): only the two open ports become nodes; the
+    // closed 3306 is not a finding.
+    let ps_data = json!({
+        "host": "10.0.0.1",
+        "ports": [
+            {"port": 22, "service": "ssh", "open": true},
+            {"port": 445, "service": "microsoft-ds", "open": true},
+            {"port": 3306, "service": "mysql", "open": false}
+        ],
+        "open_count": 2
+    });
+    let ps_prov = Provenance::new(
+        "port_scan",
+        "0.6",
+        ProbeCommand::from_exact("nmap -Pn -sT -p 22,445,3306 --open 10.0.0.1"),
+        "{\"open_count\":2}",
+    );
+    for node in evidence_from_port_scan(&ps_data, ps_prov) {
+        node_ids.push(node.id.clone());
+        push_evidence(node).expect("tool buffer should accept the port_scan finding");
+    }
+
+    // execute_command: one Info node per run.
+    let ec_data = json!({
+        "stdout": "uid=0(root)",
+        "stderr": "",
+        "exit_code": 0,
+        "timed_out": false,
+        "duration_ms": 12
+    });
+    let ec_prov = Provenance::new(
+        "shell",
+        "0.6",
+        ProbeCommand::from_exact("id"),
+        "uid=0(root)",
+    );
+    for node in evidence_from_execute_command(&ec_data, ec_prov) {
+        node_ids.push(node.id.clone());
+        push_evidence(node).expect("tool buffer should accept the execute_command node");
+    }
+
+    assert_eq!(node_ids.len(), 3, "2 open ports + 1 command_execution");
+
+    // Drain into the graph and confirm the gate sees every node as pending.
+    let forwarded = session::drain_tool_evidence_into_graph();
+    assert_eq!(forwarded, 3, "all three nodes should reach the graph");
+
+    let snapshot = session::evidence_snapshot();
+    match gate_for_report(&snapshot, engagement()) {
+        Err(GateError::PendingNodes { pending_ids }) => {
+            for id in &node_ids {
+                assert!(
+                    pending_ids.contains(id),
+                    "node {id} must block the gate before validation"
+                );
+            }
+        }
+        other => panic!("expected PendingNodes before validation, got {other:?}"),
+    }
+
+    // Validator confirms all; the gate then accepts and every finding lands.
+    let verdicts =
+        parse_validator_verdicts(&confirm_all(&node_ids)).expect("verdict reply should parse");
+    let apply = session::apply_validator_verdicts(&verdicts);
+    assert_eq!(apply.applied, 3);
+    assert!(apply.is_fully_adjudicated());
+
+    let snapshot = session::evidence_snapshot();
+    let manifest = gate_for_report(&snapshot, engagement())
+        .expect("gate should accept a fully-adjudicated graph");
+    assert_eq!(
+        manifest.findings.len(),
+        3,
+        "every port_scan + execute_command finding must reach the report manifest"
     );
 
     session::clear_evidence();


### PR DESCRIPTION
## Summary

- Extends the pick#52 evidence-coverage promotion (PR #401 landed the web wrappers) to the next two producers so findings built on them can pass the report provenance gate (`gate_for_report`).
- **port_scan**: a native TCP-connect scanner with no real command line, so it now attaches a *synthesized* nmap-equivalent probe (`nmap -Pn -sT -p <ports> --open <targets>`) as provenance and promotes every open port into an `open_port` node. Both result shapes are handled (single-host flat `ports[]` + multi-host `hosts[].open_ports[]`), and the synthesized target keeps a subnet as a CIDR rather than expanding to hundreds of hosts.
- **execute_command**: already built provenance but never promoted it. It now pushes one Info-severity `command_execution` node per **ran** probe. The push is gated on `is_ran_probe` (the same predicate `classify_command_outcome` uses), so a failed/timed-out run cannot inject an ungrounded node - preserving the pick#184 fail-closed guarantee. The node's command string comes from the provenance's already-redacted `effective_command`; raw stdout/stderr are deliberately kept out of every node field.

## Security notes

- Node fields are held no less redacted than their own provenance (the F1-class asymmetry guarded across pick#52). For execute_command the command string is the same secret-scrubbed `effective_command` from provenance; raw output never reaches a node.
- port_scan node/provenance fields are validated IPs/hostnames/CIDRs, integer ports, and a static service lookup - no user-supplied secret path. `scan_target_spec` runs only after `collect_hosts` has validated every target (`validate_hostname`/`validate_cidr` reject URL/userinfo shapes).
- Reviewed by an independent security pass and Rust pass; both approved with no BLOCKING/HIGH findings. Their MEDIUM (double-emit on a malformed both-keys payload) is fixed via mutually-exclusive branches.

## Test plan

- [x] `cargo +1.92.0 test --package pentest-tools --lib` (414 pass) - unit tests for both builders, incl. secret-leak regression guards (command output + injected token must never reach a published node byte) and the `is_ran_probe` gate contract.
- [x] `cargo +1.92.0 test --package pentest-ui --features connector,shell-ws,pentest-platform/desktop-pcap --test evidence_pipeline` - end-to-end pipeline test proving port_scan + execute_command evidence travels tool-buffer -> graph -> gate -> manifest; passes both parallel and `--test-threads=1`.
- [x] `cargo +1.92.0 clippy --package pentest-tools --all-targets -- -D warnings` clean; `cargo fmt` clean.