### PR TITLE
fix(demo): pass STRIKE48_API_URL through to the pick service (OTT callback pin)

### DIFF
--- a/docker-compose.dvwa.yml
+++ b/docker-compose.dvwa.yml
@@ -107,6 +107,14 @@ services:
       # the container + the internal scan-net, not the in-container sandbox. (The
       # full sandbox lives in the prod Kali image built from Dockerfile.scratch.)
       DISABLE_SANDBOX: "${DISABLE_SANDBOX:-true}"
+      # Same-origin base for the OTT post-approval callback. The vendored SDK
+      # resolves the register URL as: STRIKE48_API_URL > derived-from-dialed-
+      # host > server-advertised. When the connector dials an insecure
+      # grpc:// fronting that 301-redirects http→https (envoy http-to-https),
+      # the dialed-host derivation yields http:// and the token exchange dies
+      # on the redirect's empty body. Pin the tenant API base to override.
+      # Unset = SDK's built-in resolution (behavior unchanged).
+      STRIKE48_API_URL: "${STRIKE48_API_URL:-}"
       # STRIKE48_TOKEN intentionally unset → Pick registers PENDING approval
       # (OTT flow). Operator approves in Studio → Gateways. The minted JWT is
       # persisted to HOME below so the approval survives restarts.


### PR DESCRIPTION

## Problem

Since #394, the vendored SDK resolves the post-approval OTT callback in the order `STRIKE48_API_URL` env var > derived from dialed host > server-advertised. The DVWA demo unit dials an insecure `grpc://…:80` front, so the derived-from-dialed-host step yields an `http://` callback base. On platforms whose edge terminates plain HTTP with a 301 (envoy http-to-https `RequestRedirect`, for example), the `register-with-ott` POST gets the empty redirect body and the exchange dies with:

    Failed to complete OTT registration: Serialization error: Failed to parse response: error decoding response body

The connector log names the override explicitly:

    OTT callback base overridden: server advertised "https://studio.strike48.test", using "http://studio.strike48.test"
    STRIKE48_API_URL is not configured; … set STRIKE48_API_URL to pin the origin explicitly.

That is exactly what the SDK's own log message recommends — but the demo compose's pick service declares a fixed `environment:` allowlist, so **`STRIKE48_API_URL` can never reach the container even when set**. There is no supported way for a deployer of the compose unit to make the pin the SDK recommends.

## Fix

Pass the variable through. The `:-` default is the empty string: with nothing set, SDK resolution behavior is **byte-identical to today**. Nothing changes for anyone whose platform front is https/`wss://` (the derivation is already correct there); only deployments fronted by an http→https-redirecting edge (like a local newdev envoy) opt in by setting the pin.

## Evidence

- Observed on a four-connector fleet (studio built from 2026-09-02 develop): two tenants failed the OTT exchange with the exact log lines above; after adding this pass-through and setting the pin in the env file, all four completed — `Sent JWT re-registration on existing stream`, zero `ERROR` lines, engagements ran tools end-to-end.
- The same pin is already the required pattern in other pick deployment paths: our EC2 demo stacks declare `STRIKE48_API_URL` **required** (`:?`) in their generated compose, and the k8s connector chart sets it on the deployment.

## Test plan

- No unit test: pure compose allowlist pass-through, zero Rust code changes.
- Manual proof (platform with http→https edge redirect):
  1. `just dvwa-up` with the demo env (insecure `grpc://` host) **without** the pin → approve in Gateways → observe `OTT callback base overridden` + serialization error; connector never becomes authenticated.
  2. Set `STRIKE48_API_URL=<tenant API base>` in the env file → recreate → approve → `Sent JWT re-registration on existing stream`.

## Reference

  Found during testing of Strike48/init-dev#423


