### PR TITLE
fix(tools): re-register autopwn_detect and autopwn_network_plan (#406)

### DIFF
--- a/crates/tools/src/lib.rs
+++ b/crates/tools/src/lib.rs
@@ -114,9 +114,11 @@ pub fn create_tool_registry() -> ToolRegistry {
     // WiFi tools
     registry.register(WifiScanTool);
     registry.register(WifiScanDetailedTool);
+    registry.register(AutoPwnOrchestratorTool); // Hardware detection + strategy (autopwn_detect)
     registry.register(AutoPwnPlanTool);
     registry.register(AutoPwnCaptureTool);
     registry.register(AutoPwnCrackTool);
+    registry.register(AutoPwnNetworkPlanTool); // Network-mode attack planning
 
     // Vulnerability assessment
     registry.register(ServiceBannerTool);

--- a/crates/tools/tests/tools_registration_test.rs
+++ b/crates/tools/tests/tools_registration_test.rs
@@ -1,0 +1,47 @@
+//! Registration guards: tools that must (or must not) be in the runtime registry.
+//!
+//! `all_tools_registered` (crates/core) checks registry -> capabilities, and the
+//! `tools_doc_sync` guard checks registry -> docs. Neither catches a tool whose
+//! `impl PentestTool` exists but whose `registry.register(...)` line was dropped,
+//! for example silently lost in a merge resolution. These tests pin the two
+//! known cases so the regression cannot recur unnoticed.
+
+use pentest_tools::create_tool_registry;
+
+/// `autopwn_detect` and `autopwn_network_plan` were registered when introduced,
+/// then silently lost their `register()` lines in the 3-way merge f280c01
+/// (pick#406). A shipped dashboard quick-action prompt directs the agent at
+/// `autopwn_network_plan`, so leaving them unregistered is a live unknown-tool
+/// bug, not just dead code. Guard against the regression recurring.
+#[test]
+fn autopwn_orchestration_tools_are_registered() {
+    let registry = create_tool_registry();
+    let names = registry.names();
+    for tool in ["autopwn_detect", "autopwn_network_plan"] {
+        assert!(
+            names.contains(&tool),
+            "tool '{tool}' is implemented but not registered in create_tool_registry() \
+             (pick#406) - its register() line was likely dropped in a merge again. \
+             Registered: {names:?}"
+        );
+    }
+}
+
+/// `credential_harvest` and `lateral_movement` are implemented but deliberately
+/// NOT registered, pending a security decision (pick#405): credential_harvest
+/// harvests the operator's own host credentials as written, and lateral_movement
+/// is an auto-Pass-the-Hash orchestrator. This is a tripwire, not an oversight -
+/// if you register either, resolve pick#405 first (rework/scope it) and remove
+/// the corresponding entry here.
+#[test]
+fn security_gated_tools_remain_unregistered() {
+    let registry = create_tool_registry();
+    let names = registry.names();
+    for tool in ["credential_harvest", "lateral_movement"] {
+        assert!(
+            !names.contains(&tool),
+            "tool '{tool}' is registered, but it is intentionally gated pending a security \
+             decision (pick#405). Resolve that issue before wiring it up, then update this test."
+        );
+    }
+}

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -76,9 +76,11 @@ reports from `name()` - the string an operator or the model invokes. See
 
 | Tool | Type | Description | Requires Root |
 |------|------|-------------|---------------|
+| `autopwn_detect` | Native | Detect available hardware and recommend the best autopwn strategy (WiFi vs Network) | No |
 | `autopwn_plan` | Native | Generate attack plan for WiFi target | Yes |
 | `autopwn_capture` | Native | Capture WPA handshakes | Yes |
 | `autopwn_crack` | Native | Crack captured handshakes | Yes |
+| `autopwn_network_plan` | Native | Plan a network-based penetration test attack sequence (discovery, scanning, exploitation) | No |
 | `aircrack-ng` | External | WEP/WPA/WPA2 cracking suite | Yes |
 | `bettercap` | External | Man-in-the-middle attack framework | Yes |
 | `responder` | External | LLMNR/NBT-NS/MDNS poisoning | Yes |


### PR DESCRIPTION
## Summary

- Re-register `AutoPwnOrchestratorTool` (`autopwn_detect`) and `AutoPwnNetworkPlanTool` (`autopwn_network_plan`) in `create_tool_registry()`. Both were fully implemented but lost their `register()` lines in the 3-way merge `f280c01`, leaving them unreachable at runtime.
- Re-add their `docs/TOOLS.md` rows (required by the `tools_doc_sync` guard once a tool is registered).
- Add `tools_registration_test.rs` — a registration-presence guard so a future merge cannot silently drop them again, and a tripwire pinning `credential_harvest` / `lateral_movement` as intentionally unregistered pending the #405 security decision.

Fixes the live symptom: the shipped "AutoPwn" dashboard quick-action directs the agent at `autopwn_network_plan`, which returned an unknown-tool error while unregistered.

Closes #406.

## Test plan

- [x] `cargo test -p pentest-tools --test tools_registration_test` (2 passed)
- [x] `cargo test -p pentest-tools --test tools_doc_sync_test` (registry<->docs guard, passed)
- [x] `cargo test -p pentest-core --test tool_integration all_tools_registered` (registry<->capabilities guard, passed)
- [x] `cargo clippy -p pentest-tools --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all`