### PR TITLE
fix(release): publish headless agent under legacy pentest-agent name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -563,6 +563,23 @@ jobs:
         run: |
           mkdir -p release
           find artifacts -type f \( -name "*.tar.gz" -o -name "*.zip" -o -name "*.apk" \) -exec cp {} release/ \;
+
+          # Backward-compatible headless-agent asset names. Deployed StrikeHub
+          # versions fetch the agent as `pentest-agent-{os}-{arch}` (Pick's
+          # original asset name); v0.1.9 renamed the archive to `pick-agent-*`,
+          # which broke the connector download for already-installed clients
+          # (a field client on StrikeHub 0.1.20 could only run by pinning an
+          # older Pick). Publish BOTH names so already-deployed clients keep
+          # working without a StrikeHub upgrade; new StrikeHub builds consume
+          # `pick-agent-*` (see Strike48-public/strikehub#67). Aliases are copied
+          # before checksums are generated, so SHA256SUMS.txt covers them too.
+          # Remove once no supported StrikeHub fetches the old name.
+          for f in release/pick-agent-*; do
+            [ -e "$f" ] || continue
+            alias_name="$(basename "$f" | sed 's/^pick-agent-/pentest-agent-/')"
+            cp "$f" "release/${alias_name}"
+          done
+
           ls -la release/
 
       - name: Get version
@@ -611,6 +628,10 @@ jobs:
             | Windows | x86_64 | `pick-agent-windows-x86_64.zip` |
             | macOS | x86_64 | `pick-agent-darwin-x86_64.tar.gz` |
             | macOS | Apple Silicon | `pick-agent-darwin-aarch64.tar.gz` |
+
+            Each headless agent asset is also published under the legacy
+            `pentest-agent-{os}-{arch}` name for backward compatibility with
+            StrikeHub versions that fetch the original asset name.
 
             ### Checksums
 


### PR DESCRIPTION
## Summary

- Restores backward compatibility for the released headless-agent asset name. Pick v0.1.9 renamed the archive from `pentest-agent-{os}-{arch}` to `pick-agent-{os}-{arch}`. Deployed StrikeHub versions fetch the agent by the **original** name, so the rename broke the connector download for already-installed clients (a field client on StrikeHub 0.1.20 could only run by pinning an older Pick).
- New StrikeHub builds consume `pick-agent-*` (Strike48-public/strikehub#67), but shipped clients cannot be retroactively updated - so we publish **both** names.

## Change

One step, in the `release` job's asset-prep (`.github/workflows/release.yml`): for each `pick-agent-*` asset, copy it to the legacy `pentest-agent-*` name before checksums are generated (so `SHA256SUMS.txt` covers both). The inner binary (`pentest-agent`) and the per-platform build jobs are unchanged. Only the four headless-agent assets are aliased; desktop/web/android assets are untouched.

Comment in the workflow marks it for removal once no supported StrikeHub fetches the old name.

## Test plan

- [x] Simulated the collected artifact set and ran the alias loop: produces `pentest-agent-{linux-x86_64.tar.gz, windows-x86_64.zip, darwin-x86_64.tar.gz, darwin-aarch64.tar.gz}`; desktop/web/android assets untouched; aliases precede checksum generation.
- [x] `release.yml` parses as valid YAML.
- [ ] Reviewer: the release workflow only runs on tag/`workflow_dispatch`, so it can't be exercised by PR CI - the next tagged release will emit both names. Verify a deployed StrikeHub (that fetches `pentest-agent-linux-x86_64.tar.gz`) resolves against a build cut from this.

Note: this is a fork PR, so the repo's PII-name scan is skipped (secret not passed to forks - by design) and any image-push jobs may fail on fork write denial; neither is a code defect.