### PR TITLE
feat(ui): add plan-only Network Attack Plan dashboard tile

### DIFF
--- a/crates/ui/src/components/dashboard.rs
+++ b/crates/ui/src/components/dashboard.rs
@@ -7,6 +7,14 @@ use pentest_platform::WifiConnectionStatus;
 use super::icons::{Bolt, Info, MessageCircle, Network, ScrollText, Shield, Terminal, Wifi};
 use crate::platform_helper;
 
+/// Seeded chat prompt for the "Network Attack Plan" quick action.
+///
+/// Plan-only review gate: instructs the agent to call `autopwn_network_plan`,
+/// present the phased plan for review, execute no phase, and offer AutoPwn as
+/// the follow-on. The plan-only invariant is load-bearing, so it is pinned by a
+/// unit test rather than left as an inline literal.
+const NETWORK_ATTACK_PLAN_PROMPT: &str = "Call the autopwn_network_plan tool to produce a phased attack plan for the current network (the discovery, scanning, and exploitation sequence it lays out). Present the complete plan for my review but do NOT execute any phase; this is plan-only, so run no scans or attacks. When the plan is ready, offer to launch AutoPwn as the follow-on if I want to execute it.";
+
 /// Connected home screen with status, quick actions, and recent activity.
 /// Settings (shell mode) and disconnect are now in the sidebar.
 #[component]
@@ -149,7 +157,7 @@ pub fn Dashboard(
                         // the WiFi/AutoPwn tiles.
                         div {
                             class: "action-card",
-                            onclick: move |_| on_open_chat.call("Call the autopwn_network_plan tool to produce a phased attack plan for the current network (the discovery, scanning, and exploitation sequence it lays out). Present the complete plan for my review but do NOT execute any phase; this is plan-only, so run no scans or attacks. When the plan is ready, offer to launch AutoPwn as the follow-on if I want to execute it.".to_string()),
+                            onclick: move |_| on_open_chat.call(NETWORK_ATTACK_PLAN_PROMPT.to_string()),
                             span { class: "action-card-icon", ScrollText { size: 24 } }
                             span { class: "action-card-label", "Network Attack Plan" }
                         }
@@ -206,5 +214,44 @@ pub fn Dashboard(
             }
         }
 
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NETWORK_ATTACK_PLAN_PROMPT;
+
+    #[test]
+    fn network_attack_plan_prompt_targets_the_planning_tool() {
+        assert!(
+            NETWORK_ATTACK_PLAN_PROMPT.contains("autopwn_network_plan"),
+            "prompt must invoke the autopwn_network_plan tool"
+        );
+    }
+
+    #[test]
+    fn network_attack_plan_prompt_is_plan_only() {
+        // The tile's whole point is a review gate that executes nothing; guard the
+        // do-not-execute wording so a future edit can't silently make it run phases.
+        assert!(
+            NETWORK_ATTACK_PLAN_PROMPT.contains("do NOT execute any phase"),
+            "prompt must forbid executing any phase"
+        );
+        assert!(
+            NETWORK_ATTACK_PLAN_PROMPT.contains("plan-only"),
+            "prompt must state it is plan-only"
+        );
+        assert!(
+            NETWORK_ATTACK_PLAN_PROMPT.contains("run no scans or attacks"),
+            "prompt must forbid running scans or attacks"
+        );
+    }
+
+    #[test]
+    fn network_attack_plan_prompt_offers_autopwn_follow_on() {
+        assert!(
+            NETWORK_ATTACK_PLAN_PROMPT.contains("AutoPwn"),
+            "prompt must offer AutoPwn as the follow-on"
+        );
     }
 }

--- a/crates/ui/src/components/dashboard.rs
+++ b/crates/ui/src/components/dashboard.rs
@@ -4,7 +4,7 @@ use dioxus::prelude::*;
 use pentest_core::terminal::TerminalLine;
 use pentest_platform::WifiConnectionStatus;
 
-use super::icons::{Bolt, Info, MessageCircle, Network, Shield, Terminal, Wifi};
+use super::icons::{Bolt, Info, MessageCircle, Network, ScrollText, Shield, Terminal, Wifi};
 use crate::platform_helper;
 
 /// Connected home screen with status, quick actions, and recent activity.
@@ -142,6 +142,16 @@ pub fn Dashboard(
                             },
                             span { class: "action-card-icon", Bolt { size: 24 } }
                             span { class: "action-card-label", "AutoPwn" }
+                        }
+                        // Plan-only review gate: produces the phased attack plan via
+                        // autopwn_network_plan but executes nothing. No root/WiFi
+                        // preflight needed (the tool is Requires Root: No), unlike
+                        // the WiFi/AutoPwn tiles.
+                        div {
+                            class: "action-card",
+                            onclick: move |_| on_open_chat.call("Call the autopwn_network_plan tool to produce a phased attack plan for the current network (the discovery, scanning, and exploitation sequence it lays out). Present the complete plan for my review but do NOT execute any phase; this is plan-only, so run no scans or attacks. When the plan is ready, offer to launch AutoPwn as the follow-on if I want to execute it.".to_string()),
+                            span { class: "action-card-icon", ScrollText { size: 24 } }
+                            span { class: "action-card-label", "Network Attack Plan" }
                         }
                         div {
                             class: "action-card",


### PR DESCRIPTION
## Summary

- Adds a "Network Attack Plan" Quick Action tile to the dashboard (`crates/ui/src/components/dashboard.rs`), placed next to AutoPwn.
- Its seeded prompt directs the agent to call `autopwn_network_plan` and present the phased discovery/scanning/exploitation plan as a review gate, executing no phase, then offer AutoPwn as the follow-on.
- Uses a plain `on_open_chat` handler with no root/WiFi preflight (the tool is `Requires Root: No`), and a distinct `ScrollText` icon.

## Dependency

- The tile is UI-only and compiles/merges independently, but its runtime value depends on `autopwn_network_plan` being registered, which lands in #415 (re-registration of `autopwn_detect` / `autopwn_network_plan`). Merge order does not matter; the tile becomes live once #415 merges.

## Test plan

- [x] `cargo clippy --workspace --locked --features pentest-platform/desktop-pcap -- -D warnings` (green; only pre-existing third-party future-incompat warning)
- [x] `cargo fmt --all` clean
- [ ] After #415 merges: verify the tile renders on headless LiveView + desktop and the agent produces a plan-only response (no phase execution)
- [ ] Grid lays out cleanly at 375x812, 800x600, 1920x1080

Closes #416