### PR TITLE
feat(demo): remove hardcoded container_name for multi-instance demo:pick (init-dev#433)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,19 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
+  # Demo compose units (docker-compose.dvwa.yml) are pure YAML consumed by the
+  # init-dev demo:pick:* flows — nothing in CI validated them before (review
+  # Strike48-public/pick#418). `config -q` parses the file AND resolves every
+  # mandatory ${VAR:?} interpolation against the shipped example env, catching
+  # syntax drift and new required-variable gaps that would otherwise only fail
+  # at demo time, off-repo.
+  compose-lint:
+    name: Compose Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - run: docker compose --env-file .env.dvwa.example -f docker-compose.dvwa.yml config -q
+
   clippy:
     name: Clippy
     runs-on: ubuntu-latest

--- a/docker-compose.dvwa.yml
+++ b/docker-compose.dvwa.yml
@@ -25,7 +25,6 @@ services:
     # named in matrix#3207 is not anonymously pullable — pull is "denied".) amd64-only,
     # so it runs under emulation on arm64 hosts — fine for a demo target.
     image: docker.io/vulnerables/web-dvwa:latest
-    container_name: pick-demo-dvwa
     restart: unless-stopped
     networks:
       - scan-net
@@ -51,7 +50,6 @@ services:
       # HOME is /root (see the creds volume mount below).
       dockerfile: Dockerfile.scratch
     image: ghcr.io/strike48-public/pick:demo
-    container_name: pick-demo-connector
     restart: unless-stopped
     depends_on:
       dvwa:


### PR DESCRIPTION
## What

Removes the two hardcoded `container_name:` entries from `docker-compose.dvwa.yml` so the stack can run multiple times side by side.

## Why

With fixed container names, a second `demo:pick:attach` (e.g. `DEMO_INSTANCE=alpha`) collides on container identity even though its compose project is distinct — the Compose-canonical names (`<project>-dvwa-1` / `<project>-pick-1`) are unique per project, which is what enables the multi-instance demo rigs in Strike48/init-dev#433.

## Validation (live, newdev cluster)

- Three stacks attached concurrently (`demo`, `alpha`, `beta` instances): 6 containers, distinct projects/networks/volumes, no collisions
- `DEMO_INSTANCE=alpha` detach removed only that instance's containers + networks
- Parent/child tenant demo: `pick-demo-mssp` + `pick-demo-mssp-acme` both registered connectors and both engagements ran tools independently (scan-nets on separate subnets, no bleed)
- `docker compose config -q` passes on the current main

Companion: Strike48/init-dev PR for `DEMO_INSTANCE` task/script support (#433).
