### PR TITLE
feat(ui): reorder Quick Actions and mark AutoPwn beta

### DIFF
--- a/crates/ui/src/components/css/dashboard.css
+++ b/crates/ui/src/components/css/dashboard.css
@@ -372,3 +372,22 @@
     line-height: 1;
     cursor: help;
 }
+
+/* Beta pill for still-maturing actions (e.g. AutoPwn) */
+.beta-badge {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    padding: 2px 6px;
+    border-radius: 999px;
+    background-color: color-mix(in srgb, var(--primary) 18%, transparent);
+    border: 1px solid color-mix(in srgb, var(--primary) 45%, transparent);
+    color: var(--primary);
+    font-family: var(--font-mono);
+    font-size: 9px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    line-height: 1.2;
+    text-transform: uppercase;
+    pointer-events: none;
+}

--- a/crates/ui/src/components/dashboard.rs
+++ b/crates/ui/src/components/dashboard.rs
@@ -67,9 +67,21 @@ pub fn Dashboard(
                         }
                         div {
                             class: "action-card",
+                            onclick: move |_| on_open_chat.call("Perform a comprehensive network vulnerability assessment. Phase 1: Discover all hosts (ARP scan, mDNS, SSDP, WiFi). Phase 2: For each host, scan ports and grab service banners. Phase 3: Lookup CVEs for discovered services, test default credentials, scan for web vulnerabilities. Generate a detailed report with severity ratings and remediation recommendations.".to_string()),
+                            span { class: "action-card-icon", Shield { size: 24 } }
+                            span { class: "action-card-label", "Vuln Assessment" }
+                        }
+                        div {
+                            class: "action-card",
                             onclick: move |_| on_open_chat.call("Run a full network discovery — ARP, mDNS, and SSDP — and summarize what you find.".to_string()),
                             span { class: "action-card-icon", Network { size: 24 } }
                             span { class: "action-card-label", "Network Scan" }
+                        }
+                        div {
+                            class: "action-card",
+                            onclick: move |_| on_open_chat.call("Scan the local gateway for common open ports and identify running services.".to_string()),
+                            span { class: "action-card-icon", Shield { size: 24 } }
+                            span { class: "action-card-label", "Port Scan" }
                         }
                         div {
                             class: "action-card",
@@ -110,6 +122,29 @@ pub fn Dashboard(
                                 }
                             }
                         }
+                        // Plan-only review gate: produces the phased attack plan via
+                        // autopwn_network_plan but executes nothing. No root/WiFi
+                        // preflight needed (the tool is Requires Root: No), unlike
+                        // the WiFi/AutoPwn tiles.
+                        div {
+                            class: "action-card",
+                            onclick: move |_| on_open_chat.call(NETWORK_ATTACK_PLAN_PROMPT.to_string()),
+                            span { class: "action-card-icon", ScrollText { size: 24 } }
+                            span { class: "action-card-label", "Network Attack Plan" }
+                        }
+                        // No interactive shell on iOS (no PTY/proot in the iOS
+                        // sandbox), so hide the shell quick-action there.
+                        if !cfg!(target_os = "ios") {
+                            div {
+                                class: "action-card",
+                                onclick: move |_| on_open_shell.call(()),
+                                span { class: "action-card-icon", Terminal { size: 24 } }
+                                span { class: "action-card-label", "Shell" }
+                            }
+                        }
+                        // AutoPwn is the most autonomous / destructive action and is
+                        // still maturing, so it sits last and carries a BETA pill to
+                        // set expectations before an operator commits to a full run.
                         div {
                             class: "action-card",
                             onclick: move |_| {
@@ -150,38 +185,7 @@ pub fn Dashboard(
                             },
                             span { class: "action-card-icon", Bolt { size: 24 } }
                             span { class: "action-card-label", "AutoPwn" }
-                        }
-                        // Plan-only review gate: produces the phased attack plan via
-                        // autopwn_network_plan but executes nothing. No root/WiFi
-                        // preflight needed (the tool is Requires Root: No), unlike
-                        // the WiFi/AutoPwn tiles.
-                        div {
-                            class: "action-card",
-                            onclick: move |_| on_open_chat.call(NETWORK_ATTACK_PLAN_PROMPT.to_string()),
-                            span { class: "action-card-icon", ScrollText { size: 24 } }
-                            span { class: "action-card-label", "Network Attack Plan" }
-                        }
-                        div {
-                            class: "action-card",
-                            onclick: move |_| on_open_chat.call("Scan the local gateway for common open ports and identify running services.".to_string()),
-                            span { class: "action-card-icon", Shield { size: 24 } }
-                            span { class: "action-card-label", "Port Scan" }
-                        }
-                        div {
-                            class: "action-card",
-                            onclick: move |_| on_open_chat.call("Perform a comprehensive network vulnerability assessment. Phase 1: Discover all hosts (ARP scan, mDNS, SSDP, WiFi). Phase 2: For each host, scan ports and grab service banners. Phase 3: Lookup CVEs for discovered services, test default credentials, scan for web vulnerabilities. Generate a detailed report with severity ratings and remediation recommendations.".to_string()),
-                            span { class: "action-card-icon", Shield { size: 24 } }
-                            span { class: "action-card-label", "Vuln Assessment" }
-                        }
-                        // No interactive shell on iOS (no PTY/proot in the iOS
-                        // sandbox), so hide the shell quick-action there.
-                        if !cfg!(target_os = "ios") {
-                            div {
-                                class: "action-card",
-                                onclick: move |_| on_open_shell.call(()),
-                                span { class: "action-card-icon", Terminal { size: 24 } }
-                                span { class: "action-card-label", "Shell" }
-                            }
+                            span { class: "beta-badge", "BETA" }
                         }
                     }
                 }

--- a/crates/ui/src/components/dashboard.rs
+++ b/crates/ui/src/components/dashboard.rs
@@ -55,7 +55,8 @@ pub fn Dashboard(
                     }
                 }
 
-                // Quick actions grid — 2x2, each opens chat with a seeded prompt
+                // Quick actions grid — responsive tiles, each opens chat with a
+                // seeded prompt; ordered least- to most-autonomous (AutoPwn last).
                 div { class: "dashboard-section",
                     h3 { class: "dashboard-section-title", "Quick Actions" }
                     div { class: "action-grid",


### PR DESCRIPTION
## Summary

- Reorder the dashboard Quick Actions grid (`crates/ui/src/components/dashboard.rs`) to lead with lower-risk reconnaissance and end with the most autonomous action. New order: Device Info, Vuln Assessment, Network Scan, Port Scan, WiFi Scan, Network Attack Plan, Shell, AutoPwn.
- Move **AutoPwn** to last and add a **BETA pill** to it. AutoPwn is the most autonomous / destructive tile and is still maturing; the pill sets operator expectations before a full autonomous run. The plan-only Network Attack Plan tile now immediately precedes it as the review-gate alternative.
- Add a `.beta-badge` pill style (`crates/ui/src/components/css/dashboard.css`), reusing the existing top-right corner-badge pattern and theme tokens (`--primary`, `--font-mono`).

## Notes

- No behavior change to any tile's seeded prompt or handler; this is ordering + one visual badge. The Shell tile keeps its iOS `cfg` guard (hidden on iOS, so AutoPwn stays last there too).

## Test plan

- [x] `cargo test --workspace --features pentest-platform/desktop-pcap --lib dashboard::tests` (3 passed)
- [x] `cargo clippy --workspace --locked --features pentest-platform/desktop-pcap -- -D warnings` (green; only pre-existing third-party future-incompat warning)
- [x] `cargo fmt --all` clean
- [x] Visual: tiles render in the new order and the BETA pill sits cleanly in the AutoPwn tile at 375x812 / 800x600 / 1920x1080